### PR TITLE
performance optimization of libdbusmenuqt

### DIFF
--- a/src/libdbusmenuqt/dbusmenuimporter.cpp
+++ b/src/libdbusmenuqt/dbusmenuimporter.cpp
@@ -20,6 +20,7 @@
 #include <QMenu>
 #include <QPointer>
 #include <QSet>
+#include <utility>
 #include <QTime>
 #include <QTimer>
 #include <QToolButton>
@@ -147,7 +148,7 @@ public:
      */
     void updateAction(QAction *action, const QVariantMap &map)
     {
-        for (auto it = map.constBegin(); it != map.constEnd(); ++it) {
+        for (auto it = std::as_const(map).constBegin(); it != std::as_const(map).constEnd(); ++it) {
             const QString &key = it.key();
             if (key == QLatin1String("type") || key == QLatin1String("toggle-type") || key == QLatin1String("children-display")) {
                 continue;
@@ -313,9 +314,9 @@ void DBusMenuImporter::slotLayoutUpdated(uint revision, int parentId)
 
 void DBusMenuImporter::processPendingLayoutUpdates()
 {
-    const QSet<int> ids = d->m_pendingLayoutUpdates;
+    const QSet<int> ids = std::move(d->m_pendingLayoutUpdates);
     d->m_pendingLayoutUpdates.clear();
-    for (int id : ids) {
+    for (int id : std::as_const(ids)) {
         d->refresh(id);
     }
 }
@@ -331,7 +332,7 @@ QMenu *DBusMenuImporter::menu() const
 void DBusMenuImporterPrivate::slotItemsPropertiesUpdated(const DBusMenuItemList &updatedList, const DBusMenuItemKeysList &removedList)
 {
     bool needLayoutUpdate = false;
-    for (const DBusMenuItem &item : updatedList) {
+    for (const DBusMenuItem &item : std::as_const(updatedList)) {
         QAction *action = m_actionForId.value(item.id);
         if (!action) {
             // We don't know this action. It probably is in a menu we haven't fetched yet.
@@ -340,13 +341,14 @@ void DBusMenuImporterPrivate::slotItemsPropertiesUpdated(const DBusMenuItemList 
             continue;
         }
 
-        QVariantMap::ConstIterator it = item.properties.constBegin(), end = item.properties.constEnd();
+        auto it = std::as_const(item.properties).constBegin();
+        const auto end = std::as_const(item.properties).constEnd();
         for (; it != end; ++it) {
             updateActionProperty(action, it.key(), it.value());
         }
     }
 
-    for (const DBusMenuItemKeys &item : removedList) {
+    for (const DBusMenuItemKeys &item : std::as_const(removedList)) {
         QAction *action = m_actionForId.value(item.id);
         if (!action) {
             // We don't know this action. It probably is in a menu we haven't fetched yet.
@@ -354,8 +356,7 @@ void DBusMenuImporterPrivate::slotItemsPropertiesUpdated(const DBusMenuItemList 
             continue;
         }
 
-        const auto properties{item.properties};
-        for (const QString &key : properties) {
+        for (const QString &key : std::as_const(item.properties)) {
             updateActionProperty(action, key, QVariant());
         }
     }
@@ -457,7 +458,7 @@ void DBusMenuImporter::slotGetLayoutFinished(QDBusPendingCallWatcher *watcher)
     }
 
     // 2. Remove actions no longer present
-    for (QAction *action : actions) {
+    for (QAction *action : std::as_const(actions)) {
         int id = action->property(DBUSMENU_PROPERTY_ID).toInt();
         if (!newIds.contains(id)) {
             if (menu) {

--- a/src/libdbusmenuqt/dbusmenushortcut_p.cpp
+++ b/src/libdbusmenuqt/dbusmenushortcut_p.cpp
@@ -81,7 +81,7 @@ QKeySequence DBusMenuShortcut::toKeySequence() const
     for (const QStringList &keyTokens : std::as_const(*this)) {
         QStringList translatedTokens;
         translatedTokens.reserve(keyTokens.size());
-        for (const QString &token : keyTokens) {
+        for (const QString &token : std::as_const(keyTokens)) {
             const QString t = translate(token, DM_COLUMN, QT_COLUMN);
             translatedTokens.append(t.isNull() ? token : t);
         }

--- a/src/libdbusmenuqt/dbusmenutypes_p.cpp
+++ b/src/libdbusmenuqt/dbusmenutypes_p.cpp
@@ -12,6 +12,7 @@
 // Qt
 #include <QDBusArgument>
 #include <QDBusMetaType>
+#include <utility>
 
 //// DBusMenuItem
 QDBusArgument &operator<<(QDBusArgument &argument, const DBusMenuItem &obj)
@@ -84,8 +85,8 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, DBusMenuLayoutIte
 QDBusArgument &operator<<(QDBusArgument &argument, const DBusMenuShortcut &obj)
 {
     argument.beginArray(qMetaTypeId<QStringList>());
-    typename QList<QStringList>::ConstIterator it = obj.constBegin();
-    typename QList<QStringList>::ConstIterator end = obj.constEnd();
+    auto it = std::as_const(obj).constBegin();
+    const auto end = std::as_const(obj).constEnd();
     for (; it != end; ++it)
         argument << *it;
     argument.endArray();


### PR DESCRIPTION
What:
- Removed unnecessary intermediate copies of `QStringList` (and other Qt containers) before iteration, specifically targeting `slotItemsPropertiesUpdated` in `dbusmenuimporter.cpp` and similar patterns across `libdbusmenuqt`.
- Used `std::as_const()` for range-based for loops and iterator boundaries to explicitly prevent unintended container detachment (copy-on-write) and ensure the use of const iterators.
- Used `std::move()` in `processPendingLayoutUpdates` to transfer ownership of the `pendingLayoutUpdates` set, avoiding atomic reference count increments and decrements.

Why:
- Qt's implicitly shared containers (like `QStringList`, `QVariantMap`, `QSet`) increment their reference count when copied, which involves atomic operations.
- Iterating over a non-const container in a range-based for loop can trigger a "detach" (deep copy) if the container is shared, leading to significant overhead and heap allocations.
- These micro-optimizations reduce CPU cycles and memory pressure in hot paths responsible for updating menu item properties via D-Bus.
