### PR TITLE
Porting to Plasma 6.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required (VERSION 3.16.0)
 project (material-decoration)
 
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 add_definitions (-Wall -Werror)
 
 include (FeatureSummary)

--- a/README.md
+++ b/README.md
@@ -6,8 +6,12 @@ mkdir build
 cd build
 cmake .. -DQT_MAJOR_VERSION=6 -DQT_VERSION_MAJOR=6
 make
-sudo cp ./src/materialdecoration.so /usr/lib/qt6/plugins/org.kde.kdecoration2/materialdecoration.so
+sudo make install
 ```
+
+for Arch and derivatives, please install the AUR package material-kwin-decoration-git
+
+NOTE: the master branch is aligned with the latest Plasma versions. For earlier ones, see the other branches
 
 ## material-decoration
 

--- a/src/AppIconButton.h
+++ b/src/AppIconButton.h
@@ -23,7 +23,7 @@
 #include "Decoration.h"
 
 // KDecoration
-#include <KDecoration2/DecoratedClient>
+#include <KDecoration3/DecoratedWindow>
 
 // KF
 #include <KIconLoader>
@@ -39,8 +39,8 @@ class AppIconButton
 {
 
 public:
-    static void init(Button *button, KDecoration2::DecoratedClient *decoratedClient) {
-        QObject::connect(decoratedClient, &KDecoration2::DecoratedClient::iconChanged,
+    static void init(Button *button, KDecoration3::DecoratedWindow *decoratedClient) {
+        QObject::connect(decoratedClient, &KDecoration3::DecoratedWindow::iconChanged,
             button, [button] {
                 button->update();
             }
@@ -55,7 +55,7 @@ public:
         appIconRect.moveCenter(contentRect.center().toPoint());
 
         const auto *deco = qobject_cast<Decoration *>(button->decoration());
-        auto *decoratedClient = deco->client();
+        auto *decoratedClient = deco->window();
 
         const QPalette activePalette = KIconLoader::global()->customPalette();
         QPalette palette = decoratedClient->palette();

--- a/src/AppMenuButton.cc
+++ b/src/AppMenuButton.cc
@@ -25,7 +25,7 @@
 #include "AppMenuButtonGroup.h"
 
 // KDecoration
-#include <KDecoration2/DecoratedClient>
+#include <KDecoration3/DecoratedWindow>
 
 // KF
 #include <KColorUtils>
@@ -38,7 +38,7 @@ namespace Material
 {
 
 AppMenuButton::AppMenuButton(Decoration *decoration, const int buttonIndex, QObject *parent)
-    : Button(KDecoration2::DecorationButtonType::Custom, decoration, parent)
+    : Button(KDecoration3::DecorationButtonType::Custom, decoration, parent)
     , m_buttonIndex(buttonIndex)
 {
     setCheckable(true);

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -38,7 +38,7 @@
 #include <NETWM>
 
 // KWIN
-#include <kwin/window.h>
+// #include <kwin/window.h>
 #include <kwin/x11window.h>
 
 // Qt
@@ -47,9 +47,9 @@
 #include <QMenu>
 #include <QPainter>
 #include <QVariantAnimation>
-#include <QObject>
-#include <QMetaObject>
-#include <QMetaProperty>
+// #include <QObject>
+// #include <QMetaObject>
+// #include <QMetaProperty>
 
 
 namespace Material

--- a/src/AppMenuButtonGroup.h
+++ b/src/AppMenuButtonGroup.h
@@ -28,7 +28,7 @@
 // Qt
 #include <QMenu>
 #include <QVariantAnimation>
-#include <QWidget>
+// #include <QWidget>
 
 namespace Material
 {

--- a/src/AppMenuButtonGroup.h
+++ b/src/AppMenuButtonGroup.h
@@ -21,20 +21,21 @@
 #include "AppMenuModel.h"
 
 // KDecoration
-#include <KDecoration2/DecoratedClient>
-#include <KDecoration2/DecorationButton>
-#include <KDecoration2/DecorationButtonGroup>
+#include <KDecoration3/DecoratedWindow>
+#include <KDecoration3/DecorationButton>
+#include <KDecoration3/DecorationButtonGroup>
 
 // Qt
 #include <QMenu>
 #include <QVariantAnimation>
+#include <QWidget>
 
 namespace Material
 {
 
 class Decoration;
 
-class AppMenuButtonGroup : public KDecoration2::DecorationButtonGroup
+class AppMenuButtonGroup : public KDecoration3::DecorationButtonGroup
 {
     Q_OBJECT
 
@@ -51,6 +52,7 @@ public:
     Q_PROPERTY(int animationDuration READ animationDuration WRITE setAnimationDuration NOTIFY animationDurationChanged)
     Q_PROPERTY(qreal opacity READ opacity WRITE setOpacity NOTIFY opacityChanged)
 
+ 
     int currentIndex() const;
     void setCurrentIndex(int set);
 
@@ -77,7 +79,7 @@ public:
 
     bool isMenuOpen() const;
 
-    KDecoration2::DecorationButton* buttonAt(int x, int y) const;
+    KDecoration3::DecorationButton* buttonAt(int x, int y) const;
 
     void unPressAllButtons();
 

--- a/src/AppMenuModel.cc
+++ b/src/AppMenuModel.cc
@@ -393,7 +393,7 @@ void AppMenuModel::updateApplicationMenu(const QString &serviceName, const QStri
     m_importer = new KDBusMenuImporter(serviceName, menuObjectPath, this);
     QMetaObject::invokeMethod(m_importer, "updateMenu", Qt::QueuedConnection);
 
-    connect(m_importer.data(), &DBusMenuImporter::menuUpdated, this, [=](QMenu *menu) {
+    connect(m_importer.data(), &DBusMenuImporter::menuUpdated, this, [this](QMenu *menu) {
         m_menu = m_importer->menu();
         if (m_menu.isNull() || menu != m_menu) {
             return;

--- a/src/ApplicationMenuButton.h
+++ b/src/ApplicationMenuButton.h
@@ -22,7 +22,7 @@
 #include "Material.h"
 
 // KDecoration
-#include <KDecoration2/DecoratedClient>
+#include <KDecoration3/DecoratedWindow>
 
 // Qt
 #include <QPainter>
@@ -34,7 +34,7 @@ class ApplicationMenuButton
 {
 
 public:
-    static void init(Button *button, KDecoration2::DecoratedClient *decoratedClient) {
+    static void init(Button *button, KDecoration3::DecoratedWindow *decoratedClient) {
         button->setVisible(decoratedClient->hasApplicationMenu());
     }
     static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal gridUnit) {

--- a/src/BuildConfig.h.cmake
+++ b/src/BuildConfig.h.cmake
@@ -1,4 +1,4 @@
 #cmakedefine01 HAVE_Wayland
 #cmakedefine01 HAVE_X11
-#cmakedefine01 HAVE_KDecoration2_5_25
+#cmakedefine01 HAVE_KDecoration3_5_25
 #cmakedefine01 HAVE_KF5_101

--- a/src/Button.cc
+++ b/src/Button.cc
@@ -33,9 +33,9 @@
 #include "MinimizeButton.h"
 
 // KDecoration
-#include <KDecoration2/DecoratedClient>
-#include <KDecoration2/Decoration>
-#include <KDecoration2/DecorationButton>
+#include <KDecoration3/DecoratedWindow>
+#include <KDecoration3/Decoration>
+#include <KDecoration3/DecorationButton>
 
 // KF
 #include <KColorUtils>
@@ -51,7 +51,7 @@
 namespace Material
 {
 
-Button::Button(KDecoration2::DecorationButtonType type, Decoration *decoration, QObject *parent)
+Button::Button(KDecoration3::DecorationButtonType type, Decoration *decoration, QObject *parent)
     : DecorationButton(type, decoration, parent)
     , m_animationEnabled(true)
     , m_animation(new QVariantAnimation(this))
@@ -94,46 +94,46 @@ Button::Button(KDecoration2::DecorationButtonType type, Decoration *decoration, 
 
     setHeight(decoration->titleBarHeight());
 
-    auto *decoratedClient = decoration->client();
+    auto *decoratedClient = decoration->window();
 
     switch (type) {
-    case KDecoration2::DecorationButtonType::Menu:
+    case KDecoration3::DecorationButtonType::Menu:
         AppIconButton::init(this, decoratedClient);
         break;
 
-    case KDecoration2::DecorationButtonType::ApplicationMenu:
+    case KDecoration3::DecorationButtonType::ApplicationMenu:
         ApplicationMenuButton::init(this, decoratedClient);
         break;
 
-    case KDecoration2::DecorationButtonType::OnAllDesktops:
+    case KDecoration3::DecorationButtonType::OnAllDesktops:
         OnAllDesktopsButton::init(this, decoratedClient);
         break;
 
-    case KDecoration2::DecorationButtonType::ContextHelp:
+    case KDecoration3::DecorationButtonType::ContextHelp:
         ContextHelpButton::init(this, decoratedClient);
         break;
 
-    case KDecoration2::DecorationButtonType::Shade:
+    case KDecoration3::DecorationButtonType::Shade:
         ShadeButton::init(this, decoratedClient);
         break;
 
-    case KDecoration2::DecorationButtonType::KeepAbove:
+    case KDecoration3::DecorationButtonType::KeepAbove:
         KeepAboveButton::init(this, decoratedClient);
         break;
 
-    case KDecoration2::DecorationButtonType::KeepBelow:
+    case KDecoration3::DecorationButtonType::KeepBelow:
         KeepBelowButton::init(this, decoratedClient);
         break;
 
-    case KDecoration2::DecorationButtonType::Close:
+    case KDecoration3::DecorationButtonType::Close:
         CloseButton::init(this, decoratedClient);
         break;
 
-    case KDecoration2::DecorationButtonType::Maximize:
+    case KDecoration3::DecorationButtonType::Maximize:
         MaximizeButton::init(this, decoratedClient);
         break;
 
-    case KDecoration2::DecorationButtonType::Minimize:
+    case KDecoration3::DecorationButtonType::Minimize:
         MinimizeButton::init(this, decoratedClient);
         break;
 
@@ -146,7 +146,7 @@ Button::~Button()
 {
 }
 
-KDecoration2::DecorationButton* Button::create(KDecoration2::DecorationButtonType type, KDecoration2::Decoration *decoration, QObject *parent)
+KDecoration3::DecorationButton* Button::create(KDecoration3::DecorationButtonType type, KDecoration3::Decoration *decoration, QObject *parent)
 {
     auto deco = qobject_cast<Decoration*>(decoration);
     if (!deco) {
@@ -154,16 +154,16 @@ KDecoration2::DecorationButton* Button::create(KDecoration2::DecorationButtonTyp
     }
 
     switch (type) {
-    case KDecoration2::DecorationButtonType::Menu:
-    // case KDecoration2::DecorationButtonType::ApplicationMenu:
-    case KDecoration2::DecorationButtonType::OnAllDesktops:
-    case KDecoration2::DecorationButtonType::ContextHelp:
-    case KDecoration2::DecorationButtonType::Shade:
-    case KDecoration2::DecorationButtonType::KeepAbove:
-    case KDecoration2::DecorationButtonType::KeepBelow:
-    case KDecoration2::DecorationButtonType::Close:
-    case KDecoration2::DecorationButtonType::Maximize:
-    case KDecoration2::DecorationButtonType::Minimize:
+    case KDecoration3::DecorationButtonType::Menu:
+    // case KDecoration3::DecorationButtonType::ApplicationMenu:
+    case KDecoration3::DecorationButtonType::OnAllDesktops:
+    case KDecoration3::DecorationButtonType::ContextHelp:
+    case KDecoration3::DecorationButtonType::Shade:
+    case KDecoration3::DecorationButtonType::KeepAbove:
+    case KDecoration3::DecorationButtonType::KeepBelow:
+    case KDecoration3::DecorationButtonType::Close:
+    case KDecoration3::DecorationButtonType::Maximize:
+    case KDecoration3::DecorationButtonType::Minimize:
         return new Button(type, deco, parent);
 
     default:
@@ -172,11 +172,11 @@ KDecoration2::DecorationButton* Button::create(KDecoration2::DecorationButtonTyp
 }
 
 Button::Button(QObject *parent, const QVariantList &args)
-    : Button(args.at(0).value<KDecoration2::DecorationButtonType>(), args.at(1).value<Decoration*>(), parent)
+    : Button(args.at(0).value<KDecoration3::DecorationButtonType>(), args.at(1).value<Decoration*>(), parent)
 {
 }
 
-void Button::paint(QPainter *painter, const QRect &repaintRegion)
+void Button::paint(QPainter *painter, const QRectF &repaintRegion)
 {
     Q_UNUSED(repaintRegion)
 
@@ -229,43 +229,43 @@ void Button::paint(QPainter *painter, const QRect &repaintRegion)
 
     // Icon
     switch (type()) {
-    case KDecoration2::DecorationButtonType::Menu:
+    case KDecoration3::DecorationButtonType::Menu:
         AppIconButton::paintIcon(this, painter, iconRect, gridUnit);
         break;
 
-    case KDecoration2::DecorationButtonType::ApplicationMenu:
+    case KDecoration3::DecorationButtonType::ApplicationMenu:
         ApplicationMenuButton::paintIcon(this, painter, iconRect, gridUnit);
         break;
 
-    case KDecoration2::DecorationButtonType::OnAllDesktops:
+    case KDecoration3::DecorationButtonType::OnAllDesktops:
         OnAllDesktopsButton::paintIcon(this, painter, iconRect, gridUnit);
         break;
 
-    case KDecoration2::DecorationButtonType::ContextHelp:
+    case KDecoration3::DecorationButtonType::ContextHelp:
         ContextHelpButton::paintIcon(this, painter, iconRect, gridUnit);
         break;
 
-    case KDecoration2::DecorationButtonType::Shade:
+    case KDecoration3::DecorationButtonType::Shade:
         ShadeButton::paintIcon(this, painter, iconRect, gridUnit);
         break;
 
-    case KDecoration2::DecorationButtonType::KeepAbove:
+    case KDecoration3::DecorationButtonType::KeepAbove:
         KeepAboveButton::paintIcon(this, painter, iconRect, gridUnit);
         break;
 
-    case KDecoration2::DecorationButtonType::KeepBelow:
+    case KDecoration3::DecorationButtonType::KeepBelow:
         KeepBelowButton::paintIcon(this, painter, iconRect, gridUnit);
         break;
 
-    case KDecoration2::DecorationButtonType::Close:
+    case KDecoration3::DecorationButtonType::Close:
         CloseButton::paintIcon(this, painter, iconRect, gridUnit);
         break;
 
-    case KDecoration2::DecorationButtonType::Maximize:
+    case KDecoration3::DecorationButtonType::Maximize:
         MaximizeButton::paintIcon(this, painter, iconRect, gridUnit);
         break;
 
-    case KDecoration2::DecorationButtonType::Minimize:
+    case KDecoration3::DecorationButtonType::Minimize:
         MinimizeButton::paintIcon(this, painter, iconRect, gridUnit);
         break;
 
@@ -328,19 +328,19 @@ QColor Button::backgroundColor() const
     }
 
     //--- CloseButton
-    if (type() == KDecoration2::DecorationButtonType::Close) {
-        auto *decoratedClient = deco->client();
+    if (type() == KDecoration3::DecorationButtonType::Close) {
+        auto *decoratedClient = deco->window();
         const QColor hoveredColor = decoratedClient->color(
-            KDecoration2::ColorGroup::Warning,
-            KDecoration2::ColorRole::Foreground
+            KDecoration3::ColorGroup::Warning,
+            KDecoration3::ColorRole::Foreground
         );
         QColor normalColor = QColor(hoveredColor);
         normalColor.setAlphaF(0);
 
         if (isPressed()) {
             const QColor pressedColor = decoratedClient->color(
-                KDecoration2::ColorGroup::Warning,
-                KDecoration2::ColorRole::Foreground
+                KDecoration3::ColorGroup::Warning,
+                KDecoration3::ColorRole::Foreground
             ).lighter();
             return KColorUtils::mix(normalColor, pressedColor, m_transitionValue);
         }
@@ -351,7 +351,7 @@ QColor Button::backgroundColor() const
     }
 
     //--- Checked
-    if (isChecked() && type() != KDecoration2::DecorationButtonType::Maximize) {
+    if (isChecked() && type() != KDecoration3::DecorationButtonType::Maximize) {
         const QColor normalColor = deco->titleBarForegroundColor();
 
         if (isPressed()) {
@@ -400,7 +400,7 @@ QColor Button::foregroundColor() const
     }
 
     //--- Checked
-    if (isChecked() && type() != KDecoration2::DecorationButtonType::Maximize) {
+    if (isChecked() && type() != KDecoration3::DecorationButtonType::Maximize) {
         const QColor activeColor = KColorUtils::mix(
             deco->titleBarBackgroundColor(),
             deco->titleBarForegroundColor(),
@@ -425,20 +425,20 @@ QColor Button::foregroundColor() const
         // Breeze GTK has huge margins around the button. It looks better
         // when we just change the fgColor on hover instead of the bgColor.
         QColor hoveredColor;
-        if (m_isGtkButton && type() == KDecoration2::DecorationButtonType::Close) {
-            auto *decoratedClient = deco->client();
+        if (m_isGtkButton && type() == KDecoration3::DecorationButtonType::Close) {
+            auto *decoratedClient = deco->window();
             hoveredColor = decoratedClient->color(
-                KDecoration2::ColorGroup::Warning,
-                KDecoration2::ColorRole::Foreground
+                KDecoration3::ColorGroup::Warning,
+                KDecoration3::ColorRole::Foreground
             );
-        } else if (m_isGtkButton && type() == KDecoration2::DecorationButtonType::Maximize) {
+        } else if (m_isGtkButton && type() == KDecoration3::DecorationButtonType::Maximize) {
             const int grayValue = qGray(deco->titleBarBackgroundColor().rgb());
             if (grayValue < 128) { // Dark Bg
                 hoveredColor = QColor(100, 196, 86); // from SierraBreeze
             } else { // Light Bg
                 hoveredColor = QColor(40, 200, 64); // from SierraBreeze
             }
-        } else if (m_isGtkButton && type() == KDecoration2::DecorationButtonType::Minimize) {
+        } else if (m_isGtkButton && type() == KDecoration3::DecorationButtonType::Minimize) {
             const int grayValue = qGray(deco->titleBarBackgroundColor().rgb());
             if (grayValue < 128) {
                 hoveredColor = QColor(223, 192, 76); // from SierraBreeze

--- a/src/Button.h
+++ b/src/Button.h
@@ -19,8 +19,8 @@
 #pragma once
 
 // KDecoration
-#include <KDecoration2/Decoration>
-#include <KDecoration2/DecorationButton>
+#include <KDecoration3/Decoration>
+#include <KDecoration3/DecorationButton>
 
 // Qt
 #include <QMargins>
@@ -32,12 +32,12 @@ namespace Material
 
 class Decoration;
 
-class Button : public KDecoration2::DecorationButton
+class Button : public KDecoration3::DecorationButton
 {
     Q_OBJECT
 
 public:
-    Button(KDecoration2::DecorationButtonType type, Decoration *decoration, QObject *parent = nullptr);
+    Button(KDecoration3::DecorationButtonType type, Decoration *decoration, QObject *parent = nullptr);
     ~Button() override;
 
     Q_PROPERTY(bool animationEnabled READ animationEnabled WRITE setAnimationEnabled NOTIFY animationEnabledChanged)
@@ -47,7 +47,7 @@ public:
     Q_PROPERTY(QMargins* padding READ padding NOTIFY paddingChanged)
 
     // Passed to DecorationButtonGroup in Decoration
-    static KDecoration2::DecorationButton *create(KDecoration2::DecorationButtonType type, KDecoration2::Decoration *decoration, QObject *parent = nullptr);
+    static KDecoration3::DecorationButton *create(KDecoration3::DecorationButtonType type, KDecoration3::Decoration *decoration, QObject *parent = nullptr);
 
     // This is called by:
     // registerPlugin<Material::Button>(QStringLiteral("button"))
@@ -55,7 +55,7 @@ public:
     explicit Button(QObject *parent, const QVariantList &args);
 
 
-    void paint(QPainter *painter, const QRect &repaintRegion) override;
+    void paint(QPainter *painter, const QRectF &repaintRegion) override;
     virtual void paintIcon(QPainter *painter, const QRectF &iconRect, const qreal gridUnit);
 
     virtual void updateSize(int contentWidth, int contentHeight);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,7 @@ set(DKDE_INSTALL_USE_QT_SYS_PATHS=ON)
 set(DQT_MAJOR_VERSION=6)
 set(DQT_VERSION_MAJOR=6)
 
-find_package (KDecoration2 REQUIRED)
+find_package (KDecoration3 REQUIRED)
 
 find_package (Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS
     Core
@@ -21,6 +21,9 @@ find_package (KF6 REQUIRED COMPONENTS
     KCMUtils
 )
 
+find_package(KWin REQUIRED)
+
+include_directories(/usr/include/kwin)
 
 # X11
 find_package(X11 REQUIRED)
@@ -64,13 +67,13 @@ endif()
 #endif()
 
 
-# KDecoration2/Plasma Version
-if(${KDecoration2_VERSION} VERSION_GREATER_EQUAL "5.25.0")
-    set(HAVE_KDecoration2_5_25 ON)
+# KDecoration3/Plasma Version
+if(${KDecoration3_VERSION} VERSION_GREATER_EQUAL "5.25.0")
+    set(HAVE_KDecoration3_5_25 ON)
 else()
-    set(HAVE_KDecoration2_5_25 OFF)
+    set(HAVE_KDecoration3_5_25 OFF)
 endif()
-message(STATUS "HAVE_KDecoration2_5_25: ${HAVE_KDecoration2_5_25} (${KDecoration2_VERSION})")
+message(STATUS "HAVE_KDecoration3_5_25: ${HAVE_KDecoration3_5_25} (${KDecoration3_VERSION})")
 
 # KF5 Version
 #if(${KF5_VERSION} VERSION_GREATER_EQUAL "5.101.0")
@@ -119,10 +122,12 @@ target_link_libraries (materialdecoration
         KF6::WindowSystem
         KF6::KCMUtils
         ${X11_LIBRARIES}
+
 #        ${Wayland_LIBRARIES}
 
     PRIVATE
-        KDecoration2::KDecoration
+        KDecoration3::KDecoration
+        kwin
 )
 if (Qt6_FOUND)
     # The QX11Info class has been removed.
@@ -137,5 +142,9 @@ elseif(Qt5_FOUND)
     )
 endif()
 
-install (TARGETS materialdecoration
-         DESTINATION ${PLUGIN_INSTALL_DIR}/org.kde.kdecoration2)
+include(KDEInstallDirs)
+install(TARGETS materialdecoration
+        DESTINATION ${KDE_INSTALL_PLUGINDIR}/org.kde.kdecoration3)
+
+#install (TARGETS materialdecoration
+#         DESTINATION ${PLUGIN_INSTALL_DIR}/org.kde.kdecoration3)

--- a/src/CloseButton.h
+++ b/src/CloseButton.h
@@ -21,7 +21,7 @@
 #include "Button.h"
 
 // KDecoration
-#include <KDecoration2/DecoratedClient>
+#include <KDecoration3/DecoratedWindow>
 
 // Qt
 #include <QPainter>
@@ -33,8 +33,8 @@ class CloseButton
 {
 
 public:
-    static void init(Button *button, KDecoration2::DecoratedClient *decoratedClient) {
-        QObject::connect(decoratedClient, &KDecoration2::DecoratedClient::closeableChanged,
+    static void init(Button *button, KDecoration3::DecoratedWindow *decoratedClient) {
+        QObject::connect(decoratedClient, &KDecoration3::DecoratedWindow::closeableChanged,
                 button, &Button::setVisible);
 
         button->setVisible(decoratedClient->isCloseable());

--- a/src/ContextHelpButton.h
+++ b/src/ContextHelpButton.h
@@ -22,7 +22,7 @@
 #include "Material.h"
 
 // KDecoration
-#include <KDecoration2/DecoratedClient>
+#include <KDecoration3/DecoratedWindow>
 
 // Qt
 #include <QPainter>
@@ -38,8 +38,8 @@ class ContextHelpButton
 {
 
 public:
-    static void init(Button *button, KDecoration2::DecoratedClient *decoratedClient) {
-        QObject::connect(decoratedClient, &KDecoration2::DecoratedClient::providesContextHelpChanged,
+    static void init(Button *button, KDecoration3::DecoratedWindow *decoratedClient) {
+        QObject::connect(decoratedClient, &KDecoration3::DecoratedWindow::providesContextHelpChanged,
                 button, &Button::setVisible);
 
         button->setVisible(decoratedClient->providesContextHelp());

--- a/src/Decoration.cc
+++ b/src/Decoration.cc
@@ -38,7 +38,7 @@
 #include <KWindowSystem>
 
 // KWIN
-#include <kwin/window.h>
+// #include <kwin/window.h>
 #include <kwin/x11window.h>
 
 // Qt

--- a/src/Decoration.cc
+++ b/src/Decoration.cc
@@ -28,14 +28,18 @@
 #include "InternalSettings.h"
 
 // KDecoration
-#include <KDecoration2/DecoratedClient>
-#include <KDecoration2/DecorationButton>
-#include <KDecoration2/DecorationButtonGroup>
-#include <KDecoration2/DecorationSettings>
-#include <KDecoration2/DecorationShadow>
+#include <KDecoration3/DecoratedWindow>
+#include <KDecoration3/DecorationButton>
+#include <KDecoration3/DecorationButtonGroup>
+#include <KDecoration3/DecorationSettings>
+#include <KDecoration3/DecorationShadow>
 
 // KF
 #include <KWindowSystem>
+
+// KWIN
+#include <kwin/window.h>
+#include <kwin/x11window.h>
 
 // Qt
 #include <QApplication>
@@ -59,6 +63,7 @@
 
 namespace Material
 {
+    
 
 namespace
 {
@@ -151,10 +156,10 @@ static int s_decoCount = 0;
 static int s_shadowSizePreset = InternalSettings::ShadowVeryLarge;
 static int s_shadowStrength = 255;
 static QColor s_shadowColor = QColor(33, 33, 33);
-static std::shared_ptr<KDecoration2::DecorationShadow> s_cachedShadow;
+static std::shared_ptr<KDecoration3::DecorationShadow> s_cachedShadow;
 
 Decoration::Decoration(QObject *parent, const QVariantList &args)
-    : KDecoration2::Decoration(parent, args)
+    : KDecoration3::Decoration(parent, args)
     , m_internalSettings(nullptr)
 {
     ++s_decoCount;
@@ -190,9 +195,9 @@ QRect Decoration::centerRect() const
     );
 }
 
-void Decoration::paint(QPainter *painter, const QRect &repaintRegion)
+void Decoration::paint(QPainter *painter, const QRectF &repaintRegion)
 {
-    auto *decoratedClient = client();
+    auto *decoratedClient = window();
 
     if (!decoratedClient->isShaded()) {
         paintFrameBackground(painter, repaintRegion);
@@ -203,7 +208,7 @@ void Decoration::paint(QPainter *painter, const QRect &repaintRegion)
     paintCaption(painter, repaintRegion);
 
     // Don't paint outline for NoBorder, NoSideBorder, or Tiny borders.
-    if (settings()->borderSize() >= KDecoration2::BorderSize::Normal) {
+    if (settings()->borderSize() >= KDecoration3::BorderSize::Normal) {
         paintOutline(painter, repaintRegion);
     }
     updateBlur();
@@ -213,19 +218,19 @@ bool Decoration::init()
 {
     m_internalSettings = QSharedPointer<InternalSettings>(new InternalSettings());
 
-    auto *decoratedClient = client();
+    auto *decoratedClient = window();
 
     auto repaintTitleBar = [this] {
         update(titleBar());
     };
 
-    m_leftButtons = new KDecoration2::DecorationButtonGroup(
-        KDecoration2::DecorationButtonGroup::Position::Left,
+    m_leftButtons = new KDecoration3::DecorationButtonGroup(
+        KDecoration3::DecorationButtonGroup::Position::Left,
         this,
         &Button::create);
 
-    m_rightButtons = new KDecoration2::DecorationButtonGroup(
-        KDecoration2::DecorationButtonGroup::Position::Right,
+    m_rightButtons = new KDecoration3::DecorationButtonGroup(
+        KDecoration3::DecorationButtonGroup::Position::Right,
         this,
         &Button::create);
 
@@ -239,25 +244,25 @@ bool Decoration::init()
     m_menuButtons->updateAppMenuModel();
 
 
-    connect(decoratedClient, &KDecoration2::DecoratedClient::widthChanged,
+    connect(decoratedClient, &KDecoration3::DecoratedWindow::widthChanged,
             this, &Decoration::updateTitleBar);
-    connect(decoratedClient, &KDecoration2::DecoratedClient::widthChanged,
+    connect(decoratedClient, &KDecoration3::DecoratedWindow::widthChanged,
             this, &Decoration::updateButtonsGeometry);
-    connect(decoratedClient, &KDecoration2::DecoratedClient::maximizedChanged,
+    connect(decoratedClient, &KDecoration3::DecoratedWindow::maximizedChanged,
             this, &Decoration::updateButtonsGeometry);
 
-    connect(decoratedClient, &KDecoration2::DecoratedClient::adjacentScreenEdgesChanged,
+    connect(decoratedClient, &KDecoration3::DecoratedWindow::adjacentScreenEdgesChanged,
             this, &Decoration::updateBorders);
-    connect(decoratedClient, &KDecoration2::DecoratedClient::maximizedHorizontallyChanged,
+    connect(decoratedClient, &KDecoration3::DecoratedWindow::maximizedHorizontallyChanged,
             this, &Decoration::updateBorders);
-    connect(decoratedClient, &KDecoration2::DecoratedClient::maximizedVerticallyChanged,
+    connect(decoratedClient, &KDecoration3::DecoratedWindow::maximizedVerticallyChanged,
             this, &Decoration::updateBorders);
-    connect(decoratedClient, &KDecoration2::DecoratedClient::shadedChanged,
+    connect(decoratedClient, &KDecoration3::DecoratedWindow::shadedChanged,
             this, &Decoration::updateBorders);
 
-    connect(decoratedClient, &KDecoration2::DecoratedClient::captionChanged,
+    connect(decoratedClient, &KDecoration3::DecoratedWindow::captionChanged,
             this, repaintTitleBar);
-    connect(decoratedClient, &KDecoration2::DecoratedClient::activeChanged,
+    connect(decoratedClient, &KDecoration3::DecoratedWindow::activeChanged,
             this, repaintTitleBar);
 
     updateBorders();
@@ -265,7 +270,7 @@ bool Decoration::init()
     updateTitleBar();
     updateButtonsGeometry();
 
-    connect(this, &KDecoration2::Decoration::sectionUnderMouseChanged,
+    connect(this, &KDecoration3::Decoration::sectionUnderMouseChanged,
             this, &Decoration::onSectionUnderMouseChanged);
     updateTitleBarHoverState();
 
@@ -273,7 +278,7 @@ bool Decoration::init()
     // the Window Decorations KCM crashes.
     updateShadow();
 
-    connect(settings().get(), &KDecoration2::DecorationSettings::reconfigured,
+    connect(settings().get(), &KDecoration3::DecorationSettings::reconfigured,
         this, &Decoration::reconfigure);
     connect(m_internalSettings.data(), &InternalSettings::configChanged,
         this, &Decoration::reconfigure);
@@ -281,11 +286,11 @@ bool Decoration::init()
     // Window Decoration KCM
     // The reconfigure signal will update active windows, but we need to hook
     // individual signals for the preview in the KCM.
-    connect(settings().get(), &KDecoration2::DecorationSettings::borderSizeChanged,
+    connect(settings().get(), &KDecoration3::DecorationSettings::borderSizeChanged,
         this, &Decoration::updateBorders);
-    connect(settings().get(), &KDecoration2::DecorationSettings::fontChanged,
+    connect(settings().get(), &KDecoration3::DecorationSettings::fontChanged,
         this, &Decoration::updateBorders);
-    connect(settings().get(), &KDecoration2::DecorationSettings::spacingChanged,
+    connect(settings().get(), &KDecoration3::DecorationSettings::spacingChanged,
         this, &Decoration::updateBorders);
   return true;
 }
@@ -305,7 +310,7 @@ void Decoration::reconfigure()
 
 void Decoration::mousePressEvent(QMouseEvent *event)
 {
-    KDecoration2::Decoration::mousePressEvent(event);
+    KDecoration3::Decoration::mousePressEvent(event);
     // qCDebug(category) << "Decoration::mousePressEvent" << event;
 
     if (m_menuButtons->geometry().contains(event->pos())) {
@@ -315,7 +320,7 @@ void Decoration::mousePressEvent(QMouseEvent *event)
 
         // If AppMenuButton's do not handle the button
         } else if (event->button() == Qt::MiddleButton || event->button() == Qt::RightButton) {
-            // Don't accept the event. KDecoration2 will
+            // Don't accept the event. KDecoration3 will
             // accept the event even if it doesn't pass
             // button->acceptableButtons()->testFlag(button)
             event->setAccepted(false);
@@ -325,15 +330,15 @@ void Decoration::mousePressEvent(QMouseEvent *event)
 
 void Decoration::hoverEnterEvent(QHoverEvent *event)
 {
-    KDecoration2::Decoration::hoverEnterEvent(event);
-    qCDebug(category) << "Decoration::hoverEnterEvent" << event;
+    KDecoration3::Decoration::hoverEnterEvent(event);
+    // qCDebug(category) << "Decoration::hoverEnterEvent" << event;
     updateBlur();
     // m_menuButtons->setHovered(true);
 }
 
 void Decoration::hoverMoveEvent(QHoverEvent *event)
 {
-    KDecoration2::Decoration::hoverMoveEvent(event);
+    KDecoration3::Decoration::hoverMoveEvent(event);
     // qCDebug(category) << "Decoration::hoverMoveEvent" << event;
 
     const bool dragStarted = dragMoveTick(event->position().toPoint());
@@ -358,7 +363,7 @@ void Decoration::hoverMoveEvent(QHoverEvent *event)
 
 void Decoration::mouseReleaseEvent(QMouseEvent *event)
 {
-    KDecoration2::Decoration::mouseReleaseEvent(event);
+    KDecoration3::Decoration::mouseReleaseEvent(event);
     // qCDebug(category) << "Decoration::mouseReleaseEvent" << event;
 
     resetDragMove();
@@ -367,8 +372,8 @@ void Decoration::mouseReleaseEvent(QMouseEvent *event)
 
 void Decoration::hoverLeaveEvent(QHoverEvent *event)
 {
-    KDecoration2::Decoration::hoverLeaveEvent(event);
-    qCDebug(category) << "Decoration::hoverLeaveEvent" << event;
+    KDecoration3::Decoration::hoverLeaveEvent(event);
+    // qCDebug(category) << "Decoration::hoverLeaveEvent" << event;
 
     resetDragMove();
     updateBlur();
@@ -386,7 +391,7 @@ void Decoration::wheelEvent(QWheelEvent *event)
     if (m_menuButtons->geometry().contains(pos)) {
         // Skip
     } else {
-        KDecoration2::Decoration::wheelEvent(event);
+        KDecoration3::Decoration::wheelEvent(event);
     }
 }
 
@@ -399,7 +404,7 @@ void Decoration::onSectionUnderMouseChanged(const Qt::WindowFrameSection value)
 
 void Decoration::updateBlur()
 {
-#if HAVE_KDecoration2_5_25
+#if HAVE_KDecoration3_5_25
     setBlurRegion(QRegion(0, 0, size().width(), size().height()));
 #endif
 }
@@ -448,11 +453,11 @@ void Decoration::updateTitleBarHoverState()
     }
 }
 
-void Decoration::setButtonGroupHeight(KDecoration2::DecorationButtonGroup *buttonGroup, int buttonHeight)
+void Decoration::setButtonGroupHeight(KDecoration3::DecorationButtonGroup *buttonGroup, int buttonHeight)
 {
     // int vertPadding = buttonPadding();
     for (int i = 0; i < buttonGroup->buttons().length(); i++) {
-        KDecoration2::DecorationButton* decoButton = buttonGroup->buttons().value(i);
+        KDecoration3::DecorationButton* decoButton = buttonGroup->buttons().value(i);
         auto *button = qobject_cast<Button *>(decoButton);
         if (button) {
             button->setHeight(buttonHeight);
@@ -461,10 +466,10 @@ void Decoration::setButtonGroupHeight(KDecoration2::DecorationButtonGroup *butto
     }
 }
 
-void Decoration::setButtonGroupHorzPadding(KDecoration2::DecorationButtonGroup *buttonGroup, int value)
+void Decoration::setButtonGroupHorzPadding(KDecoration3::DecorationButtonGroup *buttonGroup, int value)
 {
     for (int i = 0; i < buttonGroup->buttons().length(); i++) {
-        KDecoration2::DecorationButton* decoButton = buttonGroup->buttons().value(i);
+        KDecoration3::DecorationButton* decoButton = buttonGroup->buttons().value(i);
         auto *button = qobject_cast<Button *>(decoButton);
         if (button) {
             button->setHorzPadding(value);
@@ -472,10 +477,10 @@ void Decoration::setButtonGroupHorzPadding(KDecoration2::DecorationButtonGroup *
     }
 }
 
-void Decoration::setButtonGroupVertPadding(KDecoration2::DecorationButtonGroup *buttonGroup, int value)
+void Decoration::setButtonGroupVertPadding(KDecoration3::DecorationButtonGroup *buttonGroup, int value)
 {
     for (int i = 0; i < buttonGroup->buttons().length(); i++) {
-        KDecoration2::DecorationButton* decoButton = buttonGroup->buttons().value(i);
+        KDecoration3::DecorationButton* decoButton = buttonGroup->buttons().value(i);
         auto *button = qobject_cast<Button *>(decoButton);
         if (button) {
             button->setVertPadding(value);
@@ -536,7 +541,7 @@ void Decoration::updateButtonsGeometry()
     update();
 }
 
-void Decoration::setButtonGroupAnimation(KDecoration2::DecorationButtonGroup *buttonGroup, bool enabled, int duration)
+void Decoration::setButtonGroupAnimation(KDecoration3::DecorationButtonGroup *buttonGroup, bool enabled, int duration)
 {
     for (int i = 0; i < buttonGroup->buttons().length(); i++) {
         auto *button = qobject_cast<Button *>(buttonGroup->buttons().value(i));
@@ -637,7 +642,7 @@ void Decoration::updateShadow()
 
     painter.end();
 
-    s_cachedShadow = std::make_shared<KDecoration2::DecorationShadow>();
+    s_cachedShadow = std::make_shared<KDecoration3::DecorationShadow>();
     s_cachedShadow->setPadding(padding);
     s_cachedShadow->setInnerShadowRect(QRect(shadowTexture.rect().center(), QSize(1, 1)));
     s_cachedShadow->setShadow(shadowTexture);
@@ -705,28 +710,28 @@ int Decoration::bottomBorderSize() const {
     const int baseSize = settings()->smallSpacing();
     switch (settings()->borderSize()) {
         default:
-        case KDecoration2::BorderSize::None:
+        case KDecoration3::BorderSize::None:
             return 0;
-        case KDecoration2::BorderSize::NoSides:
-        case KDecoration2::BorderSize::Tiny:
+        case KDecoration3::BorderSize::NoSides:
+        case KDecoration3::BorderSize::Tiny:
             return 1; // Breeze: max(4, baseSize)
-        case KDecoration2::BorderSize::Normal:
+        case KDecoration3::BorderSize::Normal:
             return baseSize; // Breeze: baseSize*2
-        case KDecoration2::BorderSize::Large:
+        case KDecoration3::BorderSize::Large:
             return baseSize*2; // Breeze: baseSize*3
-        case KDecoration2::BorderSize::VeryLarge:
+        case KDecoration3::BorderSize::VeryLarge:
             return baseSize*3; // Breeze: ...
-        case KDecoration2::BorderSize::Huge:
+        case KDecoration3::BorderSize::Huge:
             return baseSize*4;
-        case KDecoration2::BorderSize::VeryHuge:
+        case KDecoration3::BorderSize::VeryHuge:
             return baseSize*5;
-        case KDecoration2::BorderSize::Oversized:
+        case KDecoration3::BorderSize::Oversized:
             return baseSize*10; // Same as Breeze
     }
 }
 int Decoration::sideBorderSize() const {
     switch (settings()->borderSize()) {
-        case KDecoration2::BorderSize::NoSides:
+        case KDecoration3::BorderSize::NoSides:
             return 0;
         default:
             return bottomBorderSize();
@@ -734,22 +739,22 @@ int Decoration::sideBorderSize() const {
 }
 
 bool Decoration::Decoration::leftBorderVisible() const {
-    const auto *decoratedClient = client();
+    const auto *decoratedClient = window();
     return !decoratedClient->isMaximizedHorizontally()
         && !decoratedClient->adjacentScreenEdges().testFlag(Qt::LeftEdge);
 }
 bool Decoration::rightBorderVisible() const {
-    const auto *decoratedClient = client();
+    const auto *decoratedClient = window();
     return !decoratedClient->isMaximizedHorizontally()
         && !decoratedClient->adjacentScreenEdges().testFlag(Qt::RightEdge);
 }
 bool Decoration::topBorderVisible() const {
-    const auto *decoratedClient = client();
+    const auto *decoratedClient = window();
     return !decoratedClient->isMaximizedVertically()
         && !decoratedClient->adjacentScreenEdges().testFlag(Qt::TopEdge);
 }
 bool Decoration::bottomBorderVisible() const {
-    const auto *decoratedClient = client();
+    const auto *decoratedClient = window();
     return !decoratedClient->isMaximizedVertically()
         && !decoratedClient->adjacentScreenEdges().testFlag(Qt::BottomEdge)
         && !decoratedClient->isShaded();
@@ -774,8 +779,17 @@ template <typename T> using ScopedPointer = QScopedPointer<T, QScopedPointerPodD
 
 QPoint Decoration::windowPos() const
 {
-    const auto *decoratedClient = client();
-    WId windowId = decoratedClient->windowId();
+    const auto *decoratedClient = window();
+    // WId windowId = decoratedClient->windowId(); REMOVED IN KDecoration3
+            
+            //SO ... WE ASK TO KWIN
+            KWin::X11Window *kwinWindow = static_cast<KWin::X11Window *>(decoratedClient->decoration()->parent());
+            // qCDebug(category) << "KWin window: " << kwinWindow->window();            
+            WId windowId = 0;
+            if (kwinWindow) { 
+                windowId = kwinWindow->window();
+            };   
+            //
 
     if (KWindowSystem::isPlatformX11()) {
 #if HAVE_X11
@@ -843,8 +857,17 @@ bool Decoration::dragMoveTick(const QPoint pos)
 
 void Decoration::sendMoveEvent(const QPoint pos)
 {
-    const auto *decoratedClient = client();
-    WId windowId = decoratedClient->windowId();
+    const auto *decoratedClient = window();
+    // WId windowId = decoratedClient->windowId(); REMOVED IN KDecoration3
+            
+             //SO ... WE ASK TO KWIN
+            KWin::X11Window *kwinWindow = static_cast<KWin::X11Window *>(decoratedClient->decoration()->parent());
+            // qCDebug(category) << "KWin window: " << kwinWindow->window();            
+            WId windowId = 0;
+            if (kwinWindow) { 
+                windowId = kwinWindow->window();
+            };   
+            //
 
     QPoint globalPos = windowPos()
         - QPoint(0, titleBarHeight())
@@ -932,7 +955,7 @@ void Decoration::sendMoveEvent(const QPoint pos)
     }
 }
 
-void Decoration::paintFrameBackground(QPainter *painter, const QRect &repaintRegion) const
+void Decoration::paintFrameBackground(QPainter *painter, const QRectF &repaintRegion) const
 {
     Q_UNUSED(repaintRegion)
 
@@ -950,42 +973,42 @@ void Decoration::paintFrameBackground(QPainter *painter, const QRect &repaintReg
 
 QColor Decoration::borderColor() const
 {
-    const auto *decoratedClient = client();
+    const auto *decoratedClient = window();
     const auto group = decoratedClient->isActive()
-        ? KDecoration2::ColorGroup::Active
-        : KDecoration2::ColorGroup::Inactive;
+        ? KDecoration3::ColorGroup::Active
+        : KDecoration3::ColorGroup::Inactive;
     const qreal opacity = decoratedClient->isActive()
         ? m_internalSettings->activeOpacity()
         : m_internalSettings->inactiveOpacity();
-    QColor color = decoratedClient->color(group, KDecoration2::ColorRole::Frame);
+    QColor color = decoratedClient->color(group, KDecoration3::ColorRole::Frame);
     color.setAlphaF(opacity);
     return color;
 }
 
 QColor Decoration::titleBarBackgroundColor() const
 {
-    const auto *decoratedClient = client();
+    const auto *decoratedClient = window();
     const auto group = decoratedClient->isActive()
-        ? KDecoration2::ColorGroup::Active
-        : KDecoration2::ColorGroup::Inactive;
+        ? KDecoration3::ColorGroup::Active
+        : KDecoration3::ColorGroup::Inactive;
     const qreal opacity = decoratedClient->isActive()
         ? m_internalSettings->activeOpacity()
         : m_internalSettings->inactiveOpacity();
-    QColor color = decoratedClient->color(group, KDecoration2::ColorRole::TitleBar);
+    QColor color = decoratedClient->color(group, KDecoration3::ColorRole::TitleBar);
     color.setAlphaF(opacity);
     return color;
 }
 
 QColor Decoration::titleBarForegroundColor() const
 {
-    const auto *decoratedClient = client();
+    const auto *decoratedClient = window();
     const auto group = decoratedClient->isActive()
-        ? KDecoration2::ColorGroup::Active
-        : KDecoration2::ColorGroup::Inactive;
-    return decoratedClient->color(group, KDecoration2::ColorRole::Foreground);
+        ? KDecoration3::ColorGroup::Active
+        : KDecoration3::ColorGroup::Inactive;
+    return decoratedClient->color(group, KDecoration3::ColorRole::Foreground);
 }
 
-void Decoration::paintTitleBarBackground(QPainter *painter, const QRect &repaintRegion) const
+void Decoration::paintTitleBarBackground(QPainter *painter, const QRectF &repaintRegion) const
 {
     Q_UNUSED(repaintRegion)
 
@@ -996,7 +1019,7 @@ void Decoration::paintTitleBarBackground(QPainter *painter, const QRect &repaint
     painter->restore();
 }
 
-void Decoration::paintCaption(QPainter *painter, const QRect &repaintRegion) const
+void Decoration::paintCaption(QPainter *painter, const QRectF &repaintRegion) const
 {
     Q_UNUSED(repaintRegion)
 
@@ -1004,7 +1027,7 @@ void Decoration::paintCaption(QPainter *painter, const QRect &repaintRegion) con
         return;
     }
 
-    const auto *decoratedClient = client();
+    const auto *decoratedClient = window();
 
     const int textWidth = settings()->fontMetrics().boundingRect(decoratedClient->caption()).width();
     const QRect textRect((size().width() - textWidth) / 2, 0, textWidth, titleBarHeight());
@@ -1097,14 +1120,14 @@ void Decoration::paintCaption(QPainter *painter, const QRect &repaintRegion) con
     painter->restore();
 }
 
-void Decoration::paintButtons(QPainter *painter, const QRect &repaintRegion) const
+void Decoration::paintButtons(QPainter *painter, const QRectF &repaintRegion) const
 {
     m_leftButtons->paint(painter, repaintRegion);
     m_rightButtons->paint(painter, repaintRegion);
     m_menuButtons->paint(painter, repaintRegion);
 }
 
-void Decoration::paintOutline(QPainter *painter, const QRect &repaintRegion) const
+void Decoration::paintOutline(QPainter *painter, const QRectF &repaintRegion) const
 {
     Q_UNUSED(repaintRegion)
 

--- a/src/Decoration.h
+++ b/src/Decoration.h
@@ -24,9 +24,9 @@
 #include "InternalSettings.h"
 
 // KDecoration
-#include <KDecoration2/Decoration>
-#include <KDecoration2/DecorationButton>
-#include <KDecoration2/DecorationButtonGroup>
+#include <KDecoration3/Decoration>
+#include <KDecoration3/DecorationButton>
+#include <KDecoration3/DecorationButtonGroup>
 
 // Qt
 #include <QHoverEvent>
@@ -48,7 +48,7 @@ class Button;
 class TextButton;
 class MenuOverflowButton;
 
-class Decoration : public KDecoration2::Decoration
+class Decoration : public KDecoration3::Decoration
 {
     Q_OBJECT
 
@@ -59,7 +59,7 @@ public:
     QRect titleBarRect() const;
     QRect centerRect() const;
 
-    void paint(QPainter *painter, const QRect &repaintRegion) override;
+    void paint(QPainter *painter, const QRectF &repaintRegion) override;
 
 public slots:
     bool init() override;
@@ -82,12 +82,12 @@ private:
     void updateResizeBorders();
     void updateTitleBar();
     void updateTitleBarHoverState();
-    void setButtonGroupHeight(KDecoration2::DecorationButtonGroup *buttonGroup, int buttonHeight);
-    void setButtonGroupHorzPadding(KDecoration2::DecorationButtonGroup *buttonGroup, int value);
-    void setButtonGroupVertPadding(KDecoration2::DecorationButtonGroup *buttonGroup, int value);
+    void setButtonGroupHeight(KDecoration3::DecorationButtonGroup *buttonGroup, int buttonHeight);
+    void setButtonGroupHorzPadding(KDecoration3::DecorationButtonGroup *buttonGroup, int value);
+    void setButtonGroupVertPadding(KDecoration3::DecorationButtonGroup *buttonGroup, int value);
     void updateButtonHeight();
     void updateButtonsGeometry();
-    void setButtonGroupAnimation(KDecoration2::DecorationButtonGroup *buttonGroup, bool enabled, int duration);
+    void setButtonGroupAnimation(KDecoration3::DecorationButtonGroup *buttonGroup, bool enabled, int duration);
     void updateButtonAnimation();
     void updateShadow();
 
@@ -121,14 +121,14 @@ private:
     QColor titleBarBackgroundColor() const;
     QColor titleBarForegroundColor() const;
 
-    void paintFrameBackground(QPainter *painter, const QRect &repaintRegion) const;
-    void paintTitleBarBackground(QPainter *painter, const QRect &repaintRegion) const;
-    void paintCaption(QPainter *painter, const QRect &repaintRegion) const;
-    void paintButtons(QPainter *painter, const QRect &repaintRegion) const;
-    void paintOutline(QPainter *painter, const QRect &repaintRegion) const;
+    void paintFrameBackground(QPainter *painter, const QRectF &repaintRegion) const;
+    void paintTitleBarBackground(QPainter *painter, const QRectF &repaintRegion) const;
+    void paintCaption(QPainter *painter, const QRectF &repaintRegion) const;
+    void paintButtons(QPainter *painter, const QRectF &repaintRegion) const;
+    void paintOutline(QPainter *painter, const QRectF &repaintRegion) const;
 
-    KDecoration2::DecorationButtonGroup *m_leftButtons;
-    KDecoration2::DecorationButtonGroup *m_rightButtons;
+    KDecoration3::DecorationButtonGroup *m_leftButtons;
+    KDecoration3::DecorationButtonGroup *m_rightButtons;
     AppMenuButtonGroup *m_menuButtons;
 
     QSharedPointer<InternalSettings> m_internalSettings;

--- a/src/KeepAboveButton.h
+++ b/src/KeepAboveButton.h
@@ -22,7 +22,7 @@
 #include "Material.h"
 
 // KDecoration
-#include <KDecoration2/DecoratedClient>
+#include <KDecoration3/DecoratedWindow>
 
 // Qt
 #include <QPainter>
@@ -34,7 +34,7 @@ class KeepAboveButton
 {
 
 public:
-    static void init(Button *button, KDecoration2::DecoratedClient *decoratedClient) {
+    static void init(Button *button, KDecoration3::DecoratedWindow *decoratedClient) {
         Q_UNUSED(decoratedClient)
 
         button->setVisible(true);

--- a/src/KeepBelowButton.h
+++ b/src/KeepBelowButton.h
@@ -22,7 +22,7 @@
 #include "Material.h"
 
 // KDecoration
-#include <KDecoration2/DecoratedClient>
+#include <KDecoration3/DecoratedWindow>
 
 // Qt
 #include <QPainter>
@@ -34,7 +34,7 @@ class KeepBelowButton
 {
 
 public:
-    static void init(Button *button, KDecoration2::DecoratedClient *decoratedClient) {
+    static void init(Button *button, KDecoration3::DecoratedWindow *decoratedClient) {
         Q_UNUSED(decoratedClient)
 
         button->setVisible(true);

--- a/src/Material.h
+++ b/src/Material.h
@@ -19,10 +19,12 @@
 
 // Qt
 #include <QLoggingCategory>
+#include <QWidget>
 
 
 namespace Material
 {
+      
     static const QLoggingCategory category("kdecoration.material");
     static const QString s_configFilename = QStringLiteral("kdecoration_materialrc");
 

--- a/src/MaximizeButton.h
+++ b/src/MaximizeButton.h
@@ -21,7 +21,7 @@
 #include "Button.h"
 
 // KDecoration
-#include <KDecoration2/DecoratedClient>
+#include <KDecoration3/DecoratedWindow>
 
 // Qt
 #include <QPainter>
@@ -33,8 +33,8 @@ class MaximizeButton
 {
 
 public:
-    static void init(Button *button, KDecoration2::DecoratedClient *decoratedClient) {
-        QObject::connect(decoratedClient, &KDecoration2::DecoratedClient::maximizeableChanged,
+    static void init(Button *button, KDecoration3::DecoratedWindow *decoratedClient) {
+        QObject::connect(decoratedClient, &KDecoration3::DecoratedWindow::maximizeableChanged,
                 button, &Button::setVisible);
 
         button->setVisible(decoratedClient->isMaximizeable());

--- a/src/MenuOverflowButton.cc
+++ b/src/MenuOverflowButton.cc
@@ -24,7 +24,7 @@
 #include "ApplicationMenuButton.h"
 
 // KDecoration
-#include <KDecoration2/DecoratedClient>
+#include <KDecoration3/DecoratedWindow>
 
 // Qt
 #include <QDebug>
@@ -37,7 +37,7 @@ namespace Material
 MenuOverflowButton::MenuOverflowButton(Decoration *decoration, const int buttonIndex, QObject *parent)
     : AppMenuButton(decoration, buttonIndex, parent)
 {
-    auto *decoratedClient = decoration->client();
+    auto *decoratedClient = decoration->window();
 
     setVisible(decoratedClient->hasApplicationMenu());
 }

--- a/src/MinimizeButton.h
+++ b/src/MinimizeButton.h
@@ -21,7 +21,7 @@
 #include "Button.h"
 
 // KDecoration
-#include <KDecoration2/DecoratedClient>
+#include <KDecoration3/DecoratedWindow>
 
 // Qt
 #include <QPainter>
@@ -33,8 +33,8 @@ class MinimizeButton
 {
 
 public:
-    static void init(Button *button, KDecoration2::DecoratedClient *decoratedClient) {
-        QObject::connect(decoratedClient, &KDecoration2::DecoratedClient::minimizeableChanged,
+    static void init(Button *button, KDecoration3::DecoratedWindow *decoratedClient) {
+        QObject::connect(decoratedClient, &KDecoration3::DecoratedWindow::minimizeableChanged,
                 button, &Button::setVisible);
 
         button->setVisible(decoratedClient->isMinimizeable());

--- a/src/OnAllDesktopsButton.h
+++ b/src/OnAllDesktopsButton.h
@@ -22,7 +22,7 @@
 #include "Material.h"
 
 // KDecoration
-#include <KDecoration2/DecoratedClient>
+#include <KDecoration3/DecoratedWindow>
 
 // Qt
 #include <QPainter>
@@ -34,7 +34,7 @@ class OnAllDesktopsButton
 {
 
 public:
-    static void init(Button *button, KDecoration2::DecoratedClient *decoratedClient) {
+    static void init(Button *button, KDecoration3::DecoratedWindow *decoratedClient) {
         Q_UNUSED(decoratedClient)
 
         button->setVisible(true);

--- a/src/ShadeButton.h
+++ b/src/ShadeButton.h
@@ -22,7 +22,7 @@
 #include "Material.h"
 
 // KDecoration
-#include <KDecoration2/DecoratedClient>
+#include <KDecoration3/DecoratedWindow>
 
 // Qt
 #include <QPainter>
@@ -34,8 +34,8 @@ class ShadeButton
 {
 
 public:
-    static void init(Button *button, KDecoration2::DecoratedClient *decoratedClient) {
-        QObject::connect(decoratedClient, &KDecoration2::DecoratedClient::shadeableChanged,
+    static void init(Button *button, KDecoration3::DecoratedWindow *decoratedClient) {
+        QObject::connect(decoratedClient, &KDecoration3::DecoratedWindow::shadeableChanged,
                 button, &Button::setVisible);
 
         button->setVisible(decoratedClient->isShadeable());

--- a/src/TextButton.cc
+++ b/src/TextButton.cc
@@ -24,8 +24,8 @@
 #include "Decoration.h"
 
 // KDecoration
-#include <KDecoration2/DecoratedClient>
-#include <KDecoration2/DecorationSettings>
+#include <KDecoration3/DecoratedWindow>
+#include <KDecoration3/DecorationSettings>
 
 // Qt
 #include <QDebug>

--- a/src/material.json
+++ b/src/material.json
@@ -5,10 +5,10 @@
         "Id": "com.github.zren.material",
         "Name": "Material",
         "ServiceTypes": [
-            "org.kde.kdecoration2"
+            "org.kde.kdecoration3"
         ]
     },
-    "org.kde.kdecoration2": {
+    "org.kde.kdecoration3": {
         "blur": true,
         "kcmodule": true,
         "recommendedBorderSize": "None"


### PR DESCRIPTION
Plasma 6.3 has broken compatibility with the LIM. 

LIM relied on the windowId() method of KDecoration2::decoratedClient, which is now unavailable in KDecoration3::decoratedWindow. 

To replace it, we rely on the internal API of KWin::X11Window, in the hope that the KDE developers will stop making their Desktop Enviroment progressively incompatible with X11.
