### PR TITLE
BoxShadowHelper: use std::reverse_copy

### DIFF
--- a/src/BoxShadowHelper.cc
+++ b/src/BoxShadowHelper.cc
@@ -258,14 +258,11 @@ static inline void mirrorTopLeftQuadrant(QImage &image)
     const int stride = image.depth() >> 3;
 
     if (stride == 4) {
+        const int halfWidth = width / 2;
+        const int destOffset = width - halfWidth;
         for (int y = 0; y < centerY; ++y) {
             uint32_t *row = reinterpret_cast<uint32_t *>(image.scanLine(y));
-            uint32_t *in = row;
-            uint32_t *out = row + width - 1;
-
-            for (int x = 0; x < width / 2; ++x, ++in, --out) {
-                *out = *in;
-            }
+            std::reverse_copy(row, row + halfWidth, row + destOffset);
         }
     } else {
         for (int y = 0; y < centerY; ++y) {

--- a/src/BoxShadowHelper.cc
+++ b/src/BoxShadowHelper.cc
@@ -260,6 +260,14 @@ static inline void mirrorTopLeftQuadrant(QImage &image)
     if (stride == 4) {
         const int halfWidth = width / 2;
         const int destOffset = width - halfWidth;
+        // Proof of non-overlapping ranges for std::reverse_copy:
+        // - Source range is [row, row + halfWidth).
+        // - Destination range is [row + destOffset, row + destOffset + halfWidth).
+        // Since halfWidth = width / 2 and destOffset = width - halfWidth, we have:
+        //   destOffset >= halfWidth for all integers width >= 0.
+        // Therefore, the destination range starts exactly where the source range ends (if even)
+        // or strictly after it (if odd), ensuring they never overlap.
+        Q_ASSERT(destOffset >= halfWidth);
         for (int y = 0; y < centerY; ++y) {
             uint32_t *row = reinterpret_cast<uint32_t *>(image.scanLine(y));
             std::reverse_copy(row, row + halfWidth, row + destOffset);


### PR DESCRIPTION
## Summary by Sourcery

Miglioramenti:
- Semplificare e modernizzare la logica di mirroring con passo 4 sostituendo il ciclo manuale di copia dei pixel con `std::reverse_copy`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Simplify and modernize the stride-4 mirroring logic by replacing the manual pixel copy loop with std::reverse_copy.

</details>