### PR TITLE
Add customizable border colors for windows

### DIFF
--- a/src/Decoration.cc
+++ b/src/Decoration.cc
@@ -959,13 +959,25 @@ void Decoration::paintFrameBackground(QPainter *painter, const QRectF &repaintRe
 QColor Decoration::borderColor() const
 {
     const auto *decoratedClient = window();
-    const auto group = decoratedClient->isActive()
-        ? KDecoration3::ColorGroup::Active
-        : KDecoration3::ColorGroup::Inactive;
-    const qreal opacity = decoratedClient->isActive()
-        ? m_internalSettings->activeOpacity()
-        : m_internalSettings->inactiveOpacity();
-    QColor color = decoratedClient->color(group, KDecoration3::ColorRole::Frame);
+    const bool isActive = decoratedClient->isActive();
+    const qreal opacity = isActive ? m_internalSettings->activeOpacity()
+                                   : m_internalSettings->inactiveOpacity();
+
+    QColor color;
+    if (m_internalSettings->useCustomBorderColors()) {
+        color = isActive ? m_internalSettings->activeBorderColor()
+                         : m_internalSettings->inactiveBorderColor();
+        // If alpha is 0 (default placeholder), fall back to theme color
+        if (color.alpha() == 0) {
+            const auto group = isActive ? KDecoration3::ColorGroup::Active
+                                        : KDecoration3::ColorGroup::Inactive;
+            color = decoratedClient->color(group, KDecoration3::ColorRole::Frame);
+        }
+    } else {
+        const auto group = isActive ? KDecoration3::ColorGroup::Active
+                                    : KDecoration3::ColorGroup::Inactive;
+        color = decoratedClient->color(group, KDecoration3::ColorRole::Frame);
+    }
     color.setAlphaF(opacity);
     return color;
 }

--- a/src/InternalSettingsSchema.kcfg
+++ b/src/InternalSettingsSchema.kcfg
@@ -43,6 +43,18 @@
             <default>1.00</default>
         </entry>
 
+        <!-- custom border colors -->
+        <entry name="UseCustomBorderColors" type="Bool">
+            <default>false</default>
+        </entry>
+        <entry name="ActiveBorderColor" type="Color">
+            <!-- fall back to theme frame color when not used -->
+            <default>0, 0, 0, 0</default>
+        </entry>
+        <entry name="InactiveBorderColor" type="Color">
+            <default>0, 0, 0, 0</default>
+        </entry>
+
         <!-- menu -->
         <entry name="MenuAlwaysShow" type="Bool">
             <default>true</default>

--- a/src/kcm/config.ui
+++ b/src/kcm/config.ui
@@ -44,14 +44,50 @@
        <item row="1" column="1">
         <widget class="QComboBox" name="kcfg_ButtonSize"/>
        </item>
-       <item row="2" column="0">
+      <item row="2" column="0" colspan="2">
+       <widget class="QGroupBox" name="groupBox_BorderColors">
+        <property name="title">
+         <string>Border colors</string>
+        </property>
+        <layout class="QFormLayout" name="formLayout_border">
+         <item row="0" column="0" colspan="2">
+          <widget class="QCheckBox" name="kcfg_UseCustomBorderColors">
+           <property name="text">
+            <string>Use custom border colors</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_activeBorderColor">
+           <property name="text">
+            <string>Active border color:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="KColorButton" name="kcfg_ActiveBorderColor"/>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="label_inactiveBorderColor">
+           <property name="text">
+            <string>Inactive border color:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="KColorButton" name="kcfg_InactiveBorderColor"/>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="3" column="0">
         <widget class="QLabel" name="label_3">
          <property name="text">
           <string>Active window opacity:</string>
          </property>
         </widget>
        </item>
-       <item row="2" column="1">
+      <item row="3" column="1">
         <widget class="QSpinBox" name="kcfg_ActiveOpacity">
          <property name="suffix">
           <string>%</string>
@@ -64,14 +100,14 @@
          </property>
         </widget>
        </item>
-       <item row="3" column="0">
+      <item row="4" column="0">
         <widget class="QLabel" name="label_4">
          <property name="text">
           <string>Inactive window opacity:</string>
          </property>
         </widget>
        </item>
-       <item row="3" column="1">
+      <item row="4" column="1">
         <widget class="QSpinBox" name="kcfg_InactiveOpacity">
          <property name="suffix">
           <string>%</string>
@@ -84,14 +120,14 @@
          </property>
         </widget>
        </item>
-       <item row="4" column="0">
+      <item row="5" column="0">
         <widget class="QLabel" name="label_10">
          <property name="text">
           <string>Corner radius:</string>
          </property>
         </widget>
        </item>
-       <item row="4" column="1">
+      <item row="5" column="1">
         <widget class="QSpinBox" name="kcfg_CornerRadius">
          <property name="suffix">
           <string>px</string>

--- a/src/kcm/kcm.cpp
+++ b/src/kcm/kcm.cpp
@@ -79,6 +79,21 @@ void MaterialDecorationKCM::setupConnections()
     connect(m_ui->kcfg_ShadowStrength, &QSlider::valueChanged, this, &MaterialDecorationKCM::updateChanged);
     connect(m_ui->kcfg_AnimationsEnabled, &QCheckBox::toggled, this, &MaterialDecorationKCM::updateChanged);
     connect(m_ui->kcfg_AnimationsDuration, &QSpinBox::valueChanged, this, &MaterialDecorationKCM::updateChanged);
+    connect(m_ui->kcfg_ActiveBorderColor, &KColorButton::changed, this, &MaterialDecorationKCM::updateChanged);
+    connect(m_ui->kcfg_InactiveBorderColor, &KColorButton::changed, this, &MaterialDecorationKCM::updateChanged);
+
+    // Enable/disable border color pickers based on the checkbox
+    auto updateBorderPickersEnabled = [this]() {
+        const bool enabled = m_ui->kcfg_UseCustomBorderColors->isChecked();
+        m_ui->kcfg_ActiveBorderColor->setEnabled(enabled);
+        m_ui->kcfg_InactiveBorderColor->setEnabled(enabled);
+    };
+    connect(m_ui->kcfg_UseCustomBorderColors, &QCheckBox::toggled, this, [this, updateBorderPickersEnabled](bool){
+        updateBorderPickersEnabled();
+        updateChanged();
+    });
+    // Initialize enablement once UI is ready
+    QMetaObject::invokeMethod(this, [updateBorderPickersEnabled](){ updateBorderPickersEnabled(); }, Qt::QueuedConnection);
 }
 
 void MaterialDecorationKCM::load()
@@ -100,6 +115,11 @@ void MaterialDecorationKCM::load()
     m_ui->kcfg_ShadowStrength->setValue(m_settings->shadowStrength());
     m_ui->kcfg_AnimationsEnabled->setChecked(m_settings->animationsEnabled());
     m_ui->kcfg_AnimationsDuration->setValue(m_settings->animationsDuration());
+
+    // Custom border colors
+    m_ui->kcfg_UseCustomBorderColors->setChecked(m_settings->useCustomBorderColors());
+    m_ui->kcfg_ActiveBorderColor->setColor(m_settings->activeBorderColor());
+    m_ui->kcfg_InactiveBorderColor->setColor(m_settings->inactiveBorderColor());
 }
 
 void MaterialDecorationKCM::save()
@@ -120,6 +140,11 @@ void MaterialDecorationKCM::save()
     m_settings->setShadowStrength(m_ui->kcfg_ShadowStrength->value());
     m_settings->setAnimationsEnabled(m_ui->kcfg_AnimationsEnabled->isChecked());
     m_settings->setAnimationsDuration(m_ui->kcfg_AnimationsDuration->value());
+
+    // Custom border colors
+    m_settings->setUseCustomBorderColors(m_ui->kcfg_UseCustomBorderColors->isChecked());
+    m_settings->setActiveBorderColor(m_ui->kcfg_ActiveBorderColor->color());
+    m_settings->setInactiveBorderColor(m_ui->kcfg_InactiveBorderColor->color());
 
     m_settings->save();
     QDBusConnection::sessionBus().call(QDBusMessage::createMethodCall(QStringLiteral("org.kde.KWin"),
@@ -147,6 +172,9 @@ void MaterialDecorationKCM::defaults()
     m_ui->kcfg_ShadowStrength->setValue(m_settings->shadowStrength());
     m_ui->kcfg_AnimationsEnabled->setChecked(m_settings->animationsEnabled());
     m_ui->kcfg_AnimationsDuration->setValue(m_settings->animationsDuration());
+    m_ui->kcfg_UseCustomBorderColors->setChecked(m_settings->useCustomBorderColors());
+    m_ui->kcfg_ActiveBorderColor->setColor(m_settings->activeBorderColor());
+    m_ui->kcfg_InactiveBorderColor->setColor(m_settings->inactiveBorderColor());
     markAsChanged();
 }
 


### PR DESCRIPTION
Add configurable active and inactive border colors to allow users to customize window appearance.

---
<a href="https://cursor.com/background-agent?bcId=bc-f2fd63dd-391a-4a72-acdb-dfea62c51615"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f2fd63dd-391a-4a72-acdb-dfea62c51615"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

