### PR TITLE
Modernize Qt6 code and improve menu search and scaling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project (material-decoration)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-add_definitions (-Wall -Werror)
+add_definitions (-Wall -Werror -DQT_USE_QSTRINGBUILDER)
 
 option(FORCE_X11 "Force compilation for X11 only" OFF)
 

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -54,8 +54,6 @@
 
 #include <utility>
 
-using namespace Qt::StringLiterals;
-
 static constexpr int MAX_SEARCH_RESULTS = 100;
 
 namespace Material
@@ -199,7 +197,7 @@ void AppMenuButtonGroup::setupSearchMenu()
 
     m_searchLineEdit->installEventFilter(this);
     m_searchLineEdit->setFocusPolicy(Qt::StrongFocus);
-    m_searchLineEdit->setPlaceholderText(i18nd("plasma_applet_org.kde.plasma.appmenu","Search")+u"…"_s);
+    m_searchLineEdit->setPlaceholderText(i18nd("plasma_applet_org.kde.plasma.appmenu","Search")+QStringLiteral("…"));
     m_searchLineEdit->setClearButtonEnabled(false);
 }
 
@@ -520,7 +518,7 @@ void AppMenuButtonGroup::updateAppMenuModel()
                 }
                 QAction *itemAction = actions.at(actionIdx++);
                 textButton->setAction(itemAction);
-                textButton->setText(QStringView(itemAction->text()).trimmed().toString());
+                textButton->setText(itemAction->text().trimmed());
                 // Skip items with empty labels (The first item in a Gtk app)
                 if (itemAction->text().isEmpty()) {
                     textButton->setEnabled(false);
@@ -540,7 +538,7 @@ void AppMenuButtonGroup::updateAppMenuModel()
             // Populate
             for (int i = 0; i < menuActionCount; ++i) {
                 QAction *itemAction = actions.at(i);
-                const QString itemLabel = QStringView(itemAction->text()).trimmed().toString();
+                const QString itemLabel = itemAction->text().trimmed();
 
                 TextButton *b = new TextButton(deco, i, this);
                 b->setText(itemLabel);
@@ -1036,7 +1034,7 @@ void AppMenuButtonGroup::filterMenu(const QString &text)
 
         if (text.isEmpty()) {
             m_searchLineEdit->setClearButtonEnabled(false);
-            m_searchLineEdit->setPlaceholderText(i18nd("plasma_applet_org.kde.plasma.appmenu", "Search") + u"…"_s);
+            m_searchLineEdit->setPlaceholderText(i18nd("plasma_applet_org.kde.plasma.appmenu", "Search") + QStringLiteral("…"));
             return;
         }
         m_searchLineEdit->setClearButtonEnabled(true);
@@ -1179,7 +1177,7 @@ QString AppMenuButtonGroup::getActionText(QAction *action) const
     if (it != m_actionTextCache.end()) {
         return it.value();
     }
-    const QString cleanedText = KLocalizedString::removeAcceleratorMarker(QStringView(rawText).trimmed().toString());
+    const QString cleanedText = KLocalizedString::removeAcceleratorMarker(rawText.trimmed());
     m_actionTextCache.insert(rawText, cleanedText);
     return cleanedText;
 }
@@ -1239,8 +1237,8 @@ void AppMenuButtonGroup::searchMenu(QMenu *menu, const QString &searchText, QLis
                 info.isEffectivelyEnabled = isCurrentEnabled && action->isEnabled();
 
                 currentPath.append(itemText);
-                info.path = currentPath.join(u" » "_s);
-                info.searchablePath = (currentPath.size() > 1) ? currentPath.mid(1).join(u" » "_s) : itemText;
+                info.path = currentPath.join(QStringLiteral(" » "));
+                info.searchablePath = (currentPath.size() > 1) ? currentPath.mid(1).join(QStringLiteral(" » ")) : itemText;
                 currentPath.removeLast();
 
                 results.append({action, info});

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -1212,6 +1212,9 @@ void AppMenuButtonGroup::searchMenu(QMenu *menu, const QString &searchText, QLis
     }
 
     for (QAction *action : menu->actions()) {
+        if (results.size() >= MAX_SEARCH_RESULTS) {
+            break;
+        }
         if (action->isSeparator()) {
             continue;
         }

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -54,6 +54,8 @@
 
 #include <utility>
 
+using namespace Qt::StringLiterals;
+
 static constexpr int MAX_SEARCH_RESULTS = 100;
 
 namespace Material
@@ -170,12 +172,12 @@ AppMenuButtonGroup::~AppMenuButtonGroup()
     if (m_searchMenu) {
         m_searchMenu->deleteLater();
     }
-    
-    // explicit destruction even 
+
+    // explicit destruction even
     // if it already is Qt::WA_DeleteOnClose,
-    // deal whit the corner-case in which the window 
+    // deal whit the corner-case in which the window
     // is closed while the m_overflowMenu is open
-    if (m_overflowMenu) { 
+    if (m_overflowMenu) {
         m_overflowMenu->deleteLater();
     }
 }
@@ -197,7 +199,7 @@ void AppMenuButtonGroup::setupSearchMenu()
 
     m_searchLineEdit->installEventFilter(this);
     m_searchLineEdit->setFocusPolicy(Qt::StrongFocus);
-    m_searchLineEdit->setPlaceholderText(i18nd("plasma_applet_org.kde.plasma.appmenu","Search")+QStringLiteral("…"));
+    m_searchLineEdit->setPlaceholderText(i18nd("plasma_applet_org.kde.plasma.appmenu","Search")+u"…"_s);
     m_searchLineEdit->setClearButtonEnabled(false);
 }
 
@@ -518,7 +520,7 @@ void AppMenuButtonGroup::updateAppMenuModel()
                 }
                 QAction *itemAction = actions.at(actionIdx++);
                 textButton->setAction(itemAction);
-                textButton->setText(itemAction->text().trimmed());
+                textButton->setText(QStringView(itemAction->text()).trimmed().toString());
                 // Skip items with empty labels (The first item in a Gtk app)
                 if (itemAction->text().isEmpty()) {
                     textButton->setEnabled(false);
@@ -538,7 +540,7 @@ void AppMenuButtonGroup::updateAppMenuModel()
             // Populate
             for (int i = 0; i < menuActionCount; ++i) {
                 QAction *itemAction = actions.at(i);
-                const QString itemLabel = itemAction->text().trimmed();
+                const QString itemLabel = QStringView(itemAction->text()).trimmed().toString();
 
                 TextButton *b = new TextButton(deco, i, this);
                 b->setText(itemLabel);
@@ -1002,7 +1004,7 @@ void AppMenuButtonGroup::onHitRight()
 void AppMenuButtonGroup::onShowingChanged(bool showing)
 {
     if (m_animationEnabled) {
-        QAbstractAnimation::Direction dir = showing ? QAbstractAnimation::Forward : QAbstractAnimation::Backward;
+        const QAbstractAnimation::Direction dir = showing ? QAbstractAnimation::Forward : QAbstractAnimation::Backward;
         if (m_animation->state() == QAbstractAnimation::Running && m_animation->direction() != dir) {
             m_animation->stop();
         }
@@ -1034,7 +1036,7 @@ void AppMenuButtonGroup::filterMenu(const QString &text)
 
         if (text.isEmpty()) {
             m_searchLineEdit->setClearButtonEnabled(false);
-            m_searchLineEdit->setPlaceholderText(i18nd("plasma_applet_org.kde.plasma.appmenu", "Search") + QStringLiteral("…"));
+            m_searchLineEdit->setPlaceholderText(i18nd("plasma_applet_org.kde.plasma.appmenu", "Search") + u"…"_s);
             return;
         }
         m_searchLineEdit->setClearButtonEnabled(true);
@@ -1086,7 +1088,7 @@ void AppMenuButtonGroup::filterMenu(const QString &text)
     }
 
     int resultCount = 0;
-    for (const SearchResult &result : results) {
+    for (const SearchResult &result : std::as_const(results)) {
         if (resultCount >= MAX_SEARCH_RESULTS) { // stop after 100 results
             break;
         }
@@ -1177,14 +1179,14 @@ QString AppMenuButtonGroup::getActionText(QAction *action) const
     if (it != m_actionTextCache.end()) {
         return it.value();
     }
-    const QString cleanedText = KLocalizedString::removeAcceleratorMarker(rawText.trimmed());
+    const QString cleanedText = KLocalizedString::removeAcceleratorMarker(QStringView(rawText).trimmed().toString());
     m_actionTextCache.insert(rawText, cleanedText);
     return cleanedText;
 }
 
 void AppMenuButtonGroup::searchMenu(QMenu *menu, const QString &searchText, QList<SearchResult> &results, QSet<QMenu *> &visited, bool ignoreTopLevel, bool ignoreSubMenus, QStringList &currentPath, bool isParentEnabled, bool parentMatched)
 {
-    if (!menu || visited.contains(menu)) {
+    if (results.size() >= MAX_SEARCH_RESULTS || !menu || visited.contains(menu)) {
         return;
     }
     visited.insert(menu);
@@ -1237,8 +1239,8 @@ void AppMenuButtonGroup::searchMenu(QMenu *menu, const QString &searchText, QLis
                 info.isEffectivelyEnabled = isCurrentEnabled && action->isEnabled();
 
                 currentPath.append(itemText);
-                info.path = currentPath.join(QStringLiteral(" » "));
-                info.searchablePath = (currentPath.size() > 1) ? currentPath.mid(1).join(QStringLiteral(" » ")) : itemText;
+                info.path = currentPath.join(u" » "_s);
+                info.searchablePath = (currentPath.size() > 1) ? currentPath.mid(1).join(u" » "_s) : itemText;
                 currentPath.removeLast();
 
                 results.append({action, info});

--- a/src/AppMenuButtonGroup.h
+++ b/src/AppMenuButtonGroup.h
@@ -83,18 +83,16 @@ public:
 
     void handleHoverMove(const QPointF &pos);
 
-public slots:
+public:
     void setHamburgerMenu(bool value);
     void updateAppMenuModel();
     void updateOverflow(QRectF availableRect);
     void updateShowing();
 
-private slots:
+private:
     void onMenuReadyForSearch();
     void triggerOverflow();
     void onMenuAboutToHide();
-
-private slots:
     void onHitLeft();
     void onHitRight();
     void onHasApplicationMenuChanged(bool hasMenu);

--- a/src/AppMenuModel.cc
+++ b/src/AppMenuModel.cc
@@ -73,7 +73,7 @@ AppMenuModel::AppMenuModel(QObject *parent)
     m_serviceWatcher->setConnection(QDBusConnection::sessionBus());
     // If our current DBus connection gets lost, close the menu
     // we'll select the new menu when the focus changes
-    connect(m_serviceWatcher, &QDBusServiceWatcher::serviceUnregistered, this, [this](const QString & serviceName) {
+    connect(m_serviceWatcher, &QDBusServiceWatcher::serviceUnregistered, this, [this](const QString &serviceName) {
         if (serviceName == m_serviceName) {
             setMenuAvailable(false);
             stopCaching();
@@ -90,13 +90,13 @@ AppMenuModel::AppMenuModel(QObject *parent)
     connect(this, &AppMenuModel::modelNeedsUpdate, this, [this] {
         if (!m_updatePending) {
             m_updatePending = true;
-            QMetaObject::invokeMethod(this, "update", Qt::QueuedConnection);
+            QMetaObject::invokeMethod(this, &AppMenuModel::update, Qt::QueuedConnection);
         }
     });
 
     m_staggerTimer = new QTimer(this);
     m_staggerTimer->setSingleShot(true);
-    m_staggerTimer->setInterval(8); 
+    m_staggerTimer->setInterval(8);
     connect(m_staggerTimer, &QTimer::timeout, this, &AppMenuModel::processNext);
 }
 
@@ -136,13 +136,13 @@ void AppMenuModel::updateApplicationMenu(const QString &serviceName, const QStri
     
     if (m_serviceName == serviceName && m_menuObjectPath == menuObjectPath) {
         if (m_importer) {
-            QMetaObject::invokeMethod(m_importer, "updateMenu", Qt::QueuedConnection);
+            QMetaObject::invokeMethod(m_importer.data(), qOverload<>(&DBusMenuImporter::updateMenu), Qt::QueuedConnection);
             return;
         }
     }
 
     m_serviceName = serviceName;
-    m_serviceWatcher->setWatchedServices(QStringList({m_serviceName}));
+    m_serviceWatcher->setWatchedServices({m_serviceName});
 
     m_menuObjectPath = menuObjectPath;
     m_menu = nullptr;
@@ -153,7 +153,7 @@ void AppMenuModel::updateApplicationMenu(const QString &serviceName, const QStri
     }
 
     m_importer = new KDBusMenuImporter(serviceName, menuObjectPath, this);
-    QMetaObject::invokeMethod(m_importer, "updateMenu", Qt::QueuedConnection);
+    QMetaObject::invokeMethod(m_importer.data(), qOverload<>(&DBusMenuImporter::updateMenu), Qt::QueuedConnection);
 
     connect(m_importer.data(), &DBusMenuImporter::menuUpdated, this, &AppMenuModel::onMenuUpdated);
 
@@ -178,8 +178,7 @@ void AppMenuModel::onMenuUpdated(QMenu *menu)
         }
 
         // Connect signals for top-level actions to update the model when they change.
-        const auto actions = m_menu->actions();
-        for (QAction *a : actions) {
+        for (QAction *a : m_menu->actions()) {
             connect(a, &QAction::destroyed, this, &AppMenuModel::modelNeedsUpdate, Qt::UniqueConnection);
             connect(a, &QAction::changed, this, &AppMenuModel::onActionChanged, Qt::UniqueConnection);
         }
@@ -259,8 +258,7 @@ void AppMenuModel::registerSubMenus(QMenu *menu)
     if (!menu) {
         return;
     }
-    const auto actions = menu->actions();
-    for (QAction *a : actions) {
+    for (QAction *a : menu->actions()) {
         if (auto subMenu = a->menu()) {
             if (!m_seenMenus.contains(subMenu)) {
                 m_seenMenus.insert(subMenu);

--- a/src/AppMenuModel.h
+++ b/src/AppMenuModel.h
@@ -51,7 +51,7 @@ public:
 
     QMenu *menu() const;
 
-private Q_SLOTS:
+private:
     void update();
 
 signals:
@@ -61,14 +61,12 @@ signals:
     void menuReadyForSearch();
     void subMenuReady(QMenu *menu);
 
-public Q_SLOTS:
+public:
     void loadSubMenu(QMenu *menu);
     void stopCaching();
-
-public Q_SLOTS:
     void startDeepCaching();
 
-private Q_SLOTS:
+private:
     void onMenuUpdated(QMenu *menu);
     void onActionChanged();
     void processNext();

--- a/src/Button.cc
+++ b/src/Button.cc
@@ -122,11 +122,7 @@ Button::Button(KDecoration3::DecorationButtonType type, Decoration *decoration, 
     });
     
    
-    connect(this, &Button::hoveredChanged, this,
-        [this](bool hovered) {
-            updateAnimationState(hovered);
-            UPDATE_GEOM();
-        });
+    connect(this, &Button::hoveredChanged, this, &Button::updateAnimationState);
 
     
     connect(this, &Button::transitionValueChanged, this, [this]() {
@@ -727,7 +723,7 @@ void Button::setVertPadding(int value)
 void Button::updateAnimationState(bool hovered)
 {
     if (m_animationEnabled) {
-        QAbstractAnimation::Direction dir = hovered ? QAbstractAnimation::Forward : QAbstractAnimation::Backward;
+        const QAbstractAnimation::Direction dir = hovered ? QAbstractAnimation::Forward : QAbstractAnimation::Backward;
         if (m_animation->state() == QAbstractAnimation::Running && m_animation->direction() != dir) {
             m_animation->stop();
         }
@@ -738,6 +734,7 @@ void Button::updateAnimationState(bool hovered)
     } else {
         setTransitionValue(1);
     }
+    UPDATE_GEOM();
 }
 
 void Button::forceUnpress()

--- a/src/Button.h
+++ b/src/Button.h
@@ -81,7 +81,7 @@ public:
     void setIsLeftmost(bool isLeftmost);
     void setIsRightmost(bool isRightmost);
 
-private Q_SLOTS:
+private:
     void updateAnimationState(bool hovered);
     void handleHoldTimeout();
 

--- a/src/Decoration.cc
+++ b/src/Decoration.cc
@@ -45,6 +45,7 @@
 // Qt
 #include <QApplication>
 #include <QDebug>
+#include <QtMath>
 #include <QHoverEvent>
 #include <QMouseEvent>
 #include <QPainter>
@@ -308,7 +309,7 @@ bool Decoration::init()
     connect(decoratedClient, &KDecoration3::DecoratedWindow::activeChanged,
         this, &Decoration::updateCornerRadiusAndOutline);
     connect(decoratedClient, &KDecoration3::DecoratedWindow::activeChanged,
-        this, static_cast<void (Decoration::*)()>(&Decoration::update));
+        this, qOverload<>(&Decoration::update));
 
     connect(decoratedClient, &KDecoration3::DecoratedWindow::adjacentScreenEdgesChanged,
             this, &Decoration::updateBordersCornersBlurShadow);
@@ -972,10 +973,11 @@ QFont Decoration::menuFont() const
 qreal Decoration::getMenuTextWidth(const QString &text, bool showMnemonic) const
 {
     const QFontMetricsF fontMetrics(menuFont());
-    int flags = showMnemonic ? Qt::TextShowMnemonic : Qt::TextHideMnemonic;
+    const int flags = showMnemonic ? Qt::TextShowMnemonic : Qt::TextHideMnemonic;
     // Use an unconstrained bounding rect to get the ideal width.
     const QRectF boundingRect = fontMetrics.boundingRect(QRectF(), flags, text);
-    return boundingRect.width();
+    const qreal scale = window()->nextScale();
+    return qCeil(boundingRect.width() * scale) / scale;
 }
 
 bool Decoration::isMenuOnRight() const

--- a/src/Decoration.cc
+++ b/src/Decoration.cc
@@ -354,7 +354,7 @@ bool Decoration::init()
                  QStringLiteral("tabletModeChanged"),
                  QStringLiteral("b"),
                  this,
-                 SLOT(onTabletModeChanged(bool)));
+                 SLOT(onTabletModeChanged_slot(bool)));
 
     auto message = QDBusMessage::createMethodCall(QStringLiteral("org.kde.KWin"),
                                                   QStringLiteral("/org/kde/KWin"),

--- a/src/Decoration.cc
+++ b/src/Decoration.cc
@@ -354,7 +354,7 @@ bool Decoration::init()
                  QStringLiteral("tabletModeChanged"),
                  QStringLiteral("b"),
                  this,
-                 SLOT(onTabletModeChanged_slot(bool)));
+                 SLOT(onTabletModeChanged(bool)));
 
     auto message = QDBusMessage::createMethodCall(QStringLiteral("org.kde.KWin"),
                                                   QStringLiteral("/org/kde/KWin"),

--- a/src/Decoration.h
+++ b/src/Decoration.h
@@ -62,6 +62,11 @@ public slots:
     bool init() override;
     void reconfigure();
 
+private slots:
+#if HAVE_WAYLAND
+    void onTabletModeChanged(bool mode);
+#endif
+
 protected:
     void hoverEnterEvent(QHoverEvent *event) override;
     void hoverMoveEvent(QHoverEvent *event) override;
@@ -74,9 +79,6 @@ private:
     void onSectionUnderMouseChanged(const Qt::WindowFrameSection value);
     void onSizeChanged();
     void onNextScaleChanged();
-#if HAVE_WAYLAND
-    void onTabletModeChanged(bool mode);
-#endif
 
 private:
     QRectF titleBarRect() const;

--- a/src/Decoration.h
+++ b/src/Decoration.h
@@ -70,7 +70,7 @@ protected:
     void mouseReleaseEvent(QMouseEvent *event) override;
     void wheelEvent(QWheelEvent *event) override;
 
-private slots:
+private:
     void onSectionUnderMouseChanged(const Qt::WindowFrameSection value);
     void onSizeChanged();
     void onNextScaleChanged();

--- a/src/kcm/kcm.cpp
+++ b/src/kcm/kcm.cpp
@@ -21,9 +21,9 @@ K_PLUGIN_CLASS_WITH_JSON(MaterialDecorationKCM, "materialdecoration_kcm.json")
 
 MaterialDecorationKCM::MaterialDecorationKCM(QObject *parent, const KPluginMetaData &data)
     : KCModule(qobject_cast<QWidget*>(parent), data)
+    , m_ui(std::make_unique<Ui::Config>())
+    , m_settings(std::make_unique<Material::InternalSettings>())
 {
-    m_settings = new Material::InternalSettings();
-    m_ui = new Ui::Config();
     m_ui->setupUi(widget());
 
     // Populate combo boxes
@@ -53,11 +53,7 @@ MaterialDecorationKCM::MaterialDecorationKCM(QObject *parent, const KPluginMetaD
     setupConnections();
 }
 
-MaterialDecorationKCM::~MaterialDecorationKCM()
-{
-    delete m_settings;
-    delete m_ui;
-}
+MaterialDecorationKCM::~MaterialDecorationKCM() = default;
 
 void MaterialDecorationKCM::setupConnections()
 {
@@ -81,9 +77,9 @@ void MaterialDecorationKCM::setupConnections()
         }
     });
     connect(m_ui->kcfg_SearchEnabled, &QCheckBox::toggled, this, &MaterialDecorationKCM::updateChanged);
-    connect(m_ui->kcfg_SearchEnabled, &QCheckBox::toggled, m_ui->kcfg_ShowDisabledActions, &QCheckBox::setEnabled);
-    connect(m_ui->kcfg_SearchEnabled, &QCheckBox::toggled, m_ui->kcfg_SearchIgnoreTopLevel, &QCheckBox::setEnabled);
-    connect(m_ui->kcfg_SearchEnabled, &QCheckBox::toggled, m_ui->kcfg_SearchIgnoreSubMenus, &QCheckBox::setEnabled);
+    connect(m_ui->kcfg_SearchEnabled, &QCheckBox::toggled, m_ui->kcfg_ShowDisabledActions, &QWidget::setEnabled);
+    connect(m_ui->kcfg_SearchEnabled, &QCheckBox::toggled, m_ui->kcfg_SearchIgnoreTopLevel, &QWidget::setEnabled);
+    connect(m_ui->kcfg_SearchEnabled, &QCheckBox::toggled, m_ui->kcfg_SearchIgnoreSubMenus, &QWidget::setEnabled);
 
     connect(m_ui->kcfg_SearchIgnoreSubMenus, &QCheckBox::toggled, this, [this](bool checked) {
         if (checked) {
@@ -118,13 +114,13 @@ void MaterialDecorationKCM::setupConnections()
     connect(m_ui->kcfg_AnimationsDuration, &QSpinBox::valueChanged, this, &MaterialDecorationKCM::updateChanged);
     connect(m_ui->kcfg_BottomCorners, &QCheckBox::toggled, this, &MaterialDecorationKCM::updateChanged);
     connect(m_ui->kcfg_HideCaptionWhenLimitedSpace, &QCheckBox::toggled, this, &MaterialDecorationKCM::updateChanged);
-    connect(m_ui->kcfg_HideCaptionWhenLimitedSpace, &QCheckBox::toggled, m_ui->kcfg_MinWidthForCaption, &QSpinBox::setEnabled);
-    connect(m_ui->kcfg_HideCaptionWhenLimitedSpace, &QCheckBox::toggled, m_ui->label_minWidthForCaption, &QLabel::setEnabled);
+    connect(m_ui->kcfg_HideCaptionWhenLimitedSpace, &QCheckBox::toggled, m_ui->kcfg_MinWidthForCaption, &QWidget::setEnabled);
+    connect(m_ui->kcfg_HideCaptionWhenLimitedSpace, &QCheckBox::toggled, m_ui->label_minWidthForCaption, &QWidget::setEnabled);
     connect(m_ui->kcfg_MinWidthForCaption, qOverload<int>(&QSpinBox::valueChanged), this, &MaterialDecorationKCM::updateChanged);
     connect(m_ui->kcfg_ShowCaptionOnHover, &QCheckBox::toggled, this, &MaterialDecorationKCM::updateChanged);
 
     connect(m_ui->kcfg_LongPressEnabled, &QCheckBox::toggled, this, &MaterialDecorationKCM::updateChanged);
-    connect(m_ui->kcfg_LongPressEnabled, &QCheckBox::toggled, m_ui->kcfg_LongPressDuration, &QSpinBox::setEnabled);
+    connect(m_ui->kcfg_LongPressEnabled, &QCheckBox::toggled, m_ui->kcfg_LongPressDuration, &QWidget::setEnabled);
     connect(m_ui->kcfg_LongPressDuration, qOverload<int>(&QSpinBox::valueChanged), this, &MaterialDecorationKCM::updateChanged);
 
     connect(m_ui->kcfg_DragFromButtonsEnabled, &QCheckBox::toggled, this, &MaterialDecorationKCM::updateChanged);

--- a/src/kcm/kcm.h
+++ b/src/kcm/kcm.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <KCModule>
+#include <memory>
 
 class KConfig;
 class QWidget;
@@ -28,12 +29,12 @@ public:
     void save() override;
     void defaults() override;
 
-private Q_SLOTS:
+private:
     void updateChanged();
 
 private:
-    Ui::Config *m_ui = nullptr;
-    Material::InternalSettings *m_settings = nullptr;
+    std::unique_ptr<Ui::Config> m_ui;
+    std::unique_ptr<Material::InternalSettings> m_settings;
 
     void setupConnections();
     bool isChanged() const;


### PR DESCRIPTION
## Summary by Sourcery

Modernizzare il codice di decorazione del materiale basato su Qt, affinare il comportamento di ricerca nel menu dell’app e migliorare la scalatura del testo dei menu e la configurazione di build.

Nuove funzionalità:
- Limitare il numero massimo di risultati della ricerca nel menu dell’app per evitare elaborazioni eccessive.
- Scalare le larghezze del testo dei menu calcolate in base al fattore di scala della finestra per un rendering più nitido a diverse scale.

Correzioni di bug:
- Garantire che i menu di overflow e ricerca vengano esplicitamente distrutti in un caso limite in cui la finestra si chiude mentre i menu sono aperti.
- Evitare ricerche troppo profonde interrompendo la traversata dei menu non appena viene raggiunta la soglia massima di risultati della ricerca.

Miglioramenti:
- Rifattorizzare la gestione dell’interfaccia utente e delle impostazioni nel KCM per utilizzare smart pointer e distruttori di default.
- Aggiornare le connessioni signal-slot e le invocazioni di metodo per usare puntatori a funzioni tipizzate e iterazione const-corretta, migliorando la compatibilità con Qt6.
- Riorganizzare slot e specificatori di accesso in diverse classi per chiarire l’API pubblica rispetto agli helper interni e allinearsi ai pattern moderni di Qt/C++.
- Regolare la gestione della direzione delle animazioni nei gruppi di pulsanti e nelle classi dei pulsanti per usare variabili con ambito const, rendendo la logica più chiara.

Build:
- Abilitare l’ottimizzazione QString builder tramite la definizione QT_USE_QSTRINGBUILDER nella configurazione CMake.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Modernize the Qt-based material decoration code, refine app menu search behavior, and improve menu text scaling and build configuration.

New Features:
- Limit app menu search results to a maximum count to avoid excessive processing.
- Scale computed menu text widths according to the window scale factor for sharper rendering at different scales.

Bug Fixes:
- Ensure overflow and search menus are explicitly destroyed in a corner case where the window closes while menus are open.
- Prevent over-searching by stopping deep menu traversal once the maximum search results threshold is reached.

Enhancements:
- Refactor UI and settings management in the KCM to use smart pointers and defaulted destructors.
- Update signal-slot connections and method invocations to use typed function pointers and const-correct iteration for better Qt6 compatibility.
- Reorganize slots and access specifiers in several classes to clarify public API versus internal helpers and align with modern Qt/Cpp patterns.
- Adjust animation direction handling in button group and button classes to use const-scoped variables for clearer logic.

Build:
- Enable QString builder optimization via the QT_USE_QSTRINGBUILDER definition in the CMake configuration.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Modernizzare il codice di decorazione del materiale basato su Qt, affinare il comportamento di ricerca nel menu dell’app e migliorare la scalatura del testo dei menu e la configurazione di build.

Nuove funzionalità:
- Limitare il numero massimo di risultati della ricerca nel menu dell’app per evitare elaborazioni eccessive.
- Scalare le larghezze del testo dei menu calcolate in base al fattore di scala della finestra per un rendering più nitido a diverse scale.

Correzioni di bug:
- Garantire che i menu di overflow e ricerca vengano esplicitamente distrutti in un caso limite in cui la finestra si chiude mentre i menu sono aperti.
- Evitare ricerche troppo profonde interrompendo la traversata dei menu non appena viene raggiunta la soglia massima di risultati della ricerca.

Miglioramenti:
- Rifattorizzare la gestione dell’interfaccia utente e delle impostazioni nel KCM per utilizzare smart pointer e distruttori di default.
- Aggiornare le connessioni signal-slot e le invocazioni di metodo per usare puntatori a funzioni tipizzate e iterazione const-corretta, migliorando la compatibilità con Qt6.
- Riorganizzare slot e specificatori di accesso in diverse classi per chiarire l’API pubblica rispetto agli helper interni e allinearsi ai pattern moderni di Qt/C++.
- Regolare la gestione della direzione delle animazioni nei gruppi di pulsanti e nelle classi dei pulsanti per usare variabili con ambito const, rendendo la logica più chiara.

Build:
- Abilitare l’ottimizzazione QString builder tramite la definizione QT_USE_QSTRINGBUILDER nella configurazione CMake.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Modernize the Qt-based material decoration code, refine app menu search behavior, and improve menu text scaling and build configuration.

New Features:
- Limit app menu search results to a maximum count to avoid excessive processing.
- Scale computed menu text widths according to the window scale factor for sharper rendering at different scales.

Bug Fixes:
- Ensure overflow and search menus are explicitly destroyed in a corner case where the window closes while menus are open.
- Prevent over-searching by stopping deep menu traversal once the maximum search results threshold is reached.

Enhancements:
- Refactor UI and settings management in the KCM to use smart pointers and defaulted destructors.
- Update signal-slot connections and method invocations to use typed function pointers and const-correct iteration for better Qt6 compatibility.
- Reorganize slots and access specifiers in several classes to clarify public API versus internal helpers and align with modern Qt/Cpp patterns.
- Adjust animation direction handling in button group and button classes to use const-scoped variables for clearer logic.

Build:
- Enable QString builder optimization via the QT_USE_QSTRINGBUILDER definition in the CMake configuration.

</details>

</details>