### PR TITLE
AppMenuButtonGroup: use a cache to avoid expensive `KLocalizedString:…

### DIFF
--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -1110,6 +1110,7 @@ void AppMenuButtonGroup::filterMenu(const QString &text)
 
 void AppMenuButtonGroup::onSubMenuReady(QMenu *menu)
 {
+    m_actionTextCache.clear();
     if (m_buttonIndexWaitingForPopup == -1 || !m_appMenuModel || !m_appMenuModel->menu()) {
         return;
     }
@@ -1146,6 +1147,9 @@ void AppMenuButtonGroup::onSearchTimerTimeout()
 
 QString AppMenuButtonGroup::getActionText(QAction *action) const
 {
+    if (!action) {
+        return QString();
+    }
     auto it = m_actionTextCache.find(action);
     if (it != m_actionTextCache.end()) {
         return it.value();

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -1150,12 +1150,13 @@ QString AppMenuButtonGroup::getActionText(QAction *action) const
     if (!action) {
         return QString();
     }
-    auto it = m_actionTextCache.find(action);
+    const QString rawText = action->text();
+    auto it = m_actionTextCache.find(rawText);
     if (it != m_actionTextCache.end()) {
         return it.value();
     }
-    const QString cleanedText = KLocalizedString::removeAcceleratorMarker(action->text().trimmed());
-    m_actionTextCache.insert(action, cleanedText);
+    const QString cleanedText = KLocalizedString::removeAcceleratorMarker(rawText.trimmed());
+    m_actionTextCache.insert(rawText, cleanedText);
     return cleanedText;
 }
 

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -358,6 +358,7 @@ void AppMenuButtonGroup::resetButtons()
     m_currentMenu = nullptr;
     m_lastResults.clear();
     m_lastSearchQuery.clear();
+    m_actionTextCache.clear();
     m_textButtons.clear();
     m_overflowButton = nullptr;
     m_searchButton = nullptr;
@@ -510,6 +511,7 @@ void AppMenuButtonGroup::updateAppMenuModel()
         const bool searchStateMatches = (m_searchButton.isNull() == !deco->searchEnabled());
 
         if (m_textButtons.count() == menuActionCount && !m_textButtons.isEmpty() && searchStateMatches) {
+            m_actionTextCache.clear();
             int actionIdx = 0;
             for (auto &textButton : std::as_const(m_textButtons)) {
                 if (!textButton) {
@@ -1142,6 +1144,17 @@ void AppMenuButtonGroup::onSearchTimerTimeout()
     }
 }
 
+QString AppMenuButtonGroup::getActionText(QAction *action) const
+{
+    auto it = m_actionTextCache.find(action);
+    if (it != m_actionTextCache.end()) {
+        return it.value();
+    }
+    const QString cleanedText = KLocalizedString::removeAcceleratorMarker(action->text().trimmed());
+    m_actionTextCache.insert(action, cleanedText);
+    return cleanedText;
+}
+
 void AppMenuButtonGroup::searchMenu(QMenu *menu, const QString &text, QList<SearchResult> &results, QSet<QMenu *> &visited, bool ignoreTopLevel, bool ignoreSubMenus, const QStringList &currentPath, bool isParentEnabled)
 {
     if (!menu || visited.contains(menu)) {
@@ -1157,7 +1170,7 @@ void AppMenuButtonGroup::searchMenu(QMenu *menu, const QString &text, QList<Sear
         if (!menuAction->isEnabled()) {
             isCurrentEnabled = false;
         }
-        const QString menuText = KLocalizedString::removeAcceleratorMarker(menuAction->text().trimmed());
+        const QString menuText = getActionText(menuAction);
         if (!menuText.isEmpty()) {
             nextPath.append(menuText);
         }
@@ -1170,7 +1183,7 @@ void AppMenuButtonGroup::searchMenu(QMenu *menu, const QString &text, QList<Sear
         if (action->menu()) {
             searchMenu(action->menu(), text, results, visited, ignoreTopLevel, ignoreSubMenus, nextPath, isCurrentEnabled);
         } else {
-            const QString actionText = KLocalizedString::removeAcceleratorMarker(action->text().trimmed());
+            const QString actionText = getActionText(action);
             bool match = false;
 
             if (ignoreSubMenus) {

--- a/src/AppMenuButtonGroup.h
+++ b/src/AppMenuButtonGroup.h
@@ -30,6 +30,7 @@
 #include <QMenu>
 #include <QLineEdit>
 #include <QPointer>
+#include <QHash>
 
 class QTimer;
 class QVariantAnimation;
@@ -161,6 +162,7 @@ private:
     };
 
     void resetButtons();
+    QString getActionText(QAction *action) const;
     void setupSearchMenu();
     void repositionSearchMenu();
     void searchMenu(QMenu *menu, const QString &text, QList<SearchResult> &results, QSet<QMenu *> &visited, bool ignoreTopLevel, bool ignoreSubMenus, const QStringList &currentPath = QStringList(), bool isParentEnabled = true);
@@ -210,6 +212,8 @@ private:
     QList<QPointer<TextButton>> m_textButtons;
     QPointer<MenuOverflowButton> m_overflowButton;
     QPointer<SearchButton> m_searchButton;
+
+    mutable QHash<QAction *, QString> m_actionTextCache;
 
     QPointer<KDecoration3::DecorationButton> m_hoveredButton = nullptr;
 

--- a/src/AppMenuButtonGroup.h
+++ b/src/AppMenuButtonGroup.h
@@ -213,7 +213,7 @@ private:
     QPointer<MenuOverflowButton> m_overflowButton;
     QPointer<SearchButton> m_searchButton;
 
-    mutable QHash<QAction *, QString> m_actionTextCache;
+    mutable QHash<QString, QString> m_actionTextCache;
 
     QPointer<KDecoration3::DecorationButton> m_hoveredButton = nullptr;
 


### PR DESCRIPTION
…:removeAcceleratorMarker(action->text().trimmed())`. (Average) search lookup for action text is now O(1) instead of O(Lenght of the label) x the frequency of visits in the recursive search