### PR TITLE
Add customizable border colors for windows

### DIFF
--- a/src/Decoration.cc
+++ b/src/Decoration.cc
@@ -959,15 +959,23 @@ void Decoration::paintFrameBackground(QPainter *painter, const QRectF &repaintRe
 QColor Decoration::borderColor() const
 {
     const auto *decoratedClient = window();
-    const auto group = decoratedClient->isActive()
-        ? KDecoration3::ColorGroup::Active
-        : KDecoration3::ColorGroup::Inactive;
     const qreal opacity = decoratedClient->isActive()
         ? m_internalSettings->activeOpacity()
         : m_internalSettings->inactiveOpacity();
-    QColor color = decoratedClient->color(group, KDecoration3::ColorRole::Frame);
-    color.setAlphaF(opacity);
-    return color;
+    if (m_internalSettings->useCustomBorderColors()) {
+        QColor color = decoratedClient->isActive()
+            ? m_internalSettings->activeBorderColor()
+            : m_internalSettings->inactiveBorderColor();
+        color.setAlphaF(opacity);
+        return color;
+    }
+
+    const auto group = decoratedClient->isActive()
+        ? KDecoration3::ColorGroup::Active
+        : KDecoration3::ColorGroup::Inactive;
+    QColor fallback = decoratedClient->color(group, KDecoration3::ColorRole::Frame);
+    fallback.setAlphaF(opacity);
+    return fallback;
 }
 
 QColor Decoration::titleBarBackgroundColor() const

--- a/src/InternalSettingsSchema.kcfg
+++ b/src/InternalSettingsSchema.kcfg
@@ -91,6 +91,17 @@
             <min>25</min>
             <max>255</max>
         </entry>
+
+        <!-- border colors -->
+        <entry name="UseCustomBorderColors" type="Bool">
+            <default>false</default>
+        </entry>
+        <entry name="ActiveBorderColor" type="Color">
+            <default>0, 0, 0</default>
+        </entry>
+        <entry name="InactiveBorderColor" type="Color">
+            <default>0, 0, 0</default>
+        </entry>
     </group>
 
 </kcfg>

--- a/src/kcm/config.ui
+++ b/src/kcm/config.ui
@@ -104,6 +104,33 @@
          </property>
         </widget>
        </item>
+       <item row="5" column="0" colspan="2">
+        <widget class="QCheckBox" name="kcfg_UseCustomBorderColors">
+         <property name="text">
+          <string>Use custom border colors</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0">
+        <widget class="QLabel" name="label_active_border_color">
+         <property name="text">
+          <string>Active border color:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="1">
+        <widget class="KColorButton" name="kcfg_ActiveBorderColor"/>
+       </item>
+       <item row="7" column="0">
+        <widget class="QLabel" name="label_inactive_border_color">
+         <property name="text">
+          <string>Inactive border color:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="1">
+        <widget class="KColorButton" name="kcfg_InactiveBorderColor"/>
+       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="menuSearchTab">

--- a/src/kcm/kcm.cpp
+++ b/src/kcm/kcm.cpp
@@ -79,6 +79,15 @@ void MaterialDecorationKCM::setupConnections()
     connect(m_ui->kcfg_ShadowStrength, &QSlider::valueChanged, this, &MaterialDecorationKCM::updateChanged);
     connect(m_ui->kcfg_AnimationsEnabled, &QCheckBox::toggled, this, &MaterialDecorationKCM::updateChanged);
     connect(m_ui->kcfg_AnimationsDuration, &QSpinBox::valueChanged, this, &MaterialDecorationKCM::updateChanged);
+    connect(m_ui->kcfg_UseCustomBorderColors, &QCheckBox::toggled, this, &MaterialDecorationKCM::updateChanged);
+    connect(m_ui->kcfg_ActiveBorderColor, &KColorButton::changed, this, &MaterialDecorationKCM::updateChanged);
+    connect(m_ui->kcfg_InactiveBorderColor, &KColorButton::changed, this, &MaterialDecorationKCM::updateChanged);
+
+    // Enable/disable color pickers based on checkbox
+    connect(m_ui->kcfg_UseCustomBorderColors, &QCheckBox::toggled, m_ui->kcfg_ActiveBorderColor, &QWidget::setEnabled);
+    connect(m_ui->kcfg_UseCustomBorderColors, &QCheckBox::toggled, m_ui->kcfg_InactiveBorderColor, &QWidget::setEnabled);
+    connect(m_ui->kcfg_UseCustomBorderColors, &QCheckBox::toggled, m_ui->label_active_border_color, &QWidget::setEnabled);
+    connect(m_ui->kcfg_UseCustomBorderColors, &QCheckBox::toggled, m_ui->label_inactive_border_color, &QWidget::setEnabled);
 }
 
 void MaterialDecorationKCM::load()
@@ -100,6 +109,15 @@ void MaterialDecorationKCM::load()
     m_ui->kcfg_ShadowStrength->setValue(m_settings->shadowStrength());
     m_ui->kcfg_AnimationsEnabled->setChecked(m_settings->animationsEnabled());
     m_ui->kcfg_AnimationsDuration->setValue(m_settings->animationsDuration());
+    m_ui->kcfg_UseCustomBorderColors->setChecked(m_settings->useCustomBorderColors());
+    m_ui->kcfg_ActiveBorderColor->setColor(m_settings->activeBorderColor());
+    m_ui->kcfg_InactiveBorderColor->setColor(m_settings->inactiveBorderColor());
+
+    const bool useCustom = m_settings->useCustomBorderColors();
+    m_ui->kcfg_ActiveBorderColor->setEnabled(useCustom);
+    m_ui->kcfg_InactiveBorderColor->setEnabled(useCustom);
+    m_ui->label_active_border_color->setEnabled(useCustom);
+    m_ui->label_inactive_border_color->setEnabled(useCustom);
 }
 
 void MaterialDecorationKCM::save()
@@ -120,6 +138,9 @@ void MaterialDecorationKCM::save()
     m_settings->setShadowStrength(m_ui->kcfg_ShadowStrength->value());
     m_settings->setAnimationsEnabled(m_ui->kcfg_AnimationsEnabled->isChecked());
     m_settings->setAnimationsDuration(m_ui->kcfg_AnimationsDuration->value());
+    m_settings->setUseCustomBorderColors(m_ui->kcfg_UseCustomBorderColors->isChecked());
+    m_settings->setActiveBorderColor(m_ui->kcfg_ActiveBorderColor->color());
+    m_settings->setInactiveBorderColor(m_ui->kcfg_InactiveBorderColor->color());
 
     m_settings->save();
     QDBusConnection::sessionBus().call(QDBusMessage::createMethodCall(QStringLiteral("org.kde.KWin"),
@@ -147,6 +168,14 @@ void MaterialDecorationKCM::defaults()
     m_ui->kcfg_ShadowStrength->setValue(m_settings->shadowStrength());
     m_ui->kcfg_AnimationsEnabled->setChecked(m_settings->animationsEnabled());
     m_ui->kcfg_AnimationsDuration->setValue(m_settings->animationsDuration());
+    m_ui->kcfg_UseCustomBorderColors->setChecked(m_settings->useCustomBorderColors());
+    m_ui->kcfg_ActiveBorderColor->setColor(m_settings->activeBorderColor());
+    m_ui->kcfg_InactiveBorderColor->setColor(m_settings->inactiveBorderColor());
+    const bool useCustom = m_settings->useCustomBorderColors();
+    m_ui->kcfg_ActiveBorderColor->setEnabled(useCustom);
+    m_ui->kcfg_InactiveBorderColor->setEnabled(useCustom);
+    m_ui->label_active_border_color->setEnabled(useCustom);
+    m_ui->label_inactive_border_color->setEnabled(useCustom);
     markAsChanged();
 }
 


### PR DESCRIPTION
Add user-configurable border colors for active and inactive windows.

---
<a href="https://cursor.com/background-agent?bcId=bc-f2d45e94-b784-42f9-98bd-ccb31118ef07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f2d45e94-b784-42f9-98bd-ccb31118ef07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

