### PR TITLE
optimization in AppMenuButtonGroup

### DIFF
--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -205,7 +205,7 @@ void AppMenuButtonGroup::repositionSearchMenu()
     }
 
     auto *deco = qobject_cast<Decoration *>(decoration());
-    KDecoration3::DecorationButton *button = buttons().value(m_searchIndex);
+    KDecoration3::DecorationButton *button = m_searchButton;
     if (!deco || !button) {
         return;
     }
@@ -317,10 +317,14 @@ void AppMenuButtonGroup::setOpacity(qreal value)
     if (m_opacity != value) {
         m_opacity = value;
 
-        for (auto *decoButton : buttons()) {
-            if (auto *button = qobject_cast<Button *>(decoButton)) {
-                button->setOpacity(m_opacity);
-            }
+        for (auto *tb : m_textButtons) {
+            tb->setOpacity(m_opacity);
+        }
+        if (m_overflowButton) {
+            m_overflowButton->setOpacity(m_opacity);
+        }
+        if (m_searchButton) {
+            m_searchButton->setOpacity(m_opacity);
         }
 
         Q_EMIT opacityChanged(value);
@@ -329,30 +333,43 @@ void AppMenuButtonGroup::setOpacity(qreal value)
 
 KDecoration3::DecorationButton* AppMenuButtonGroup::buttonAt(QPoint pos) const
 {
-    for (auto *button : buttons()) {
-        if (button->isVisible() && button->geometry().contains(pos)) {
-            return button;
+    for (auto *tb : m_textButtons) {
+        if (tb->isVisible() && tb->geometry().contains(pos)) {
+            return tb;
         }
+    }
+    if (m_overflowButton && m_overflowButton->isVisible() && m_overflowButton->geometry().contains(pos)) {
+        return m_overflowButton;
+    }
+    if (m_searchButton && m_searchButton->isVisible() && m_searchButton->geometry().contains(pos)) {
+        return m_searchButton;
     }
     return nullptr;
 }
 
 void AppMenuButtonGroup::resetButtons()
 {
-    if (buttons().isEmpty()) {
+    if (m_textButtons.isEmpty() && m_overflowButton.isNull() && m_searchButton.isNull()) {
         return;
     }
     setCurrentIndex(-1);
     m_currentMenu = nullptr;
     m_lastResults.clear();
     m_lastSearchQuery.clear();
+    
+    // Create a copy of the button pointers before clearing caches and removing from group.
+    QList<KDecoration3::DecorationButton *> allButtons;
+    for (auto *b : m_textButtons) allButtons.append(b);
+    if (m_overflowButton) allButtons.append(m_overflowButton);
+    if (m_searchButton) allButtons.append(m_searchButton);
+
+    m_textButtons.clear();
+    m_overflowButton = nullptr;
+    m_searchButton = nullptr;
 
     if (m_overflowMenu) {
         m_overflowMenu->deleteLater();
     }
-    
-    // Create a copy of the button pointers before removing them from the group.
-    const auto allButtons = buttons();
 
     // This removes all buttons with the "Custom" type from the group's list,
     // but does not delete the button widgets themselves.
@@ -490,34 +507,21 @@ void AppMenuButtonGroup::updateAppMenuModel()
         QPointer<QMenu> previousMenu = m_currentMenu;
 
         // Try in-place update if possible to reduce flicker and object churn
-        int existingTextButtonCount = 0;
-        bool hasSearchButton = false;
-        for (auto *b : buttons()) {
-            if (qobject_cast<TextButton *>(b)) {
-                existingTextButtonCount++;
-            } else if (qobject_cast<SearchButton *>(b)) {
-                hasSearchButton = true;
-            }
-        }
+        const bool searchStateMatches = (m_searchButton.isNull() == !deco->searchEnabled());
 
-        const bool searchStateMatches = (hasSearchButton == deco->searchEnabled());
-
-        if (existingTextButtonCount == menuActionCount && existingTextButtonCount > 0 && searchStateMatches) {
-            const auto buttonList = buttons();
+        if (m_textButtons.count() == menuActionCount && !m_textButtons.isEmpty() && searchStateMatches) {
             int actionIdx = 0;
-            for (auto *b : buttonList) {
-                if (auto *textButton = qobject_cast<TextButton *>(b)) {
-                    QAction *itemAction = actions.at(actionIdx++);
-                    textButton->setAction(itemAction);
-                    textButton->setText(itemAction->text().trimmed());
-                    // Skip items with empty labels (The first item in a Gtk app)
-                    if (itemAction->text().isEmpty()) {
-                        textButton->setEnabled(false);
-                        textButton->setVisible(false);
-                    } else {
-                        textButton->setEnabled(itemAction->isEnabled());
-                        textButton->setVisible(true);
-                    }
+            for (auto *textButton : m_textButtons) {
+                QAction *itemAction = actions.at(actionIdx++);
+                textButton->setAction(itemAction);
+                textButton->setText(itemAction->text().trimmed());
+                // Skip items with empty labels (The first item in a Gtk app)
+                if (itemAction->text().isEmpty()) {
+                    textButton->setEnabled(false);
+                    textButton->setVisible(false);
+                } else {
+                    textButton->setEnabled(itemAction->isEnabled());
+                    textButton->setVisible(true);
                 }
             }
 
@@ -545,16 +549,19 @@ void AppMenuButtonGroup::updateAppMenuModel()
                     b->setEnabled(itemAction->isEnabled());
                 }
 
+                m_textButtons.append(b);
                 addButton(QPointer<KDecoration3::DecorationButton>(b));
             }
 
             if (menuActionCount > 0) {
                 m_overflowIndex = menuActionCount;
-                addButton(new MenuOverflowButton(deco, m_overflowIndex, this));
+                m_overflowButton = new MenuOverflowButton(deco, m_overflowIndex, this);
+                addButton(QPointer<KDecoration3::DecorationButton>(m_overflowButton));
 
                 if (deco->searchEnabled()) {
                     m_searchIndex = menuActionCount + 1;
-                    addButton(new SearchButton(deco, m_searchIndex, this));
+                    m_searchButton = new SearchButton(deco, m_searchIndex, this);
+                    addButton(QPointer<KDecoration3::DecorationButton>(m_searchButton));
                 }
             }
         }
@@ -570,7 +577,17 @@ void AppMenuButtonGroup::updateAppMenuModel()
         if (indexToRestore != -1) {
             setCurrentIndex(indexToRestore);
             m_currentMenu = previousMenu;
-            if (auto *b = buttons().value(m_currentIndex)) {
+            
+            AppMenuButton *b = nullptr;
+            if (m_currentIndex == m_searchIndex) {
+                b = m_searchButton;
+            } else if (m_currentIndex == m_overflowIndex) {
+                b = m_overflowButton;
+            } else if (m_currentIndex >= 0 && m_currentIndex < m_textButtons.count()) {
+                b = m_textButtons.at(m_currentIndex);
+            }
+
+            if (b) {
                 b->setChecked(true);
             }
         }
@@ -597,29 +614,15 @@ void AppMenuButtonGroup::updateOverflow(QRectF availableRect)
 {
     const qreal availableWidth = availableRect.width();
 
-    KDecoration3::DecorationButton *overflowButton = nullptr;
-    KDecoration3::DecorationButton *searchButton = nullptr;
-    QList<TextButton *> textButtons;
-
-    for (KDecoration3::DecorationButton *button : buttons()) {
-        if (auto *tb = qobject_cast<TextButton *>(button)) {
-            textButtons.append(tb);
-        } else if (qobject_cast<MenuOverflowButton *>(button)) {
-            overflowButton = button;
-        } else if (qobject_cast<SearchButton *>(button)) {
-            searchButton = button;
-        }
-    }
-
     qreal fixedWidth = 0;
-    if (searchButton && searchButton->isVisible()) {
-        fixedWidth += searchButton->geometry().width();
+    if (m_searchButton && m_searchButton->isVisible()) {
+        fixedWidth += m_searchButton->geometry().width();
     }
 
     bool showOverflow = m_hamburgerMenu;
 
     if (m_hamburgerMenu) {
-        for (TextButton *tb : textButtons) {
+        for (TextButton *tb : m_textButtons) {
             tb->setVisible(false);
         }
         showOverflow = true;
@@ -627,7 +630,7 @@ void AppMenuButtonGroup::updateOverflow(QRectF availableRect)
         // First pass: check if all enabled text buttons fit without overflow button
         qreal totalTextWidth = 0;
         int enabledCount = 0;
-        for (TextButton *tb : textButtons) {
+        for (TextButton *tb : m_textButtons) {
             if (tb->isEnabled()) {
                 totalTextWidth += tb->geometry().width();
                 enabledCount++;
@@ -638,18 +641,18 @@ void AppMenuButtonGroup::updateOverflow(QRectF availableRect)
 
         if (enabledCount > 0 && fixedWidth + totalTextWidth <= availableWidth) {
             showOverflow = false;
-            for (TextButton *tb : textButtons) {
+            for (TextButton *tb : m_textButtons) {
                 if (tb->isEnabled()) {
                     tb->setVisible(true);
                 }
             }
         } else if (enabledCount > 0) {
             showOverflow = true;
-            const qreal overflowBtnWidth = overflowButton ? overflowButton->geometry().width() : 0;
+            const qreal overflowBtnWidth = m_overflowButton ? m_overflowButton->geometry().width() : 0;
             qreal remainingWidth = availableWidth - fixedWidth - overflowBtnWidth;
 
             bool fits = true;
-            for (TextButton *tb : textButtons) {
+            for (TextButton *tb : m_textButtons) {
                 if (!tb->isEnabled()) {
                     continue;
                 }
@@ -668,17 +671,23 @@ void AppMenuButtonGroup::updateOverflow(QRectF availableRect)
         }
     }
 
-    if (overflowButton) {
-        overflowButton->setVisible(showOverflow);
+    if (m_overflowButton) {
+        m_overflowButton->setVisible(showOverflow);
     }
     setOverflowing(showOverflow);
 
     // calculate visible width
     qreal currentVisibleWidth = 0;
-    for (KDecoration3::DecorationButton *button : buttons()) {
-        if (button->isVisible()) {
-            currentVisibleWidth += button->geometry().width();
+    for (auto *tb : m_textButtons) {
+        if (tb->isVisible()) {
+            currentVisibleWidth += tb->geometry().width();
         }
+    }
+    if (m_overflowButton && m_overflowButton->isVisible()) {
+        currentVisibleWidth += m_overflowButton->geometry().width();
+    }
+    if (m_searchButton && m_searchButton->isVisible()) {
+        currentVisibleWidth += m_searchButton->geometry().width();
     }
 
     if (m_visibleWidth != currentVisibleWidth) {
@@ -708,13 +717,29 @@ void AppMenuButtonGroup::popupMenu(QMenu *menu, int buttonIndex)
     m_appMenuModel->stopCaching();
 
     auto *deco = qobject_cast<Decoration *>(decoration());
-    KDecoration3::DecorationButton *button = buttons().value(buttonIndex);
+    
+    AppMenuButton *button = nullptr;
+    if (buttonIndex == m_searchIndex) {
+        button = m_searchButton;
+    } else if (buttonIndex == m_overflowIndex) {
+        button = m_overflowButton;
+    } else if (buttonIndex >= 0 && buttonIndex < m_textButtons.count()) {
+        button = m_textButtons.at(buttonIndex);
+    }
+
     if (!menu || !deco || !button) {
         return;
     }
 
     QPointer<QMenu> oldMenu = m_currentMenu;
-    KDecoration3::DecorationButton *oldButton = (0 <= m_currentIndex && m_currentIndex < buttons().length()) ? buttons().value(m_currentIndex) : nullptr;
+    AppMenuButton *oldButton = nullptr;
+    if (m_currentIndex == m_searchIndex) {
+        oldButton = m_searchButton;
+    } else if (m_currentIndex == m_overflowIndex) {
+        oldButton = m_overflowButton;
+    } else if (m_currentIndex >= 0 && m_currentIndex < m_textButtons.count()) {
+        oldButton = m_textButtons.at(m_currentIndex);
+    }
 
     // 1. Set the new internal state. This must happen before popup for positioning.
     setCurrentIndex(buttonIndex);
@@ -828,9 +853,8 @@ void AppMenuButtonGroup::handleOverflowTrigger()
     if (m_appMenuModel && m_appMenuModel->menu()) {
         int overflowStartsAt = 0;
         // Find the first non-visible button to determine where the overflow starts
-        for (KDecoration3::DecorationButton *b : buttons()) {
-            auto *textButton = qobject_cast<TextButton *>(b);
-            if (textButton && textButton->isEnabled() && !textButton->isVisible()) {
+        for (auto *textButton : m_textButtons) {
+            if (textButton->isEnabled() && !textButton->isVisible()) {
                 overflowStartsAt = textButton->buttonIndex();
                 break;
             }
@@ -849,7 +873,15 @@ void AppMenuButtonGroup::trigger(int buttonIndex)
 {
     // The button is checked in popupMenu, but we need to check it here
     // for the case where the menu is not yet loaded.
-    KDecoration3::DecorationButton *button = buttons().value(buttonIndex);
+    AppMenuButton *button = nullptr;
+    if (buttonIndex == m_searchIndex) {
+        button = m_searchButton;
+    } else if (buttonIndex == m_overflowIndex) {
+        button = m_overflowButton;
+    } else if (buttonIndex >= 0 && buttonIndex < m_textButtons.count()) {
+        button = m_textButtons.at(buttonIndex);
+    }
+
     if (!button) {
         return;
     }
@@ -928,10 +960,14 @@ bool AppMenuButtonGroup::isMenuOpen() const
 
 void AppMenuButtonGroup::unPressAllButtons()
 {
-    for (auto *decoButton : buttons()) {
-        if (auto *button = qobject_cast<Button *>(decoButton)) {
-            button->forceUnpress();
-        }
+    for (auto *tb : m_textButtons) {
+        tb->forceUnpress();
+    }
+    if (m_overflowButton) {
+        m_overflowButton->forceUnpress();
+    }
+    if (m_searchButton) {
+        m_searchButton->forceUnpress();
     }
 }
 
@@ -968,8 +1004,17 @@ void AppMenuButtonGroup::onMenuAboutToHide()
         m_lastSearchQuery.clear();
     }
 
-    if (0 <= m_currentIndex && m_currentIndex < buttons().length()) {
-        buttons().value(m_currentIndex)->setChecked(false);
+    AppMenuButton *currentButton = nullptr;
+    if (m_currentIndex == m_searchIndex) {
+        currentButton = m_searchButton;
+    } else if (m_currentIndex == m_overflowIndex) {
+        currentButton = m_overflowButton;
+    } else if (m_currentIndex >= 0 && m_currentIndex < m_textButtons.count()) {
+        currentButton = m_textButtons.at(m_currentIndex);
+    }
+
+    if (currentButton) {
+        currentButton->setChecked(false);
     }
     setCurrentIndex(-1);
     m_currentMenu = nullptr;
@@ -1195,8 +1240,16 @@ void AppMenuButtonGroup::searchMenu(QMenu *menu, const QString &text, QList<Sear
 
 int AppMenuButtonGroup::findNextVisibleButtonIndex(int currentIndex, bool forward) const
 {
-    const auto buttonList = buttons();
-    if (buttonList.isEmpty()) {
+    // The button list in this group is composed of: m_textButtons + m_overflowButton + m_searchButton.
+    // However, for navigation, we should still respect the underlying group order.
+    // Since we only ever have one group of buttons in this class, we can use our caches.
+    
+    QList<AppMenuButton *> allButtons;
+    for (auto *b : m_textButtons) allButtons.append(b);
+    if (m_overflowButton) allButtons.append(m_overflowButton);
+    if (m_searchButton) allButtons.append(m_searchButton);
+
+    if (allButtons.isEmpty()) {
         return -1;
     }
 
@@ -1207,15 +1260,15 @@ int AppMenuButtonGroup::findNextVisibleButtonIndex(int currentIndex, bool forwar
     // Start from the next button, not the current one
     int newIndex = currentIndex + step;
 
-    for (int i = 0; i < buttonList.length(); ++i) {
+    for (int i = 0; i < allButtons.length(); ++i) {
         // Wrap around logic
         if (newIndex < 0) {
-            newIndex = buttonList.length() - 1;
-        } else if (newIndex >= buttonList.length()) {
+            newIndex = allButtons.length() - 1;
+        } else if (newIndex >= allButtons.length()) {
             newIndex = 0;
         }
 
-        const auto *button = buttonList.value(newIndex);
+        const auto *button = allButtons.value(newIndex);
         if (button && button->isVisible() && button->isEnabled()) {
             return newIndex;
         }
@@ -1238,14 +1291,13 @@ void AppMenuButtonGroup::handleHoverMove(const QPointF &pos)
         m_hoveredButton = newHoveredButton;
 
         if (m_hoveredButton) {
-            auto *appMenuButton = qobject_cast<AppMenuButton *>(m_hoveredButton.data());
-            if (appMenuButton) {
-                if (m_currentIndex != appMenuButton->buttonIndex()
-                    && appMenuButton->isVisible()
-                    && appMenuButton->isEnabled()
-                ) {
-                    trigger(appMenuButton->buttonIndex());
-                }
+            // All buttons in this group are AppMenuButtons
+            auto *appMenuButton = static_cast<AppMenuButton *>(m_hoveredButton.data());
+            if (m_currentIndex != appMenuButton->buttonIndex()
+                && appMenuButton->isVisible()
+                && appMenuButton->isEnabled()
+            ) {
+                trigger(appMenuButton->buttonIndex());
             }
         }
     }

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -359,6 +359,8 @@ void AppMenuButtonGroup::resetButtons()
     m_textButtons.clear();
     m_overflowButton = nullptr;
     m_searchButton = nullptr;
+    m_overflowIndex = -1;
+    m_searchIndex = -1;
 
     if (m_overflowMenu) {
         m_overflowMenu->deleteLater();
@@ -1212,16 +1214,11 @@ AppMenuButton *AppMenuButtonGroup::getAppMenuButton(int index) const
 
 int AppMenuButtonGroup::findNextVisibleButtonIndex(int currentIndex, bool forward) const
 {
-    // The button list in this group is composed of: m_textButtons + m_overflowButton + m_searchButton.
-    // However, for navigation, we should still respect the underlying group order.
-    // Since we only ever have one group of buttons in this class, we can use our caches.
-    
-    QList<QPointer<AppMenuButton>> allButtons;
-    for (auto &b : m_textButtons) allButtons.append(b);
-    if (m_overflowButton) allButtons.append(m_overflowButton);
-    if (m_searchButton) allButtons.append(m_searchButton);
+    int maxIndex = m_textButtons.count() - 1;
+    if (m_overflowIndex > maxIndex) maxIndex = m_overflowIndex;
+    if (m_searchIndex > maxIndex) maxIndex = m_searchIndex;
 
-    if (allButtons.isEmpty()) {
+    if (maxIndex < 0) {
         return -1;
     }
 
@@ -1232,17 +1229,18 @@ int AppMenuButtonGroup::findNextVisibleButtonIndex(int currentIndex, bool forwar
     // Start from the next button, not the current one
     int newIndex = currentIndex + step;
 
-    for (int i = 0; i < allButtons.length(); ++i) {
+    for (int i = 0; i <= maxIndex; ++i) {
         // Wrap around logic
         if (newIndex < 0) {
-            newIndex = allButtons.length() - 1;
-        } else if (newIndex >= allButtons.length()) {
+            newIndex = maxIndex;
+        } else if (newIndex > maxIndex) {
             newIndex = 0;
         }
 
-        const auto &button = allButtons.value(newIndex);
-        if (button && button->isVisible() && button->isEnabled()) {
-            return newIndex;
+        if (AppMenuButton *button = getAppMenuButton(newIndex)) {
+            if (button->isVisible() && button->isEnabled()) {
+                return newIndex;
+            }
         }
 
         newIndex += step;

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -317,8 +317,8 @@ void AppMenuButtonGroup::setOpacity(qreal value)
     if (m_opacity != value) {
         m_opacity = value;
 
-        for (auto *tb : m_textButtons) {
-            tb->setOpacity(m_opacity);
+        for (auto &tb : m_textButtons) {
+            if (tb) tb->setOpacity(m_opacity);
         }
         if (m_overflowButton) {
             m_overflowButton->setOpacity(m_opacity);
@@ -333,8 +333,8 @@ void AppMenuButtonGroup::setOpacity(qreal value)
 
 KDecoration3::DecorationButton* AppMenuButtonGroup::buttonAt(QPoint pos) const
 {
-    for (auto *tb : m_textButtons) {
-        if (tb->isVisible() && tb->geometry().contains(pos)) {
+    for (auto &tb : m_textButtons) {
+        if (tb && tb->isVisible() && tb->geometry().contains(pos)) {
             return tb;
         }
     }
@@ -349,20 +349,13 @@ KDecoration3::DecorationButton* AppMenuButtonGroup::buttonAt(QPoint pos) const
 
 void AppMenuButtonGroup::resetButtons()
 {
-    if (m_textButtons.isEmpty() && m_overflowButton.isNull() && m_searchButton.isNull()) {
+    if (buttons().isEmpty()) {
         return;
     }
     setCurrentIndex(-1);
     m_currentMenu = nullptr;
     m_lastResults.clear();
     m_lastSearchQuery.clear();
-    
-    // Create a copy of the button pointers before clearing caches and removing from group.
-    QList<KDecoration3::DecorationButton *> allButtons;
-    for (auto *b : m_textButtons) allButtons.append(b);
-    if (m_overflowButton) allButtons.append(m_overflowButton);
-    if (m_searchButton) allButtons.append(m_searchButton);
-
     m_textButtons.clear();
     m_overflowButton = nullptr;
     m_searchButton = nullptr;
@@ -370,6 +363,9 @@ void AppMenuButtonGroup::resetButtons()
     if (m_overflowMenu) {
         m_overflowMenu->deleteLater();
     }
+    
+    // Create a copy of the button pointers before removing them from the group.
+    const auto allButtons = buttons();
 
     // This removes all buttons with the "Custom" type from the group's list,
     // but does not delete the button widgets themselves.
@@ -511,7 +507,11 @@ void AppMenuButtonGroup::updateAppMenuModel()
 
         if (m_textButtons.count() == menuActionCount && !m_textButtons.isEmpty() && searchStateMatches) {
             int actionIdx = 0;
-            for (auto *textButton : m_textButtons) {
+            for (auto &textButton : m_textButtons) {
+                if (!textButton) {
+                    actionIdx++;
+                    continue;
+                }
                 QAction *itemAction = actions.at(actionIdx++);
                 textButton->setAction(itemAction);
                 textButton->setText(itemAction->text().trimmed());
@@ -578,16 +578,7 @@ void AppMenuButtonGroup::updateAppMenuModel()
             setCurrentIndex(indexToRestore);
             m_currentMenu = previousMenu;
             
-            AppMenuButton *b = nullptr;
-            if (m_currentIndex == m_searchIndex) {
-                b = m_searchButton;
-            } else if (m_currentIndex == m_overflowIndex) {
-                b = m_overflowButton;
-            } else if (m_currentIndex >= 0 && m_currentIndex < m_textButtons.count()) {
-                b = m_textButtons.at(m_currentIndex);
-            }
-
-            if (b) {
+            if (AppMenuButton *b = getAppMenuButton(m_currentIndex)) {
                 b->setChecked(true);
             }
         }
@@ -622,16 +613,16 @@ void AppMenuButtonGroup::updateOverflow(QRectF availableRect)
     bool showOverflow = m_hamburgerMenu;
 
     if (m_hamburgerMenu) {
-        for (TextButton *tb : m_textButtons) {
-            tb->setVisible(false);
+        for (auto &tb : m_textButtons) {
+            if (tb) tb->setVisible(false);
         }
         showOverflow = true;
     } else {
         // First pass: check if all enabled text buttons fit without overflow button
         qreal totalTextWidth = 0;
         int enabledCount = 0;
-        for (TextButton *tb : m_textButtons) {
-            if (tb->isEnabled()) {
+        for (auto &tb : m_textButtons) {
+            if (tb && tb->isEnabled()) {
                 totalTextWidth += tb->geometry().width();
                 enabledCount++;
             } else {
@@ -641,8 +632,8 @@ void AppMenuButtonGroup::updateOverflow(QRectF availableRect)
 
         if (enabledCount > 0 && fixedWidth + totalTextWidth <= availableWidth) {
             showOverflow = false;
-            for (TextButton *tb : m_textButtons) {
-                if (tb->isEnabled()) {
+            for (auto &tb : m_textButtons) {
+                if (tb && tb->isEnabled()) {
                     tb->setVisible(true);
                 }
             }
@@ -652,8 +643,8 @@ void AppMenuButtonGroup::updateOverflow(QRectF availableRect)
             qreal remainingWidth = availableWidth - fixedWidth - overflowBtnWidth;
 
             bool fits = true;
-            for (TextButton *tb : m_textButtons) {
-                if (!tb->isEnabled()) {
+            for (auto &tb : m_textButtons) {
+                if (!tb || !tb->isEnabled()) {
                     continue;
                 }
 
@@ -678,8 +669,8 @@ void AppMenuButtonGroup::updateOverflow(QRectF availableRect)
 
     // calculate visible width
     qreal currentVisibleWidth = 0;
-    for (auto *tb : m_textButtons) {
-        if (tb->isVisible()) {
+    for (auto &tb : m_textButtons) {
+        if (tb && tb->isVisible()) {
             currentVisibleWidth += tb->geometry().width();
         }
     }
@@ -717,29 +708,14 @@ void AppMenuButtonGroup::popupMenu(QMenu *menu, int buttonIndex)
     m_appMenuModel->stopCaching();
 
     auto *deco = qobject_cast<Decoration *>(decoration());
-    
-    AppMenuButton *button = nullptr;
-    if (buttonIndex == m_searchIndex) {
-        button = m_searchButton;
-    } else if (buttonIndex == m_overflowIndex) {
-        button = m_overflowButton;
-    } else if (buttonIndex >= 0 && buttonIndex < m_textButtons.count()) {
-        button = m_textButtons.at(buttonIndex);
-    }
+    AppMenuButton *button = getAppMenuButton(buttonIndex);
 
     if (!menu || !deco || !button) {
         return;
     }
 
     QPointer<QMenu> oldMenu = m_currentMenu;
-    AppMenuButton *oldButton = nullptr;
-    if (m_currentIndex == m_searchIndex) {
-        oldButton = m_searchButton;
-    } else if (m_currentIndex == m_overflowIndex) {
-        oldButton = m_overflowButton;
-    } else if (m_currentIndex >= 0 && m_currentIndex < m_textButtons.count()) {
-        oldButton = m_textButtons.at(m_currentIndex);
-    }
+    AppMenuButton *oldButton = getAppMenuButton(m_currentIndex);
 
     // 1. Set the new internal state. This must happen before popup for positioning.
     setCurrentIndex(buttonIndex);
@@ -853,8 +829,8 @@ void AppMenuButtonGroup::handleOverflowTrigger()
     if (m_appMenuModel && m_appMenuModel->menu()) {
         int overflowStartsAt = 0;
         // Find the first non-visible button to determine where the overflow starts
-        for (auto *textButton : m_textButtons) {
-            if (textButton->isEnabled() && !textButton->isVisible()) {
+        for (auto &textButton : m_textButtons) {
+            if (textButton && textButton->isEnabled() && !textButton->isVisible()) {
                 overflowStartsAt = textButton->buttonIndex();
                 break;
             }
@@ -873,14 +849,7 @@ void AppMenuButtonGroup::trigger(int buttonIndex)
 {
     // The button is checked in popupMenu, but we need to check it here
     // for the case where the menu is not yet loaded.
-    AppMenuButton *button = nullptr;
-    if (buttonIndex == m_searchIndex) {
-        button = m_searchButton;
-    } else if (buttonIndex == m_overflowIndex) {
-        button = m_overflowButton;
-    } else if (buttonIndex >= 0 && buttonIndex < m_textButtons.count()) {
-        button = m_textButtons.at(buttonIndex);
-    }
+    AppMenuButton *button = getAppMenuButton(buttonIndex);
 
     if (!button) {
         return;
@@ -960,8 +929,8 @@ bool AppMenuButtonGroup::isMenuOpen() const
 
 void AppMenuButtonGroup::unPressAllButtons()
 {
-    for (auto *tb : m_textButtons) {
-        tb->forceUnpress();
+    for (auto &tb : m_textButtons) {
+        if (tb) tb->forceUnpress();
     }
     if (m_overflowButton) {
         m_overflowButton->forceUnpress();
@@ -1004,16 +973,7 @@ void AppMenuButtonGroup::onMenuAboutToHide()
         m_lastSearchQuery.clear();
     }
 
-    AppMenuButton *currentButton = nullptr;
-    if (m_currentIndex == m_searchIndex) {
-        currentButton = m_searchButton;
-    } else if (m_currentIndex == m_overflowIndex) {
-        currentButton = m_overflowButton;
-    } else if (m_currentIndex >= 0 && m_currentIndex < m_textButtons.count()) {
-        currentButton = m_textButtons.at(m_currentIndex);
-    }
-
-    if (currentButton) {
+    if (AppMenuButton *currentButton = getAppMenuButton(m_currentIndex)) {
         currentButton->setChecked(false);
     }
     setCurrentIndex(-1);
@@ -1238,14 +1198,26 @@ void AppMenuButtonGroup::searchMenu(QMenu *menu, const QString &text, QList<Sear
     }
 }
 
+AppMenuButton *AppMenuButtonGroup::getAppMenuButton(int index) const
+{
+    if (index == m_searchIndex) {
+        return m_searchButton;
+    } else if (index == m_overflowIndex) {
+        return m_overflowButton;
+    } else if (index >= 0 && index < m_textButtons.count()) {
+        return m_textButtons.at(index);
+    }
+    return nullptr;
+}
+
 int AppMenuButtonGroup::findNextVisibleButtonIndex(int currentIndex, bool forward) const
 {
     // The button list in this group is composed of: m_textButtons + m_overflowButton + m_searchButton.
     // However, for navigation, we should still respect the underlying group order.
     // Since we only ever have one group of buttons in this class, we can use our caches.
     
-    QList<AppMenuButton *> allButtons;
-    for (auto *b : m_textButtons) allButtons.append(b);
+    QList<QPointer<AppMenuButton>> allButtons;
+    for (auto &b : m_textButtons) allButtons.append(b);
     if (m_overflowButton) allButtons.append(m_overflowButton);
     if (m_searchButton) allButtons.append(m_searchButton);
 
@@ -1268,7 +1240,7 @@ int AppMenuButtonGroup::findNextVisibleButtonIndex(int currentIndex, bool forwar
             newIndex = 0;
         }
 
-        const auto *button = allButtons.value(newIndex);
+        const auto &button = allButtons.value(newIndex);
         if (button && button->isVisible() && button->isEnabled()) {
             return newIndex;
         }
@@ -1292,8 +1264,8 @@ void AppMenuButtonGroup::handleHoverMove(const QPointF &pos)
 
         if (m_hoveredButton) {
             // All buttons in this group are AppMenuButtons
-            auto *appMenuButton = static_cast<AppMenuButton *>(m_hoveredButton.data());
-            if (m_currentIndex != appMenuButton->buttonIndex()
+            auto *appMenuButton = qobject_cast<AppMenuButton *>(m_hoveredButton.data());
+            if (appMenuButton && m_currentIndex != appMenuButton->buttonIndex()
                 && appMenuButton->isVisible()
                 && appMenuButton->isEnabled()
             ) {

--- a/src/AppMenuButtonGroup.h
+++ b/src/AppMenuButtonGroup.h
@@ -28,6 +28,7 @@
 // Qt
 #include <QMenu>
 #include <QLineEdit>
+#include <QPointer>
 
 class QTimer;
 class QVariantAnimation;
@@ -36,6 +37,9 @@ namespace Material
 {
 
 class Decoration;
+class TextButton;
+class MenuOverflowButton;
+class SearchButton;
 
 class AppMenuButtonGroup : public KDecoration3::DecorationButtonGroup
 {
@@ -200,6 +204,10 @@ private:
     bool m_menuLoadedOnce = false;
     QString m_lastSearchQuery;
     QList<SearchResult> m_lastResults;
+
+    QList<TextButton *> m_textButtons;
+    QPointer<MenuOverflowButton> m_overflowButton;
+    QPointer<SearchButton> m_searchButton;
 
     QPointer<KDecoration3::DecorationButton> m_hoveredButton = nullptr;
 

--- a/src/AppMenuButtonGroup.h
+++ b/src/AppMenuButtonGroup.h
@@ -20,6 +20,7 @@
 
 // own
 #include "AppMenuModel.h"
+#include "AppMenuButton.h"
 
 // KDecoration
 #include <KDecoration3/DecorationButton>
@@ -163,6 +164,7 @@ private:
     void setupSearchMenu();
     void repositionSearchMenu();
     void searchMenu(QMenu *menu, const QString &text, QList<SearchResult> &results, QSet<QMenu *> &visited, bool ignoreTopLevel, bool ignoreSubMenus, const QStringList &currentPath = QStringList(), bool isParentEnabled = true);
+    AppMenuButton *getAppMenuButton(int index) const;
     int findNextVisibleButtonIndex(int currentIndex, bool forward) const;
 
     void popupMenu(QMenu *menu, int buttonIndex);
@@ -205,7 +207,7 @@ private:
     QString m_lastSearchQuery;
     QList<SearchResult> m_lastResults;
 
-    QList<TextButton *> m_textButtons;
+    QList<QPointer<TextButton>> m_textButtons;
     QPointer<MenuOverflowButton> m_overflowButton;
     QPointer<SearchButton> m_searchButton;
 


### PR DESCRIPTION
.... by introducing button caching and simplifying access paths

Introduce explicit caching for AppMenuButtons (text, overflow, and search)
to avoid repeated traversal of the generic button list. Replace multiple
O(N) scans and qobject_cast usages with direct O(1) access through cached
pointers and indexed lookup.

Refactor code paths to consistently use the cached structures, including:
- opacity updates
- button lookup and hit testing
- menu triggering and state restoration
- hover handling and navigation

Add getAppMenuButton() helper to centralize index-based access and remove
duplicated branching logic across the codebase.

Improve robustness by:
- switching to QPointer-based storage for safe lifetime handling
- adding null checks in all iteration paths
- resetting overflow/search indices during teardown

Further simplify navigation logic by removing temporary button lists and
iterating via indices with direct lookup.

Overall, this reduces complexity, removes redundant casts, improves
readability, and makes behavior more predictable without changing
functional semantics.