### PR TITLE
Make the plugin builded on Wayland-only (e.g. from chaotic-aur) working also for X11

### DIFF
--- a/src/Decoration.cc
+++ b/src/Decoration.cc
@@ -1416,22 +1416,21 @@ void Decoration::onSpacingChanged()
 
 void Decoration::onTabletModeChanged(bool mode)
 {
-    if (KWindowSystem::isPlatformWayland()) {
 #if HAVE_WAYLAND
-    if (m_tabletMode == mode) {
+    if (KWindowSystem::isPlatformWayland()) {
+        if (m_tabletMode == mode) {
+            return;
+        }
+        m_tabletMode = mode;
+        updateBordersCornersBlurShadow();
+        updateResizeBorders();
+        updateTitleBar();
+        updateButtonsGeometryDelayed();
+        update();
         return;
     }
-    m_tabletMode = mode;
-    updateBordersCornersBlurShadow();
-    updateResizeBorders();
-    updateTitleBar();
-    updateButtonsGeometryDelayed();
-    update();
 #endif
-    } else {
-        Q_UNUSED(mode);
-        return;
-    }    
+    Q_UNUSED(mode);
 }
 
 

--- a/src/Decoration.cc
+++ b/src/Decoration.cc
@@ -307,13 +307,7 @@ bool Decoration::init()
     
     connect(this, &KDecoration3::Decoration::bordersChanged, 
             this, &Decoration::updateTitleBar);
-    
-    
-
-    
-    
-    
-    
+     
     updateColors();
     updateBordersCornersBlurShadow();
     updateResizeBorders();
@@ -335,27 +329,29 @@ bool Decoration::init()
                  SLOT(reconfigure()));
 
 #if HAVE_WAYLAND
-    dbus.connect(QStringLiteral("org.kde.KWin"),
-                 QStringLiteral("/org/kde/KWin"),
-                 QStringLiteral("org.kde.KWin.TabletModeManager"),
-                 QStringLiteral("tabletModeChanged"),
-                 QStringLiteral("b"),
-                 this,
-                 SLOT(onTabletModeChanged(bool)));
-
-    auto message = QDBusMessage::createMethodCall(QStringLiteral("org.kde.KWin"),
-                                                  QStringLiteral("/org/kde/KWin"),
-                                                  QStringLiteral("org.freedesktop.DBus.Properties"),
-                                                  QStringLiteral("Get"));
-    message.setArguments({QStringLiteral("org.kde.KWin.TabletModeManager"), QStringLiteral("tabletMode")});
-    auto *call = new QDBusPendingCallWatcher(dbus.asyncCall(message), this);
-    connect(call, &QDBusPendingCallWatcher::finished, this, [this, call]() {
-        QDBusPendingReply<QDBusVariant> reply = *call;
-        if (!reply.isError()) {
-            onTabletModeChanged(reply.value().variant().toBool());
-        }
-        call->deleteLater();
-    });
+    if (KWindowSystem::isPlatformX11()) {
+        dbus.connect(QStringLiteral("org.kde.KWin"),
+                     QStringLiteral("/org/kde/KWin"),
+                     QStringLiteral("org.kde.KWin.TabletModeManager"),
+                     QStringLiteral("tabletModeChanged"),
+                     QStringLiteral("b"),
+                     this,
+                     SLOT(onTabletModeChanged(bool)));
+        
+        auto message = QDBusMessage::createMethodCall(QStringLiteral("org.kde.KWin"),
+                                                      QStringLiteral("/org/kde/KWin"),
+                                                      QStringLiteral("org.freedesktop.DBus.Properties"),
+                                                      QStringLiteral("Get"));
+        message.setArguments({QStringLiteral("org.kde.KWin.TabletModeManager"), QStringLiteral("tabletMode")});
+        auto *call = new QDBusPendingCallWatcher(dbus.asyncCall(message), this);
+        connect(call, &QDBusPendingCallWatcher::finished, this, [this, call]() {
+            QDBusPendingReply<QDBusVariant> reply = *call;
+            if (!reply.isError()) {
+                onTabletModeChanged(reply.value().variant().toBool());
+            }
+            call->deleteLater();
+        });
+    }
 #endif
 
     // Window Decoration KCM
@@ -1420,6 +1416,10 @@ void Decoration::onSpacingChanged()
 #if HAVE_WAYLAND
 void Decoration::onTabletModeChanged(bool mode)
 {
+    if (KWindowSystem::isPlatformX11()) {
+        return;
+    }
+    
     if (m_tabletMode == mode) {
         return;
     }

--- a/src/Decoration.cc
+++ b/src/Decoration.cc
@@ -973,12 +973,12 @@ bool Decoration::isMenuOnRight() const
 
 QPoint Decoration::windowPos() const
 {
-#if HAVE_X11
-    if (const auto *p = parent()) {
-        return p->property("clientGeometry").toRect().topLeft();
-    }
-#endif
-
+    if (KWindowSystem::isPlatformX11()) {
+        if (const auto *p = parent()) {
+            return p->property("clientGeometry").toRect().topLeft();
+        }
+    }    
+    
     return QPoint(0, 0);
 }
 

--- a/src/Decoration.cc
+++ b/src/Decoration.cc
@@ -329,7 +329,7 @@ bool Decoration::init()
                  SLOT(reconfigure()));
 
 #if HAVE_WAYLAND
-    if (KWindowSystem::isPlatformX11()) {
+    if (KWindowSystem::isPlatformWayland()) {
         dbus.connect(QStringLiteral("org.kde.KWin"),
                      QStringLiteral("/org/kde/KWin"),
                      QStringLiteral("org.kde.KWin.TabletModeManager"),

--- a/src/Decoration.cc
+++ b/src/Decoration.cc
@@ -1416,9 +1416,7 @@ void Decoration::onSpacingChanged()
 
 void Decoration::onTabletModeChanged(bool mode)
 {
-    if (KWindowSystem::isPlatformX11()) {
-        return;
-    }
+    if (KWindowSystem::isPlatformWayland()) {
 #if HAVE_WAYLAND
     if (m_tabletMode == mode) {
         return;
@@ -1430,6 +1428,10 @@ void Decoration::onTabletModeChanged(bool mode)
     updateButtonsGeometryDelayed();
     update();
 #endif
+    } else {
+        Q_UNUSED(mode);
+        return;
+    }    
 }
 
 

--- a/src/Decoration.cc
+++ b/src/Decoration.cc
@@ -1413,13 +1413,13 @@ void Decoration::onSpacingChanged()
     updateButtonsGeometryDelayed();
 }
 
-#if HAVE_WAYLAND
+
 void Decoration::onTabletModeChanged(bool mode)
 {
     if (KWindowSystem::isPlatformX11()) {
         return;
     }
-    
+#if HAVE_WAYLAND
     if (m_tabletMode == mode) {
         return;
     }
@@ -1429,7 +1429,8 @@ void Decoration::onTabletModeChanged(bool mode)
     updateTitleBar();
     updateButtonsGeometryDelayed();
     update();
-}
 #endif
+}
+
 
 } // namespace Material

--- a/src/Decoration.h
+++ b/src/Decoration.h
@@ -63,9 +63,7 @@ public slots:
     void reconfigure();
 
 private slots:
-#if HAVE_WAYLAND
     void onTabletModeChanged(bool mode);
-#endif
 
 protected:
     void hoverEnterEvent(QHoverEvent *event) override;


### PR DESCRIPTION
## Summary by Sourcery

Gestire la modalità tablet e l’accesso alla geometria specifica di X11 tramite controlli della piattaforma a runtime, in modo che il plugin di decorazione funzioni correttamente sia su Wayland che su X11.

Bug Fixes:
- Impedire l’esecuzione del codice di gestione della modalità tablet quando la piattaforma è X11, mantenendo comunque funzionanti le build X11.
- Garantire che il recupero della posizione della finestra utilizzi la geometria client specifica di X11 solo quando è effettivamente in esecuzione su X11.

Enhancements:
- Pulire l’inizializzazione della decorazione rimuovendo gli spazi bianchi ridondanti attorno alle connessioni dei segnali.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Gate tablet mode handling and X11-specific geometry access on runtime platform checks to make the decoration plugin work correctly on both Wayland and X11.

Bug Fixes:
- Prevent tablet mode handling code from running when the platform is X11 while keeping X11 builds functional.
- Ensure window position retrieval only uses X11-specific client geometry when actually running on X11.

Enhancements:
- Clean up decoration initialization by removing redundant whitespace around signal connections.

</details>