### PR TITLE
Fix empty first time search

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -4,7 +4,9 @@ on:
   issue_comment:
     types: [created]
 
-permissions: write-all
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
   gemini-code-review:
@@ -14,8 +16,10 @@ jobs:
       contains(github.event.comment.body, '/gemini-review')
     steps:
       - name: PR Info
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
-          echo "Comment: ${{ github.event.comment.body }}"
+          echo "Comment: $COMMENT_BODY"
           echo "Issue Number: ${{ github.event.issue.number }}"
           echo "Repository: ${{ github.repository }}"
 

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -1,0 +1,41 @@
+name: Gemini AI Code Reviewer
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions: write-all
+
+jobs:
+  gemini-code-review:
+    runs-on: ubuntu-latest
+    if: |
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/gemini-review')
+    steps:
+      - name: PR Info
+        run: |
+          echo "Comment: ${{ github.event.comment.body }}"
+          echo "Issue Number: ${{ github.event.issue.number }}"
+          echo "Repository: ${{ github.repository }}"
+
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Get PR Details
+        id: pr
+        run: |
+          PR_JSON=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.issue.number }})
+          echo "head_sha=$(echo $PR_JSON | jq -r .head.sha)" >> $GITHUB_OUTPUT
+          echo "base_sha=$(echo $PR_JSON | jq -r .base.sha)" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: truongnh1992/gemini-ai-code-reviewer@main
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GEMINI_MODEL: gemini-3.5-flash # Optional, default is `gemini-2.5-flash`
+          EXCLUDE: "*.md,*.txt,package-lock.json,*.yml,*.yaml"

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -1131,7 +1131,9 @@ void AppMenuButtonGroup::onSubMenuReady(QMenu *menu)
     m_actionTextCache.clear();
 
     if (m_searchUiVisible && !m_lastSearchQuery.isEmpty()) {
-        m_searchDebounceTimer->start();
+        if (!m_searchDebounceTimer->isActive()) {
+            m_searchDebounceTimer->start();
+        }
     }
 
     if (m_buttonIndexWaitingForPopup == -1 || !m_appMenuModel || !m_appMenuModel->menu()) {

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -387,7 +387,6 @@ void AppMenuButtonGroup::resetButtons()
 
 void AppMenuButtonGroup::onMenuReadyForSearch()
 {
-    m_menuReadyForSearch = true;
     if (!m_lastSearchQuery.isEmpty() && m_searchUiVisible) {
         filterMenu(m_lastSearchQuery);
     }
@@ -491,8 +490,6 @@ void AppMenuButtonGroup::updateAppMenuModel()
     }
 
     if (m_appMenuModel) {
-        m_menuReadyForSearch = false;
-
         QMenu *menu = m_appMenuModel->menu();
         if (!menu) {
             // Defer reset to avoid flicker during window closure

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -1046,8 +1046,7 @@ void AppMenuButtonGroup::filterMenu(const QString &text)
         m_searchLineEdit->setClearButtonEnabled(true);
     }
 
-    if (!m_appMenuModel || !m_menuReadyForSearch) {
-        // Menu is not ready yet, search will be re-triggered later
+    if (!m_appMenuModel) {
         return;
     }
 
@@ -1130,6 +1129,11 @@ void AppMenuButtonGroup::filterMenu(const QString &text)
 void AppMenuButtonGroup::onSubMenuReady(QMenu *menu)
 {
     m_actionTextCache.clear();
+
+    if (m_searchUiVisible && !m_lastSearchQuery.isEmpty()) {
+        m_searchDebounceTimer->start();
+    }
+
     if (m_buttonIndexWaitingForPopup == -1 || !m_appMenuModel || !m_appMenuModel->menu()) {
         return;
     }

--- a/src/AppMenuButtonGroup.h
+++ b/src/AppMenuButtonGroup.h
@@ -204,7 +204,6 @@ private:
 
     bool m_isMenuUpdateThrottled = false;
     bool m_pendingMenuUpdate = false;
-    bool m_menuReadyForSearch = false;
     bool m_menuLoadedOnce = false;
     QString m_lastSearchQuery;
     QList<SearchResult> m_lastResults;

--- a/src/AppMenuModel.cc
+++ b/src/AppMenuModel.cc
@@ -194,7 +194,7 @@ void AppMenuModel::onMenuUpdated(QMenu *menu)
         if (m_pendingMenuUpdates > 0) {
             m_pendingMenuUpdates--;
             if (m_pendingMenuUpdates == 0 && m_nextMenuToProcess >= m_menusToDeepCache.size()) {
-                Q_EMIT menuReadyForSearch();
+                processNext();
             }
         }
     }
@@ -260,10 +260,12 @@ void AppMenuModel::startDeepCaching()
 
 void AppMenuModel::resumeDeepCacheIfIdle(QMenu *menu)
 {
+    if (!menu) {
+        return;
+    }
+
     const bool wasQueueFinished = (m_nextMenuToProcess >= m_menusToDeepCache.size());
     
-    if (!menu) return;
-
     const auto actions = menu->actions();
     for (QAction *a : actions) {
         if (auto subMenu = a->menu()) {

--- a/src/AppMenuModel.cc
+++ b/src/AppMenuModel.cc
@@ -212,10 +212,9 @@ void AppMenuModel::loadSubMenu(QMenu *menu)
 
 void AppMenuModel::stopCaching()
 {
-    for (const auto &conn : m_destroyedConnections) {
-        disconnect(conn);
+    for (QMenu *subMenu : std::as_const(m_seenMenus)) {
+        disconnect(subMenu, nullptr, this, nullptr);
     }
-    m_destroyedConnections.clear();
 
     if (!m_isCachingEverything) {
         m_pendingMenuUpdates = 0; // Ensure consistency
@@ -267,10 +266,9 @@ void AppMenuModel::registerSubMenus(QMenu *menu)
         if (auto subMenu = a->menu()) {
             if (!m_seenMenus.contains(subMenu)) {
                 m_seenMenus.insert(subMenu);
-                auto conn = connect(subMenu, &QObject::destroyed, this, [this, subMenu]() {
+                connect(subMenu, &QObject::destroyed, this, [this, subMenu]() {
                     m_seenMenus.remove(subMenu);
                 });
-                m_destroyedConnections.append(conn);
                 m_menusToDeepCache.append(QPointer(subMenu));
             }
         }

--- a/src/AppMenuModel.cc
+++ b/src/AppMenuModel.cc
@@ -41,6 +41,9 @@
 // libdbusmenuqt
 #include <dbusmenuimporter.h>
 
+//std
+#include <utility>
+
 namespace Material
 {
 

--- a/src/AppMenuModel.cc
+++ b/src/AppMenuModel.cc
@@ -181,7 +181,7 @@ void AppMenuModel::onMenuUpdated(QMenu *menu)
 
         // Pre-fetching and deep caching are now handled on-demand.
         if (m_isCachingEverything) {
-            const bool wasQueueEmpty = m_menusToDeepCache.isEmpty();
+            const bool wasQueueFinished = (m_nextMenuToProcess >= m_menusToDeepCache.size());
             const auto actions = m_menu->actions();
             for (QAction *a : actions) {
                 if (auto subMenu = a->menu()) {
@@ -192,31 +192,31 @@ void AppMenuModel::onMenuUpdated(QMenu *menu)
                 }
             }
 
-            if (wasQueueEmpty && !m_menusToDeepCache.isEmpty()) {
+            if (wasQueueFinished && m_nextMenuToProcess < m_menusToDeepCache.size()) {
                 processNext();
             }
         }
     } else { // This is an update for a submenu that was previously requested.
         Q_EMIT subMenuReady(menu);
-        const bool wasQueueEmpty = m_menusToDeepCache.isEmpty();
+        const bool wasQueueFinished = (m_nextMenuToProcess >= m_menusToDeepCache.size());
         if (m_isCachingEverything) {
             // The deep caching phase has begun. Add the children of the newly-loaded
             // submenu to the processing queue.
             const auto actions = menu->actions();
-             for (QAction *a : actions) {
-                 if (auto subMenu = a->menu()) {
-                     if (m_seenMenus.contains(subMenu)) {
-                         continue;
-                     }
-                     m_seenMenus.insert(subMenu);
-                     m_menusToDeepCache.append(QPointer(subMenu));
-                 }
-             }
+            for (QAction *a : actions) {
+                if (auto subMenu = a->menu()) {
+                    if (m_seenMenus.contains(subMenu)) {
+                        continue;
+                    }
+                    m_seenMenus.insert(subMenu);
+                    m_menusToDeepCache.append(QPointer(subMenu));
+                }
+            }
         }
 
         // If the processing chain was idle and we've just added new items,
         // we need to kick-start it again.
-        if (wasQueueEmpty && !m_menusToDeepCache.isEmpty()) {
+        if (wasQueueFinished && m_nextMenuToProcess < m_menusToDeepCache.size()) {
             processNext();
         }
 
@@ -224,7 +224,7 @@ void AppMenuModel::onMenuUpdated(QMenu *menu)
         // the entire menu tree has been fetched and is ready for searching.
         if (m_pendingMenuUpdates > 0) {
             m_pendingMenuUpdates--;
-            if (m_pendingMenuUpdates == 0) {
+            if (m_pendingMenuUpdates == 0 && m_nextMenuToProcess >= m_menusToDeepCache.size()) {
                 Q_EMIT menuReadyForSearch();
             }
         }

--- a/src/AppMenuModel.cc
+++ b/src/AppMenuModel.cc
@@ -97,7 +97,10 @@ AppMenuModel::AppMenuModel(QObject *parent)
     connect(m_staggerTimer, &QTimer::timeout, this, &AppMenuModel::processNext);
 }
 
-AppMenuModel::~AppMenuModel() = default;
+AppMenuModel::~AppMenuModel()
+{
+    stopCaching();
+}
 
 bool AppMenuModel::menuAvailable() const
 {
@@ -209,6 +212,11 @@ void AppMenuModel::loadSubMenu(QMenu *menu)
 
 void AppMenuModel::stopCaching()
 {
+    for (const auto &conn : m_destroyedConnections) {
+        disconnect(conn);
+    }
+    m_destroyedConnections.clear();
+
     if (!m_isCachingEverything) {
         m_pendingMenuUpdates = 0; // Ensure consistency
         m_nextMenuToProcess = 0;
@@ -243,22 +251,30 @@ void AppMenuModel::startDeepCaching()
 
     // Populate the queue with the first level of submenus.
     // The recursive loading will happen as each menu is processed.
-    const auto actions = m_menu->actions();
-    for (QAction *a : actions) {
-        if (auto subMenu = a->menu()) {
-             if (m_seenMenus.contains(subMenu)) {
-                 continue;
-             }
-            m_seenMenus.insert(subMenu);
-            connect(subMenu, &QObject::destroyed, this, [this, subMenu]() {
-                m_seenMenus.remove(subMenu);
-            });
-            m_menusToDeepCache.append(QPointer(subMenu));
-        }
-    }
+    registerSubMenus(m_menu.data());
 
     // Start processing the queue.
     processNext();
+}
+
+void AppMenuModel::registerSubMenus(QMenu *menu)
+{
+    if (!menu) {
+        return;
+    }
+    const auto actions = menu->actions();
+    for (QAction *a : actions) {
+        if (auto subMenu = a->menu()) {
+            if (!m_seenMenus.contains(subMenu)) {
+                m_seenMenus.insert(subMenu);
+                auto conn = connect(subMenu, &QObject::destroyed, this, [this, subMenu]() {
+                    m_seenMenus.remove(subMenu);
+                });
+                m_destroyedConnections.append(conn);
+                m_menusToDeepCache.append(QPointer(subMenu));
+            }
+        }
+    }
 }
 
 void AppMenuModel::resumeDeepCacheIfIdle(QMenu *menu)
@@ -268,20 +284,8 @@ void AppMenuModel::resumeDeepCacheIfIdle(QMenu *menu)
     }
 
     const bool wasQueueFinished = (m_nextMenuToProcess >= m_menusToDeepCache.size());
-    
-    const auto actions = menu->actions();
-    for (QAction *a : actions) {
-        if (auto subMenu = a->menu()) {
-            if (m_seenMenus.contains(subMenu)) {
-                continue;
-            }
-            m_seenMenus.insert(subMenu);
-            connect(subMenu, &QObject::destroyed, this, [this, subMenu]() {
-                m_seenMenus.remove(subMenu);
-            });
-            m_menusToDeepCache.append(QPointer(subMenu));
-        }
-    }
+
+    registerSubMenus(menu);
 
     if (wasQueueFinished && m_nextMenuToProcess < m_menusToDeepCache.size()) {
         processNext();
@@ -311,18 +315,7 @@ void AppMenuModel::processNext()
 
         if (menuToProcess) {
             if (!menuToProcess->actions().isEmpty()) {
-                const auto actions = menuToProcess->actions();
-                for (QAction *a : actions) {
-                    if (auto subMenu = a->menu()) {
-                        if (!m_seenMenus.contains(subMenu)) {
-                            m_seenMenus.insert(subMenu);
-                            connect(subMenu, &QObject::destroyed, this, [this, subMenu]() {
-                                m_seenMenus.remove(subMenu);
-                            });
-                            m_menusToDeepCache.append(QPointer(subMenu));
-                        }
-                    }
-                }
+                registerSubMenus(menuToProcess);
                 if (deadline.hasExpired()) {
                     m_staggerTimer->start();
                     return;

--- a/src/AppMenuModel.cc
+++ b/src/AppMenuModel.cc
@@ -299,6 +299,9 @@ void AppMenuModel::processNext()
             if (m_pendingMenuUpdates > 0) {
                 return; // Wait for pending updates to finish and potentially add more items
             }
+            for (QMenu *subMenu : std::as_const(m_seenMenus)) {
+                disconnect(subMenu, nullptr, this, nullptr);
+            }
             m_menusToDeepCache.clear();
             m_nextMenuToProcess = 0;
             m_isCachingEverything = false;
@@ -333,6 +336,9 @@ void AppMenuModel::processNext()
     m_isCachingEverything = false;
     m_deepCacheStarted = false;
     m_nextMenuToProcess = 0;
+    for (QMenu *subMenu : std::as_const(m_seenMenus)) {
+        disconnect(subMenu, nullptr, this, nullptr);
+    }
     m_seenMenus.clear();
     if (m_pendingMenuUpdates == 0) {
         Q_EMIT menuReadyForSearch();

--- a/src/AppMenuModel.cc
+++ b/src/AppMenuModel.cc
@@ -250,6 +250,9 @@ void AppMenuModel::startDeepCaching()
                  continue;
              }
             m_seenMenus.insert(subMenu);
+            connect(subMenu, &QObject::destroyed, this, [this, subMenu]() {
+                m_seenMenus.remove(subMenu);
+            });
             m_menusToDeepCache.append(QPointer(subMenu));
         }
     }
@@ -273,6 +276,9 @@ void AppMenuModel::resumeDeepCacheIfIdle(QMenu *menu)
                 continue;
             }
             m_seenMenus.insert(subMenu);
+            connect(subMenu, &QObject::destroyed, this, [this, subMenu]() {
+                m_seenMenus.remove(subMenu);
+            });
             m_menusToDeepCache.append(QPointer(subMenu));
         }
     }
@@ -310,6 +316,9 @@ void AppMenuModel::processNext()
                     if (auto subMenu = a->menu()) {
                         if (!m_seenMenus.contains(subMenu)) {
                             m_seenMenus.insert(subMenu);
+                            connect(subMenu, &QObject::destroyed, this, [this, subMenu]() {
+                                m_seenMenus.remove(subMenu);
+                            });
                             m_menusToDeepCache.append(QPointer(subMenu));
                         }
                     }

--- a/src/AppMenuModel.cc
+++ b/src/AppMenuModel.cc
@@ -181,43 +181,12 @@ void AppMenuModel::onMenuUpdated(QMenu *menu)
 
         // Pre-fetching and deep caching are now handled on-demand.
         if (m_isCachingEverything) {
-            const bool wasQueueFinished = (m_nextMenuToProcess >= m_menusToDeepCache.size());
-            const auto actions = m_menu->actions();
-            for (QAction *a : actions) {
-                if (auto subMenu = a->menu()) {
-                    if (!m_seenMenus.contains(subMenu)) {
-                        m_seenMenus.insert(subMenu);
-                        m_menusToDeepCache.append(QPointer(subMenu));
-                    }
-                }
-            }
-
-            if (wasQueueFinished && m_nextMenuToProcess < m_menusToDeepCache.size()) {
-                processNext();
-            }
+            resumeDeepCacheIfIdle(m_menu.data());
         }
     } else { // This is an update for a submenu that was previously requested.
         Q_EMIT subMenuReady(menu);
-        const bool wasQueueFinished = (m_nextMenuToProcess >= m_menusToDeepCache.size());
         if (m_isCachingEverything) {
-            // The deep caching phase has begun. Add the children of the newly-loaded
-            // submenu to the processing queue.
-            const auto actions = menu->actions();
-            for (QAction *a : actions) {
-                if (auto subMenu = a->menu()) {
-                    if (m_seenMenus.contains(subMenu)) {
-                        continue;
-                    }
-                    m_seenMenus.insert(subMenu);
-                    m_menusToDeepCache.append(QPointer(subMenu));
-                }
-            }
-        }
-
-        // If the processing chain was idle and we've just added new items,
-        // we need to kick-start it again.
-        if (wasQueueFinished && m_nextMenuToProcess < m_menusToDeepCache.size()) {
-            processNext();
+            resumeDeepCacheIfIdle(menu);
         }
 
         // Track the number of pending submenu updates. When it reaches zero,
@@ -289,20 +258,43 @@ void AppMenuModel::startDeepCaching()
     processNext();
 }
 
+void AppMenuModel::resumeDeepCacheIfIdle(QMenu *menu)
+{
+    const bool wasQueueFinished = (m_nextMenuToProcess >= m_menusToDeepCache.size());
+    
+    if (!menu) return;
+
+    const auto actions = menu->actions();
+    for (QAction *a : actions) {
+        if (auto subMenu = a->menu()) {
+            if (m_seenMenus.contains(subMenu)) {
+                continue;
+            }
+            m_seenMenus.insert(subMenu);
+            m_menusToDeepCache.append(QPointer(subMenu));
+        }
+    }
+
+    if (wasQueueFinished && m_nextMenuToProcess < m_menusToDeepCache.size()) {
+        processNext();
+    }
+}
+
 void AppMenuModel::processNext()
 {
     QDeadlineTimer deadline(std::chrono::milliseconds(8));
 
     while (!m_menusToDeepCache.isEmpty()) {
         if (m_nextMenuToProcess >= m_menusToDeepCache.size()) {
+            if (m_pendingMenuUpdates > 0) {
+                return; // Wait for pending updates to finish and potentially add more items
+            }
             m_menusToDeepCache.clear();
             m_nextMenuToProcess = 0;
             m_isCachingEverything = false;
             m_deepCacheStarted = false;
             m_seenMenus.clear();
-            if (m_pendingMenuUpdates == 0) {
-                Q_EMIT menuReadyForSearch();
-            }
+            Q_EMIT menuReadyForSearch();
             return;
         }
 

--- a/src/AppMenuModel.h
+++ b/src/AppMenuModel.h
@@ -89,8 +89,6 @@ private:
     int m_pendingMenuUpdates = 0;
     bool m_updatePending = false;
 
-    QList<QMetaObject::Connection> m_destroyedConnections;
-
     QPointer<QMenu> m_menu;
 
     QDBusServiceWatcher *m_serviceWatcher;

--- a/src/AppMenuModel.h
+++ b/src/AppMenuModel.h
@@ -74,6 +74,7 @@ private Q_SLOTS:
     void processNext();
 
 private:
+    void registerSubMenus(QMenu *menu);
     void resumeDeepCacheIfIdle(QMenu *menu);
     bool menuAvailable() const;
     void setMenuAvailable(bool set);
@@ -87,6 +88,8 @@ private:
     bool m_deepCacheStarted = false;
     int m_pendingMenuUpdates = 0;
     bool m_updatePending = false;
+
+    QList<QMetaObject::Connection> m_destroyedConnections;
 
     QPointer<QMenu> m_menu;
 

--- a/src/AppMenuModel.h
+++ b/src/AppMenuModel.h
@@ -74,6 +74,7 @@ private Q_SLOTS:
     void processNext();
 
 private:
+    void resumeDeepCacheIfIdle(QMenu *menu);
     bool menuAvailable() const;
     void setMenuAvailable(bool set);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app menu search filtering so it works reliably without requiring a prior “ready for search” state.
  * Enhanced search responsiveness while submenus load by restarting the search debounce when the search UI is open and there’s an active query.
  * Refined when the app menu reports search readiness so it’s emitted only after submenu updates finish, reducing temporary “search unavailable” moments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->