### PR TITLE
fix missing underscores in menu actions via an heuristic…

### DIFF
--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -1155,7 +1155,7 @@ void AppMenuButtonGroup::searchMenu(QMenu *menu, const QString &text, QList<Sear
         if (!menuAction->isEnabled()) {
             isCurrentEnabled = false;
         }
-        const QString menuText = menuAction->text().trimmed().remove(QLatin1Char('&'));
+        const QString menuText = KLocalizedString::removeAcceleratorMarker(menuAction->text().trimmed());
         if (!menuText.isEmpty()) {
             nextPath.append(menuText);
         }
@@ -1168,7 +1168,7 @@ void AppMenuButtonGroup::searchMenu(QMenu *menu, const QString &text, QList<Sear
         if (action->menu()) {
             searchMenu(action->menu(), text, results, visited, ignoreTopLevel, ignoreSubMenus, nextPath, isCurrentEnabled);
         } else {
-            const QString actionText = action->text().trimmed().remove(QLatin1Char('&'));
+            const QString actionText = KLocalizedString::removeAcceleratorMarker(action->text().trimmed());
             bool match = false;
 
             if (ignoreSubMenus) {

--- a/src/libdbusmenuqt/utils.cpp
+++ b/src/libdbusmenuqt/utils.cpp
@@ -19,20 +19,28 @@ QString swapMnemonicChar(const QString &in, const char src, const char dst)
         QChar ch = in[pos];
         if (ch == src) {
             if (pos == in.length() - 1) {
-                // 'src' at the end of string, skip it
+                // 'src' at the end of string, keep it
+                out += src;
                 ++pos;
+            } else if (in[pos + 1] == src) {
+                // A real 'src'
+                out += src;
+                pos += 2;
             } else {
-                if (in[pos + 1] == src) {
-                    // A real 'src'
-                    out += src;
-                    pos += 2;
-                } else if (!mnemonicFound) {
-                    // We found the mnemonic
+                bool isMnemonic = !mnemonicFound;
+
+                // Heuristic: if followed by a digit and preceded by an alphanumeric char,
+                // it's probably part of an identifier (like video_1) rather than a mnemonic.
+                if (isMnemonic && in[pos + 1].isDigit() && pos > 0 && in[pos - 1].isLetterOrNumber()) {
+                    isMnemonic = false;
+                }
+
+                if (isMnemonic) {
                     mnemonicFound = true;
                     out += dst;
                     ++pos;
                 } else {
-                    // We already have a mnemonic, just skip the char
+                    out += src;
                     ++pos;
                 }
             }


### PR DESCRIPTION
…also use KLocalizedString::removeAcceleratorMarker() to manage ampersands in AppMenuButtonGroup