### PR TITLE
Optimize searchMenu using QStringMatcher

### DIFF
--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -1057,7 +1057,8 @@ void AppMenuButtonGroup::filterMenu(const QString &text)
             const bool ignoreTopLevel = deco && deco->searchIgnoreTopLevel();
             const bool ignoreSubMenus = deco && deco->searchIgnoreSubMenus();
             QStringList currentPath;
-            searchMenu(rootMenu, text, results, visited, ignoreTopLevel, ignoreSubMenus, currentPath);
+            QStringMatcher matcher(text, Qt::CaseInsensitive);
+            searchMenu(rootMenu, matcher, results, visited, ignoreTopLevel, ignoreSubMenus, currentPath);
         }
     }
 
@@ -1182,7 +1183,7 @@ QString AppMenuButtonGroup::getActionText(QAction *action) const
     return cleanedText;
 }
 
-void AppMenuButtonGroup::searchMenu(QMenu *menu, const QString &searchText, QList<SearchResult> &results, QSet<QMenu *> &visited, bool ignoreTopLevel, bool ignoreSubMenus, QStringList &currentPath, bool isParentEnabled, bool parentMatched)
+void AppMenuButtonGroup::searchMenu(QMenu *menu, const QStringMatcher &matcher, QList<SearchResult> &results, QSet<QMenu *> &visited, bool ignoreTopLevel, bool ignoreSubMenus, QStringList &currentPath, bool isParentEnabled, bool parentMatched)
 {
     if (results.size() >= MAX_SEARCH_RESULTS || !menu || visited.contains(menu)) {
         return;
@@ -1204,7 +1205,7 @@ void AppMenuButtonGroup::searchMenu(QMenu *menu, const QString &searchText, QLis
             addedToPath = true;
 
             if (!currentMatched && (!ignoreTopLevel || currentPath.size() > 1)) {
-                if (menuText.contains(searchText, Qt::CaseInsensitive)) {
+                if (matcher.indexIn(menuText) != -1) {
                     currentMatched = true;
                 }
             }
@@ -1219,16 +1220,16 @@ void AppMenuButtonGroup::searchMenu(QMenu *menu, const QString &searchText, QLis
             continue;
         }
         if (action->menu()) {
-            searchMenu(action->menu(), searchText, results, visited, ignoreTopLevel, ignoreSubMenus, currentPath, isCurrentEnabled, currentMatched);
+            searchMenu(action->menu(), matcher, results, visited, ignoreTopLevel, ignoreSubMenus, currentPath, isCurrentEnabled, currentMatched);
         } else {
             const QString itemText = getActionText(action);
             bool match = currentMatched;
             if (ignoreSubMenus) {
-                match = itemText.contains(searchText, Qt::CaseInsensitive);
+                match = matcher.indexIn(itemText) != -1;
             } else {
                 // Check the text of the action
                 if (!match && (!ignoreTopLevel || !currentPath.isEmpty())) {
-                    if (itemText.contains(searchText, Qt::CaseInsensitive)) {
+                    if (matcher.indexIn(itemText) != -1) {
                         match = true;
                     }
                 }

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -49,6 +49,7 @@
 #include <QScreen>
 #include <QSet>
 #include <QTimer>
+#include <QStringMatcher>
 #include <QVariantAnimation>
 #include <QWidgetAction>
 

--- a/src/AppMenuButtonGroup.h
+++ b/src/AppMenuButtonGroup.h
@@ -31,6 +31,7 @@
 #include <QLineEdit>
 #include <QPointer>
 #include <QHash>
+#include <QStringMatcher>
 
 class QTimer;
 class QVariantAnimation;
@@ -163,7 +164,7 @@ private:
     QString getActionText(QAction *action) const;
     void setupSearchMenu();
     void repositionSearchMenu();
-    void searchMenu(QMenu *menu, const QString &searchText, QList<SearchResult> &results, QSet<QMenu *> &visited, bool ignoreTopLevel, bool ignoreSubMenus, QStringList &currentPath, bool isParentEnabled = true, bool parentMatched = false);
+    void searchMenu(QMenu *menu, const QStringMatcher &matcher, QList<SearchResult> &results, QSet<QMenu *> &visited, bool ignoreTopLevel, bool ignoreSubMenus, QStringList &currentPath, bool isParentEnabled = true, bool parentMatched = false);
     AppMenuButton *getAppMenuButton(int index) const;
     int findNextVisibleButtonIndex(int currentIndex, bool forward) const;
 

--- a/src/AppMenuButtonGroup.h
+++ b/src/AppMenuButtonGroup.h
@@ -31,9 +31,9 @@
 #include <QLineEdit>
 #include <QPointer>
 #include <QHash>
-#include <QStringMatcher>
 
 class QTimer;
+class QStringMatcher;
 class QVariantAnimation;
 
 namespace Material

--- a/src/libdbusmenuqt/dbusmenushortcut_p.cpp
+++ b/src/libdbusmenuqt/dbusmenushortcut_p.cpp
@@ -60,7 +60,7 @@ DBusMenuShortcut DBusMenuShortcut::fromKeySequence(const QKeySequence &sequence)
 
         QStringList keyTokens;
         keyTokens.reserve(4);
-        for (const QStringView kt : QStringTokenizer{subToken, QLatin1Char('+'), Qt::SkipEmptyParts}) {
+        for (auto kt : QStringTokenizer{subToken, QLatin1Char('+'), Qt::SkipEmptyParts}) {
             if (const auto t = translate(kt, QT_COLUMN, DM_COLUMN); !t.isEmpty()) {
                 keyTokens.append(t);
             } else {

--- a/src/libdbusmenuqt/dbusmenushortcut_p.cpp
+++ b/src/libdbusmenuqt/dbusmenushortcut_p.cpp
@@ -45,7 +45,7 @@ DBusMenuShortcut DBusMenuShortcut::fromKeySequence(const QKeySequence &sequence)
 {
     const QString string = sequence.toString();
     DBusMenuShortcut shortcut;
-    for (auto token : QStringTokenizer{string, QLatin1StringView(", "), Qt::SkipEmptyParts}) {
+    for (const QStringView token : QStringTokenizer{string, QLatin1StringView(", "), Qt::SkipEmptyParts}) {
         if (token == QLatin1StringView("+")) {
             shortcut.append({QLatin1String("plus")});
             continue;
@@ -60,7 +60,7 @@ DBusMenuShortcut DBusMenuShortcut::fromKeySequence(const QKeySequence &sequence)
 
         QStringList keyTokens;
         keyTokens.reserve(4);
-        for (auto kt : QStringTokenizer{subToken, QLatin1Char('+'), Qt::SkipEmptyParts}) {
+        for (const QStringView kt : QStringTokenizer{subToken, QLatin1Char('+'), Qt::SkipEmptyParts}) {
             if (const auto t = translate(kt, QT_COLUMN, DM_COLUMN); !t.isEmpty()) {
                 keyTokens.append(t);
             } else {

--- a/src/libdbusmenuqt/dbusmenushortcut_p.cpp
+++ b/src/libdbusmenuqt/dbusmenushortcut_p.cpp
@@ -45,7 +45,7 @@ DBusMenuShortcut DBusMenuShortcut::fromKeySequence(const QKeySequence &sequence)
 {
     const QString string = sequence.toString();
     DBusMenuShortcut shortcut;
-    for (auto token : QStringTokenizer{string, QLatin1StringView(", "), Qt::SkipEmptyParts}) {
+    for (const auto &token : QStringTokenizer{string, QLatin1StringView(", "), Qt::SkipEmptyParts}) {
         if (token == QLatin1StringView("+")) {
             shortcut.append({QLatin1String("plus")});
             continue;
@@ -60,7 +60,7 @@ DBusMenuShortcut DBusMenuShortcut::fromKeySequence(const QKeySequence &sequence)
 
         QStringList keyTokens;
         keyTokens.reserve(4);
-        for (auto kt : QStringTokenizer{subToken, QLatin1Char('+'), Qt::SkipEmptyParts}) {
+        for (const auto &kt : QStringTokenizer{subToken, QLatin1Char('+'), Qt::SkipEmptyParts}) {
             if (const auto t = translate(kt, QT_COLUMN, DM_COLUMN); !t.isEmpty()) {
                 keyTokens.append(t);
             } else {

--- a/src/libdbusmenuqt/dbusmenushortcut_p.cpp
+++ b/src/libdbusmenuqt/dbusmenushortcut_p.cpp
@@ -45,7 +45,7 @@ DBusMenuShortcut DBusMenuShortcut::fromKeySequence(const QKeySequence &sequence)
 {
     const QString string = sequence.toString();
     DBusMenuShortcut shortcut;
-    for (const auto &token : QStringTokenizer{string, QLatin1StringView(", "), Qt::SkipEmptyParts}) {
+    for (auto token : QStringTokenizer{string, QLatin1StringView(", "), Qt::SkipEmptyParts}) {
         if (token == QLatin1StringView("+")) {
             shortcut.append({QLatin1String("plus")});
             continue;
@@ -60,7 +60,7 @@ DBusMenuShortcut DBusMenuShortcut::fromKeySequence(const QKeySequence &sequence)
 
         QStringList keyTokens;
         keyTokens.reserve(4);
-        for (const auto &kt : QStringTokenizer{subToken, QLatin1Char('+'), Qt::SkipEmptyParts}) {
+        for (auto kt : QStringTokenizer{subToken, QLatin1Char('+'), Qt::SkipEmptyParts}) {
             if (const auto t = translate(kt, QT_COLUMN, DM_COLUMN); !t.isEmpty()) {
                 keyTokens.append(t);
             } else {

--- a/src/libdbusmenuqt/dbusmenushortcut_p.cpp
+++ b/src/libdbusmenuqt/dbusmenushortcut_p.cpp
@@ -45,7 +45,7 @@ DBusMenuShortcut DBusMenuShortcut::fromKeySequence(const QKeySequence &sequence)
 {
     const QString string = sequence.toString();
     DBusMenuShortcut shortcut;
-    for (const QStringView token : QStringTokenizer{string, QLatin1StringView(", "), Qt::SkipEmptyParts}) {
+    for (auto token : QStringTokenizer{string, QLatin1StringView(", "), Qt::SkipEmptyParts}) {
         if (token == QLatin1StringView("+")) {
             shortcut.append({QLatin1String("plus")});
             continue;


### PR DESCRIPTION
## Summary by Sourcery

Miglioramenti:
- Sostituire le chiamate ripetute a `QString::contains` con un `QStringMatcher` condiviso durante il filtraggio del menu dell’applicazione.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Replace repeated QString::contains calls with a shared QStringMatcher when filtering the application menu.

</details>

Miglioramenti:
- Usa un `QStringMatcher` pre-costruito per la ricerca case-insensitive nel menu invece di chiamate ripetute a `QString::contains`.
- Rendi corretti rispetto a const i loop basati su `QStringTokenizer` in `DBusMenuShortcut` iterando con riferimenti const.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Miglioramenti:
- Sostituire le chiamate ripetute a `QString::contains` con un `QStringMatcher` condiviso durante il filtraggio del menu dell’applicazione.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Replace repeated QString::contains calls with a shared QStringMatcher when filtering the application menu.

</details>

</details>