### PR TITLE
Add customizable border colors for windows

### DIFF
--- a/src/Decoration.cc
+++ b/src/Decoration.cc
@@ -959,13 +959,24 @@ void Decoration::paintFrameBackground(QPainter *painter, const QRectF &repaintRe
 QColor Decoration::borderColor() const
 {
     const auto *decoratedClient = window();
-    const auto group = decoratedClient->isActive()
-        ? KDecoration3::ColorGroup::Active
-        : KDecoration3::ColorGroup::Inactive;
     const qreal opacity = decoratedClient->isActive()
         ? m_internalSettings->activeOpacity()
         : m_internalSettings->inactiveOpacity();
-    QColor color = decoratedClient->color(group, KDecoration3::ColorRole::Frame);
+    
+    QColor color;
+    if (m_internalSettings->useCustomBorderColors()) {
+        // Use custom border colors
+        color = decoratedClient->isActive()
+            ? m_internalSettings->activeBorderColor()
+            : m_internalSettings->inactiveBorderColor();
+    } else {
+        // Use system colors (original behavior)
+        const auto group = decoratedClient->isActive()
+            ? KDecoration3::ColorGroup::Active
+            : KDecoration3::ColorGroup::Inactive;
+        color = decoratedClient->color(group, KDecoration3::ColorRole::Frame);
+    }
+    
     color.setAlphaF(opacity);
     return color;
 }

--- a/src/InternalSettingsSchema.kcfg
+++ b/src/InternalSettingsSchema.kcfg
@@ -72,6 +72,17 @@
             <default>250</default>
         </entry>
 
+        <!-- border colors -->
+        <entry name="ActiveBorderColor" type="Color">
+            <default>0, 0, 0</default>
+        </entry>
+        <entry name="InactiveBorderColor" type="Color">
+            <default>128, 128, 128</default>
+        </entry>
+        <entry name="UseCustomBorderColors" type="Bool">
+            <default>false</default>
+        </entry>
+
         <!-- shadow -->
         <entry name="ShadowSize" type="Enum">
             <choices>

--- a/src/kcm/config.ui
+++ b/src/kcm/config.ui
@@ -104,6 +104,33 @@
          </property>
         </widget>
        </item>
+       <item row="5" column="0" colspan="2">
+        <widget class="QCheckBox" name="kcfg_UseCustomBorderColors">
+         <property name="text">
+          <string>Use custom border colors</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0">
+        <widget class="QLabel" name="label_11">
+         <property name="text">
+          <string>Active window border color:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="1">
+        <widget class="KColorButton" name="kcfg_ActiveBorderColor"/>
+       </item>
+       <item row="7" column="0">
+        <widget class="QLabel" name="label_12">
+         <property name="text">
+          <string>Inactive window border color:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="1">
+        <widget class="KColorButton" name="kcfg_InactiveBorderColor"/>
+       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="menuSearchTab">

--- a/src/kcm/kcm.cpp
+++ b/src/kcm/kcm.cpp
@@ -51,6 +51,10 @@ MaterialDecorationKCM::MaterialDecorationKCM(QObject *parent, const KPluginMetaD
     connect(m_ui->kcfg_ShadowStrength, &QSlider::valueChanged, m_ui->spinShadowStrength, &QSpinBox::setValue);
     connect(m_ui->spinShadowStrength, qOverload<int>(&QSpinBox::valueChanged), m_ui->kcfg_ShadowStrength, &QSlider::setValue);
 
+    // Enable/disable border color controls based on checkbox
+    connect(m_ui->kcfg_UseCustomBorderColors, &QCheckBox::toggled, m_ui->kcfg_ActiveBorderColor, &KColorButton::setEnabled);
+    connect(m_ui->kcfg_UseCustomBorderColors, &QCheckBox::toggled, m_ui->kcfg_InactiveBorderColor, &KColorButton::setEnabled);
+
     setupConnections();
 }
 
@@ -79,6 +83,9 @@ void MaterialDecorationKCM::setupConnections()
     connect(m_ui->kcfg_ShadowStrength, &QSlider::valueChanged, this, &MaterialDecorationKCM::updateChanged);
     connect(m_ui->kcfg_AnimationsEnabled, &QCheckBox::toggled, this, &MaterialDecorationKCM::updateChanged);
     connect(m_ui->kcfg_AnimationsDuration, &QSpinBox::valueChanged, this, &MaterialDecorationKCM::updateChanged);
+    connect(m_ui->kcfg_UseCustomBorderColors, &QCheckBox::toggled, this, &MaterialDecorationKCM::updateChanged);
+    connect(m_ui->kcfg_ActiveBorderColor, &KColorButton::changed, this, &MaterialDecorationKCM::updateChanged);
+    connect(m_ui->kcfg_InactiveBorderColor, &KColorButton::changed, this, &MaterialDecorationKCM::updateChanged);
 }
 
 void MaterialDecorationKCM::load()
@@ -100,6 +107,13 @@ void MaterialDecorationKCM::load()
     m_ui->kcfg_ShadowStrength->setValue(m_settings->shadowStrength());
     m_ui->kcfg_AnimationsEnabled->setChecked(m_settings->animationsEnabled());
     m_ui->kcfg_AnimationsDuration->setValue(m_settings->animationsDuration());
+    m_ui->kcfg_UseCustomBorderColors->setChecked(m_settings->useCustomBorderColors());
+    m_ui->kcfg_ActiveBorderColor->setColor(m_settings->activeBorderColor());
+    m_ui->kcfg_InactiveBorderColor->setColor(m_settings->inactiveBorderColor());
+    
+    // Enable/disable border color controls based on checkbox state
+    m_ui->kcfg_ActiveBorderColor->setEnabled(m_settings->useCustomBorderColors());
+    m_ui->kcfg_InactiveBorderColor->setEnabled(m_settings->useCustomBorderColors());
 }
 
 void MaterialDecorationKCM::save()
@@ -120,6 +134,9 @@ void MaterialDecorationKCM::save()
     m_settings->setShadowStrength(m_ui->kcfg_ShadowStrength->value());
     m_settings->setAnimationsEnabled(m_ui->kcfg_AnimationsEnabled->isChecked());
     m_settings->setAnimationsDuration(m_ui->kcfg_AnimationsDuration->value());
+    m_settings->setUseCustomBorderColors(m_ui->kcfg_UseCustomBorderColors->isChecked());
+    m_settings->setActiveBorderColor(m_ui->kcfg_ActiveBorderColor->color());
+    m_settings->setInactiveBorderColor(m_ui->kcfg_InactiveBorderColor->color());
 
     m_settings->save();
     QDBusConnection::sessionBus().call(QDBusMessage::createMethodCall(QStringLiteral("org.kde.KWin"),
@@ -147,6 +164,13 @@ void MaterialDecorationKCM::defaults()
     m_ui->kcfg_ShadowStrength->setValue(m_settings->shadowStrength());
     m_ui->kcfg_AnimationsEnabled->setChecked(m_settings->animationsEnabled());
     m_ui->kcfg_AnimationsDuration->setValue(m_settings->animationsDuration());
+    m_ui->kcfg_UseCustomBorderColors->setChecked(m_settings->useCustomBorderColors());
+    m_ui->kcfg_ActiveBorderColor->setColor(m_settings->activeBorderColor());
+    m_ui->kcfg_InactiveBorderColor->setColor(m_settings->inactiveBorderColor());
+    
+    // Enable/disable border color controls based on checkbox state
+    m_ui->kcfg_ActiveBorderColor->setEnabled(m_settings->useCustomBorderColors());
+    m_ui->kcfg_InactiveBorderColor->setEnabled(m_settings->useCustomBorderColors());
     markAsChanged();
 }
 


### PR DESCRIPTION
Add options to customize active and inactive window border colors.

---
<a href="https://cursor.com/background-agent?bcId=bc-f4f95d6d-be57-4a36-90d8-31355479ae37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f4f95d6d-be57-4a36-90d8-31355479ae37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

