### PR TITLE
Modernize and optimize DBusMenuShortcut for Qt6

### DIFF
--- a/src/libdbusmenuqt/dbusmenushortcut_p.cpp
+++ b/src/libdbusmenuqt/dbusmenushortcut_p.cpp
@@ -21,22 +21,21 @@ struct Row {
     const char *one;
 };
 
-static const Row table[] = {{"Meta", "Super"},
-                            {"Ctrl", "Control"},
-                            // Special cases for compatibility with libdbusmenu-glib which uses
-                            // "plus" for "+" and "minus" for "-".
-                            // cf https://bugs.launchpad.net/libdbusmenu-qt/+bug/712565
-                            {"+", "plus"},
-                            {"-", "minus"},
-                            {nullptr, nullptr}};
+static constexpr Row table[] = {{"Meta", "Super"},
+                                {"Ctrl", "Control"},
+                                // Special cases for compatibility with libdbusmenu-glib which uses
+                                // "plus" for "+" and "minus" for "-".
+                                // cf https://bugs.launchpad.net/libdbusmenu-qt/+bug/712565
+                                {"+", "plus"},
+                                {"-", "minus"},
+                                {nullptr, nullptr}};
 
-static QString translate(QStringView token, int srcCol, int dstCol)
+static constexpr QLatin1StringView translate(QStringView token, int srcCol, int dstCol)
 {
     for (const Row *ptr = table; ptr->zero != nullptr; ++ptr) {
         const char *from = (srcCol == QT_COLUMN ? ptr->zero : ptr->one);
-        if (token == QLatin1String(from)) {
-            const char *to = (dstCol == QT_COLUMN ? ptr->zero : ptr->one);
-            return QLatin1String(to);
+        if (token == QLatin1StringView(from)) {
+            return QLatin1StringView(dstCol == QT_COLUMN ? ptr->zero : ptr->one);
         }
     }
     return {};
@@ -46,8 +45,8 @@ DBusMenuShortcut DBusMenuShortcut::fromKeySequence(const QKeySequence &sequence)
 {
     const QString string = sequence.toString();
     DBusMenuShortcut shortcut;
-    for (auto token : QStringTokenizer{string, QLatin1String(", ")}) {
-        if (token == QLatin1String("+")) {
+    for (auto token : QStringTokenizer{string, QLatin1StringView(", "), Qt::SkipEmptyParts}) {
+        if (token == QLatin1StringView("+")) {
             shortcut.append({QLatin1String("plus")});
             continue;
         }
@@ -56,13 +55,17 @@ DBusMenuShortcut DBusMenuShortcut::fromKeySequence(const QKeySequence &sequence)
         // but we don't want the call to token.split() to consider the
         // second '+' as a separator so we handle it by checking if the token
         // ends with "++".
-        const bool endsWithPlusPlus = token.endsWith(QLatin1String("++"));
-        const auto subToken = endsWithPlusPlus ? token.left(token.size() - 2) : token;
+        const bool endsWithPlusPlus = token.endsWith(QLatin1StringView("++"));
+        const QStringView subToken = endsWithPlusPlus ? token.chopped(2) : token;
 
         QStringList keyTokens;
-        for (auto kt : QStringTokenizer{subToken, QLatin1Char('+')}) {
-            const QString t = translate(kt, QT_COLUMN, DM_COLUMN);
-            keyTokens.append(t.isNull() ? kt.toString() : t);
+        keyTokens.reserve(4);
+        for (auto kt : QStringTokenizer{subToken, QLatin1Char('+'), Qt::SkipEmptyParts}) {
+            if (const auto t = translate(kt, QT_COLUMN, DM_COLUMN); !t.isEmpty()) {
+                keyTokens.append(t);
+            } else {
+                keyTokens.append(kt.toString());
+            }
         }
 
         if (endsWithPlusPlus) {
@@ -76,16 +79,30 @@ DBusMenuShortcut DBusMenuShortcut::fromKeySequence(const QKeySequence &sequence)
 
 QKeySequence DBusMenuShortcut::toKeySequence() const
 {
-    QStringList tmp;
-    tmp.reserve(size());
+    QString res;
+    // Heuristic: estimate size to minimize reallocations.
+    // Each shortcut part is at least a few chars, plus separators.
+    res.reserve(size() * 16);
+
     for (const QStringList &keyTokens : std::as_const(*this)) {
-        QStringList translatedTokens;
-        translatedTokens.reserve(keyTokens.size());
-        for (const QString &token : keyTokens) {
-            const QString t = translate(token, DM_COLUMN, QT_COLUMN);
-            translatedTokens.append(t.isNull() ? token : t);
+        if (keyTokens.isEmpty()) {
+            continue;
         }
-        tmp.append(translatedTokens.join(QLatin1Char('+')));
+        if (!res.isEmpty()) {
+            res += QLatin1StringView(", ");
+        }
+        bool first = true;
+        for (const QString &token : keyTokens) {
+            if (!first) {
+                res += QLatin1Char('+');
+            }
+            first = false;
+            if (const auto t = translate(token, DM_COLUMN, QT_COLUMN); !t.isEmpty()) {
+                res += t;
+            } else {
+                res += token;
+            }
+        }
     }
-    return QKeySequence::fromString(tmp.join(QLatin1String(", ")));
+    return QKeySequence::fromString(res);
 }

--- a/src/libdbusmenuqt/dbusmenushortcut_p.cpp
+++ b/src/libdbusmenuqt/dbusmenushortcut_p.cpp
@@ -21,16 +21,16 @@ struct Row {
     const char *one;
 };
 
-static constexpr Row table[] = {{"Meta", "Super"},
-                                {"Ctrl", "Control"},
-                                // Special cases for compatibility with libdbusmenu-glib which uses
-                                // "plus" for "+" and "minus" for "-".
-                                // cf https://bugs.launchpad.net/libdbusmenu-qt/+bug/712565
-                                {"+", "plus"},
-                                {"-", "minus"},
-                                {nullptr, nullptr}};
+static const Row table[] = {{"Meta", "Super"},
+                            {"Ctrl", "Control"},
+                            // Special cases for compatibility with libdbusmenu-glib which uses
+                            // "plus" for "+" and "minus" for "-".
+                            // cf https://bugs.launchpad.net/libdbusmenu-qt/+bug/712565
+                            {"+", "plus"},
+                            {"-", "minus"},
+                            {nullptr, nullptr}};
 
-static constexpr QLatin1StringView translate(QStringView token, int srcCol, int dstCol)
+static inline QLatin1StringView translate(QStringView token, int srcCol, int dstCol)
 {
     for (const Row *ptr = table; ptr->zero != nullptr; ++ptr) {
         const char *from = (srcCol == QT_COLUMN ? ptr->zero : ptr->one);


### PR DESCRIPTION
## Summary by Sourcery

Modernizza l’analisi e la serializzazione delle scorciatoie di DBusMenuShortcut per Qt6, migliorando le prestazioni e la robustezza nella gestione delle sequenze di tasti.

Miglioramenti:
- Sostituisce la tabella di traduzione delle scorciatoie e l’helper con `constexpr`/`QLatin1StringView` per una gestione delle stringhe più efficiente e moderna.
- Modifica la logica di tokenizzazione per usare `QStringTokenizer` con `Qt::SkipEmptyParts` ed evitare allocazioni inutili di `QString` durante l’analisi delle sequenze di tasti.
- Riscrive la serializzazione delle sequenze di tasti per costruire direttamente la stringa di risultato con capacità pre-allocata invece di passare attraverso `QStringLists` intermedi.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Modernize DBusMenuShortcut’s shortcut parsing and serialization for Qt6, improving performance and robustness of key sequence handling.

Enhancements:
- Switch shortcut translation table and helper to constexpr/QLatin1StringView for more efficient, modern string handling.
- Adjust tokenization logic to use QStringTokenizer with Qt::SkipEmptyParts and avoid unnecessary QString allocations when parsing key sequences.
- Rewrite key sequence serialization to build the result string directly with reserved capacity instead of going through intermediate QStringLists.

</details>