### PR TITLE
AppMenuButtonGroup: fix search menu grouping and cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,8 @@ Thumbs.db
 
 ## Dolphin
 .directory
+
+## Patch
+*.patch
+*.diff
+

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -1016,6 +1016,30 @@ void AppMenuButtonGroup::onShowingChanged(bool showing)
     }
 }
 
+void AppMenuButtonGroup::clearSearchResultActions()
+{
+    if (!m_searchMenu) {
+        return;
+    }
+
+    const auto actions = m_searchMenu->actions();
+    for (int i = actions.count() - 1; i >= 2; --i) {
+        QAction *action = actions.at(i);
+        m_searchMenu->removeAction(action);
+        action->deleteLater();
+    }
+
+    // The old proxy actions no longer reference these groups (deleteLater()
+    // above), so nothing else owns them: delete explicitly to avoid leaking
+    // one QActionGroup per exclusive result set on every keystroke.
+    for (const QPointer<QActionGroup> &oldGroup : std::as_const(m_searchResultGroups)) {
+        if (oldGroup) {
+            oldGroup->deleteLater();
+        }
+    }
+    m_searchResultGroups.clear();
+}
+
 void AppMenuButtonGroup::filterMenu(const QString &text)
 {
     if (!m_searchMenu) {
@@ -1025,14 +1049,7 @@ void AppMenuButtonGroup::filterMenu(const QString &text)
 
     // Clear results if search text is too short
     if (text.length() < 3) {
-        const auto actions = m_searchMenu->actions();
-        if (actions.count() > 2) {
-            for (int i = actions.count() - 1; i >= 2; --i) {
-                QAction *action = actions.at(i);
-                m_searchMenu->removeAction(action);
-                action->deleteLater();
-            }
-        }
+        clearSearchResultActions();
         m_lastResults.clear();
         repositionSearchMenu();
 
@@ -1078,12 +1095,7 @@ void AppMenuButtonGroup::filterMenu(const QString &text)
     m_searchMenu->setUpdatesEnabled(false);
 
     // Clear previous results
-    const auto actions = m_searchMenu->actions();
-    for (int i = actions.count() - 1; i >= 2; --i) {
-        QAction *action = actions.at(i);
-        m_searchMenu->removeAction(action);
-        action->deleteLater();
-    }
+    clearSearchResultActions();
 
     // Add new results
     const auto *deco = qobject_cast<const Decoration *>(decoration());
@@ -1093,6 +1105,12 @@ void AppMenuButtonGroup::filterMenu(const QString &text)
     }
 
     int resultCount = 0;
+    // Map each *original* action group to the QActionGroup we create for its
+    // search-result proxies, so results that were mutually exclusive in the
+    // real menu (e.g. radio-button items) stay mutually exclusive here too.
+    // Without this, each proxy action got its own isolated single-member
+    // group and could show several "checked" radio results at once.
+    QHash<QActionGroup *, QActionGroup *> groupMap;
     for (const SearchResult &result : std::as_const(m_lastResults)) {
         if (resultCount >= MAX_SEARCH_RESULTS) { // stop after 100 results
             break;
@@ -1108,10 +1126,14 @@ void AppMenuButtonGroup::filterMenu(const QString &text)
         newAction->setCheckable(action->isCheckable());
         newAction->setChecked(action->isChecked());
 
-        if (action->actionGroup() && action->actionGroup()->isExclusive()) {
-            auto *group = new QActionGroup(newAction);
-            group->setExclusive(true);
-            group->addAction(newAction);
+        if (QActionGroup *originalGroup = action->actionGroup(); originalGroup && originalGroup->isExclusive()) {
+            QActionGroup *&proxyGroup = groupMap[originalGroup];
+            if (!proxyGroup) {
+                proxyGroup = new QActionGroup(m_searchMenu);
+                proxyGroup->setExclusive(true);
+                m_searchResultGroups.append(proxyGroup);
+            }
+            proxyGroup->addAction(newAction);
         }
       
         QPointer<QAction> safeAction = action;

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -1026,6 +1026,10 @@ void AppMenuButtonGroup::clearSearchResultActions()
     for (int i = actions.count() - 1; i >= 2; --i) {
         QAction *action = actions.at(i);
         m_searchMenu->removeAction(action);
+        // Detach action from its group before scheduling deletion
+        if (QActionGroup *group = action->actionGroup()) {
+            group->removeAction(action);
+        }
         action->deleteLater();
     }
 
@@ -1130,7 +1134,7 @@ void AppMenuButtonGroup::filterMenu(const QString &text)
             QActionGroup *&proxyGroup = groupMap[originalGroup];
             if (!proxyGroup) {
                 proxyGroup = new QActionGroup(m_searchMenu);
-                proxyGroup->setExclusive(true);
+                proxyGroup->setExclusionPolicy(originalGroup->exclusionPolicy());
                 m_searchResultGroups.append(proxyGroup);
             }
             proxyGroup->addAction(newAction);

--- a/src/AppMenuButtonGroup.h
+++ b/src/AppMenuButtonGroup.h
@@ -150,7 +150,7 @@ private:
     };
 
     struct SearchResult {
-        QAction *action;
+        QPointer<QAction> action;
         ActionInfo info;
 
         bool operator==(const SearchResult &other) const {

--- a/src/AppMenuButtonGroup.h
+++ b/src/AppMenuButtonGroup.h
@@ -35,6 +35,7 @@
 class QTimer;
 class QStringMatcher;
 class QVariantAnimation;
+class QActionGroup;
 
 namespace Material
 {
@@ -103,6 +104,7 @@ private:
     void onDelayedCacheTimerTimeout();
     void onShowingChanged(bool hovered);
     void filterMenu(const QString &text);
+    void clearSearchResultActions();
     void onSearchTimerTimeout();
     void onSubMenuReady(QMenu *menu);
 
@@ -206,6 +208,11 @@ private:
     bool m_menuLoadedOnce = false;
     QString m_lastSearchQuery;
     QList<SearchResult> m_lastResults;
+    // QActionGroups created in filterMenu() to preserve mutual exclusivity
+    // between search-result proxies; owned here (parented to m_searchMenu)
+    // since they aren't owned by any single proxy action anymore and must
+    // be deleted explicitly when the previous results are cleared.
+    QList<QPointer<QActionGroup>> m_searchResultGroups;
 
     QList<QPointer<TextButton>> m_textButtons;
     QPointer<MenuOverflowButton> m_overflowButton;


### PR DESCRIPTION
## Summary by Sourcery

Migliora la gestione dei risultati di ricerca nel menu dell'app per preservare l’esclusività dei gruppi di azioni e evitare leak quando il menu di ricerca viene svuotato e ricostruito.

Nuove funzionalità:
- Introduce il tracciamento dei QActionGroups dei risultati di ricerca, in modo che l’esclusività reciproca degli elementi di menu in stile radio venga preservata nei risultati di ricerca.

Correzioni di bug:
- Corregge il raggruppamento dei risultati di ricerca affinché le azioni provenienti da gruppi esclusivi rimangano mutualmente esclusive, invece che ogni azione proxy formi il proprio gruppo isolato.
- Previene memory leak svuotando esplicitamente le azioni dei risultati di ricerca e i rispettivi QActionGroups quando il testo di ricerca viene accorciato o i risultati vengono aggiornati.
- Rende i risultati di ricerca più robusti rispetto alle azioni eliminate memorizzando le azioni dei risultati come QPointer<QAction> invece che come puntatori QAction grezzi.

Miglioramenti:
- Refactoring della logica di svuotamento dei risultati di ricerca in un helper dedicato, per semplificare filterMenu() e centralizzare la logica di cleanup.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve app menu search results handling to preserve action group exclusivity and avoid leaks when clearing and rebuilding the search menu.

New Features:
- Introduce tracking of search-result QActionGroups so mutual exclusivity of radio-style menu items is preserved in the search results.

Bug Fixes:
- Fix search result grouping so actions from exclusive groups remain mutually exclusive instead of each proxy action forming its own isolated group.
- Prevent memory leaks by explicitly clearing search-result actions and their associated QActionGroups when search text is shortened or results are refreshed.
- Make search results more robust to deleted actions by storing result actions as QPointer<QAction> instead of raw QAction pointers.

Enhancements:
- Refactor search result clearing into a dedicated helper to simplify filterMenu() and centralize cleanup logic.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migliora la gestione dei risultati di ricerca nel menu dell'app per preservare l’esclusività dei gruppi di azioni e evitare leak quando il menu di ricerca viene svuotato e ricostruito.

Nuove funzionalità:
- Introduce il tracciamento dei QActionGroups dei risultati di ricerca, in modo che l’esclusività reciproca degli elementi di menu in stile radio venga preservata nei risultati di ricerca.

Correzioni di bug:
- Corregge il raggruppamento dei risultati di ricerca affinché le azioni provenienti da gruppi esclusivi rimangano mutualmente esclusive, invece che ogni azione proxy formi il proprio gruppo isolato.
- Previene memory leak svuotando esplicitamente le azioni dei risultati di ricerca e i rispettivi QActionGroups quando il testo di ricerca viene accorciato o i risultati vengono aggiornati.
- Rende i risultati di ricerca più robusti rispetto alle azioni eliminate memorizzando le azioni dei risultati come QPointer<QAction> invece che come puntatori QAction grezzi.

Miglioramenti:
- Refactoring della logica di svuotamento dei risultati di ricerca in un helper dedicato, per semplificare filterMenu() e centralizzare la logica di cleanup.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve app menu search results handling to preserve action group exclusivity and avoid leaks when clearing and rebuilding the search menu.

New Features:
- Introduce tracking of search-result QActionGroups so mutual exclusivity of radio-style menu items is preserved in the search results.

Bug Fixes:
- Fix search result grouping so actions from exclusive groups remain mutually exclusive instead of each proxy action forming its own isolated group.
- Prevent memory leaks by explicitly clearing search-result actions and their associated QActionGroups when search text is shortened or results are refreshed.
- Make search results more robust to deleted actions by storing result actions as QPointer<QAction> instead of raw QAction pointers.

Enhancements:
- Refactor search result clearing into a dedicated helper to simplify filterMenu() and centralize cleanup logic.

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Correzioni**
  * Migliorata la gestione delle azioni dei risultati di ricerca nei menu, mantenendo correttamente il comportamento esclusivo tra le opzioni correlate.
  * Risolti problemi durante ricerche consecutive: la pulizia dei risultati precedenti è ora più affidabile prima di mostrare quelli nuovi.
* **Manutenzione**
  * Aggiornate le regole di esclusione per ignorare automaticamente file temporanei con estensione patch e diff.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->