### PR TITLE
Show radio actions as radio in search menu

### DIFF
--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -38,6 +38,7 @@
 
 // Qt
 #include <QAction>
+#include <QActionGroup>
 #include <QApplication>
 #include <QDebug>
 #include <QEvent>
@@ -1103,6 +1104,13 @@ void AppMenuButtonGroup::filterMenu(const QString &text)
         newAction->setEnabled(info.isEffectivelyEnabled);
         newAction->setCheckable(action->isCheckable());
         newAction->setChecked(action->isChecked());
+
+        if (action->actionGroup() && action->actionGroup()->isExclusive()) {
+            auto *group = new QActionGroup(newAction);
+            group->setExclusive(true);
+            group->addAction(newAction);
+        }
+
         QPointer<QAction> safeAction = action;
         connect(newAction, &QAction::triggered, this, [safeAction, this]() {
             if (safeAction) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search results now preserve exclusive selection behavior for menu actions, so grouped options continue to act like a single-choice set when opened from search.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->