### PR TITLE
Optimized AppMenuButtonGroup::filterMenu…

### DIFF
--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -1073,7 +1073,7 @@ void AppMenuButtonGroup::filterMenu(const QString &text)
 
     m_searchMenu->setUpdatesEnabled(false);
 
-    m_lastResults = results;
+    m_lastResults = std::move(results);
 
     // Clear previous results
     const auto actions = m_searchMenu->actions();
@@ -1091,7 +1091,7 @@ void AppMenuButtonGroup::filterMenu(const QString &text)
     }
 
     int resultCount = 0;
-    for (const SearchResult &result : std::as_const(results)) {
+    for (const SearchResult &result : std::as_const(m_lastResults)) {
         if (resultCount >= MAX_SEARCH_RESULTS) { // stop after 100 results
             break;
         }

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -1051,29 +1051,31 @@ void AppMenuButtonGroup::filterMenu(const QString &text)
         return;
     }
 
-    // Find results
-    QList<SearchResult> results;
-    if (m_appMenuModel) {
-        QMenu *rootMenu = m_appMenuModel->menu();
-        if (rootMenu) {
-            QSet<QMenu *> visited;
-            const auto *deco = qobject_cast<const Decoration *>(decoration());
-            const bool ignoreTopLevel = deco && deco->searchIgnoreTopLevel();
-            const bool ignoreSubMenus = deco && deco->searchIgnoreSubMenus();
-            QStringList currentPath;
-            QStringMatcher matcher(text, Qt::CaseInsensitive);
-            searchMenu(rootMenu, matcher, results, visited, ignoreTopLevel, ignoreSubMenus, currentPath);
+    {
+        // Find results
+        QList<SearchResult> results;
+        if (m_appMenuModel) {
+            QMenu *rootMenu = m_appMenuModel->menu();
+            if (rootMenu) {
+                QSet<QMenu *> visited;
+                const auto *deco = qobject_cast<const Decoration *>(decoration());
+                const bool ignoreTopLevel = deco && deco->searchIgnoreTopLevel();
+                const bool ignoreSubMenus = deco && deco->searchIgnoreSubMenus();
+                QStringList currentPath;
+                QStringMatcher matcher(text, Qt::CaseInsensitive);
+                searchMenu(rootMenu, matcher, results, visited, ignoreTopLevel, ignoreSubMenus, currentPath);
+            }
         }
-    }
 
-    // If results are the same as last time, do nothing to prevent the freeze.
-    if (m_lastResults == results) {
-        return;
-    }
+        // If results are the same as last time, do nothing to prevent the freeze.
+        if (m_lastResults == results) {
+            return;
+        }
+
+        m_lastResults = std::move(results);
+    } // 'results' goes out of scope here to prevent accidental use-after-move
 
     m_searchMenu->setUpdatesEnabled(false);
-
-    m_lastResults = std::move(results);
 
     // Clear previous results
     const auto actions = m_searchMenu->actions();


### PR DESCRIPTION
…to avoid copying the QList<SearchResult> container by moving it into m_lastResults using std::move. The subsequent range-based loop has been updated to iterate over std::as_const(m_lastResults) instead of results.

## Summary by Sourcery

Ottimizza la gestione dei risultati di ricerca in AppMenuButtonGroup per evitare copie non necessarie e garantire l’iterazione sui risultati memorizzati.

Miglioramenti:
- Memorizzare i risultati di ricerca in `m_lastResults` tramite assegnazione per spostamento (move assignment) per ridurre le copie.
- Iterare il ciclo di elaborazione della ricerca su `m_lastResults` invece che sul contenitore locale dei risultati.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize AppMenuButtonGroup search result handling to avoid unnecessary copying and ensure iteration over the stored results.

Enhancements:
- Store search results in m_lastResults via move assignment to reduce copying.
- Iterate the search processing loop over m_lastResults instead of the local results container.

</details>