### PR TITLE
Search decouplig

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ for Arch and derivatives, please install the AUR package
 NOTE: the master branch is aligned with the latest Plasma version. For earlier
 ones, see the other branches.
 
-![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/guiodic/material-decoration?utm_source=oss&utm_medium=github&utm_campaign=guiodic%2Fmaterial-decoration&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)
 
 ....
 

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -396,8 +396,8 @@ void AppMenuButtonGroup::resetButtons()
 
 void AppMenuButtonGroup::onMenuReadyForSearch()
 {
-    if (!m_search->lastSearchQuery().isEmpty() && m_searchUiVisible) {
-        filterMenu(m_search->lastSearchQuery());
+    if (m_searchLineEdit && !m_searchLineEdit->text().isEmpty() && m_searchUiVisible) {
+        filterMenu(m_searchLineEdit->text());
     }
 }
 
@@ -588,12 +588,13 @@ void AppMenuButtonGroup::updateAppMenuModel()
         if (indexToRestore != -1) {
             setCurrentIndex(indexToRestore);
             m_currentMenu = previousMenu;
-            
+
             if (AppMenuButton *b = getAppMenuButton(m_currentIndex)) {
                 b->setChecked(true);
             }
 
-            if (wasSearchOpen && !savedQuery.isEmpty()) {
+            if (wasSearchOpen && !savedQuery.isEmpty() && m_searchLineEdit) {
+                m_searchLineEdit->setText(savedQuery);
                 m_searchDebounceTimer->start();
             }
         }

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -84,7 +84,7 @@ AppMenuButtonGroup::AppMenuButtonGroup(Decoration *decoration)
     , m_searchLineEdit(nullptr)
     , m_searchDebounceTimer(nullptr)
     , m_searchUiVisible(false)
-    , m_search(new Material::AppMenuSearch(m_appMenuModel, this))
+    , m_search(new AppMenuSearch(m_appMenuModel, this))
 {
     m_searchDebounceTimer = new QTimer(this);
     m_searchDebounceTimer->setInterval(150);
@@ -1036,7 +1036,7 @@ void AppMenuButtonGroup::filterMenu(const QString &text)
     }
 
     const auto *deco = qobject_cast<const Decoration *>(decoration());
-    Material::AppMenuSearch::FilterOptions options;
+    AppMenuSearch::FilterOptions options;
     options.ignoreTopLevel = deco && deco->searchIgnoreTopLevel();
     options.ignoreSubMenus = deco && deco->searchIgnoreSubMenus();
     options.showDisabledActions = deco && deco->showDisabledActions();

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -20,6 +20,7 @@
 
 // own
 #include "AppMenuButtonGroup.h"
+#include "AppMenuSearch.h"
 #include "Material.h"
 #include "BuildConfig.h"
 #include "AppMenuModel.h"
@@ -83,6 +84,7 @@ AppMenuButtonGroup::AppMenuButtonGroup(Decoration *decoration)
     , m_searchLineEdit(nullptr)
     , m_searchDebounceTimer(nullptr)
     , m_searchUiVisible(false)
+    , m_search(new AppMenuSearch(m_appMenuModel, this))
 {
     m_searchDebounceTimer = new QTimer(this);
     m_searchDebounceTimer->setInterval(150);
@@ -205,6 +207,8 @@ void AppMenuButtonGroup::setupSearchMenu()
     m_searchLineEdit->setFocusPolicy(Qt::StrongFocus);
     m_searchLineEdit->setPlaceholderText(i18nd("plasma_applet_org.kde.plasma.appmenu","Search")+QStringLiteral("…"));
     m_searchLineEdit->setClearButtonEnabled(false);
+
+    connect(m_search, &AppMenuSearch::repositionRequested, this, &AppMenuButtonGroup::repositionSearchMenu);
 }
 
 void AppMenuButtonGroup::repositionSearchMenu()
@@ -363,9 +367,10 @@ void AppMenuButtonGroup::resetButtons()
     }
     setCurrentIndex(-1);
     m_currentMenu = nullptr;
-    m_lastResults.clear();
-    m_lastSearchQuery.clear();
-    m_actionTextCache.clear();
+    if (m_search) {
+        m_search->clearLastResults();
+        m_search->clear(m_searchMenu);
+    }
     m_textButtons.clear();
     m_overflowButton = nullptr;
     m_searchButton = nullptr;
@@ -393,8 +398,8 @@ void AppMenuButtonGroup::resetButtons()
 
 void AppMenuButtonGroup::onMenuReadyForSearch()
 {
-    if (!m_lastSearchQuery.isEmpty() && m_searchUiVisible) {
-        filterMenu(m_lastSearchQuery);
+    if (m_search && !m_search->lastSearchQuery().isEmpty() && m_searchUiVisible) {
+        filterMenu(m_search->lastSearchQuery());
     }
 }
 
@@ -477,7 +482,9 @@ void AppMenuButtonGroup::performDebouncedMenuUpdate()
 
 void AppMenuButtonGroup::updateAppMenuModel()
 {
-    m_searchCandidatesDirty = true;
+    if (m_search) {
+        m_search->invalidateCandidates();
+    }
 
     auto *deco = qobject_cast<Decoration *>(decoration());
     if (!deco) {
@@ -517,7 +524,9 @@ void AppMenuButtonGroup::updateAppMenuModel()
         const bool searchStateMatches = (m_searchButton.isNull() == !deco->searchEnabled());
 
         if (m_textButtons.count() == menuActionCount && !m_textButtons.isEmpty() && searchStateMatches) {
-            m_actionTextCache.clear();
+            if (m_search) {
+                m_search->invalidateCandidates();
+            }
             int actionIdx = 0;
             for (auto &textButton : std::as_const(m_textButtons)) {
                 if (!textButton) {
@@ -537,8 +546,8 @@ void AppMenuButtonGroup::updateAppMenuModel()
                 }
             }
 
-            if (wasSearchOpen && !m_lastSearchQuery.isEmpty()) {
-                filterMenu(m_lastSearchQuery);
+            if (wasSearchOpen && m_search && !m_search->lastSearchQuery().isEmpty()) {
+                filterMenu(m_search->lastSearchQuery());
             }
         } else {
             resetButtons(); // Immediate reset is intended here for structural changes
@@ -983,8 +992,9 @@ void AppMenuButtonGroup::onMenuAboutToHide()
     if (menu == m_searchMenu && m_searchLineEdit) {
         m_searchLineEdit->clear();
         m_searchUiVisible = false;
-        m_lastResults.clear();
-        m_lastSearchQuery.clear();
+        if (m_search) {
+            m_search->clearLastResults();
+        }
     }
 
     if (AppMenuButton *currentButton = getAppMenuButton(m_currentIndex)) {
@@ -1023,147 +1033,36 @@ void AppMenuButtonGroup::onShowingChanged(bool showing)
     }
 }
 
-void AppMenuButtonGroup::clearSearchResultActions()
-{
-    if (!m_searchMenu) {
-        return;
-    }
-
-    const auto actions = m_searchMenu->actions();
-    for (int i = actions.count() - 1; i >= 2; --i) {
-        QAction *action = actions.at(i);
-        m_searchMenu->removeAction(action);
-        // Detach action from its group before scheduling deletion
-        if (QActionGroup *group = action->actionGroup()) {
-            group->removeAction(action);
-        }
-        action->deleteLater();
-    }
-
-    // The old proxy actions no longer reference these groups (deleteLater()
-    // above), so nothing else owns them: delete explicitly to avoid leaking
-    // one QActionGroup per exclusive result set on every keystroke.
-    for (const QPointer<QActionGroup> &oldGroup : std::as_const(m_searchResultGroups)) {
-        if (oldGroup) {
-            oldGroup->deleteLater();
-        }
-    }
-    m_searchResultGroups.clear();
-}
-
 void AppMenuButtonGroup::filterMenu(const QString &text)
 {
     if (!m_searchMenu) {
-            return;
-    }
-    m_lastSearchQuery = text;
-
-    // Clear results if search text is too short
-    if (text.length() < 3) {
-        clearSearchResultActions();
-        m_lastResults.clear();
-        repositionSearchMenu();
-
-        if (text.isEmpty()) {
-            m_searchLineEdit->setClearButtonEnabled(false);
-            m_searchLineEdit->setPlaceholderText(i18nd("plasma_applet_org.kde.plasma.appmenu", "Search") + QStringLiteral("…"));
-            return;
-        }
-        m_searchLineEdit->setClearButtonEnabled(true);
         return;
+    }
+
+    const auto *deco = qobject_cast<const Decoration *>(decoration());
+    const bool ignoreTopLevel = deco && deco->searchIgnoreTopLevel();
+    const bool ignoreSubMenus = deco && deco->searchIgnoreSubMenus();
+    const bool showDisabledActions = deco && deco->showDisabledActions();
+
+    if (m_search) {
+        m_search->filter(m_searchMenu, text, ignoreTopLevel, ignoreSubMenus, showDisabledActions);
+    }
+
+    if (text.isEmpty()) {
+        m_searchLineEdit->setClearButtonEnabled(false);
+        m_searchLineEdit->setPlaceholderText(i18nd("plasma_applet_org.kde.plasma.appmenu", "Search") + QStringLiteral("…"));
     } else {
         m_searchLineEdit->setClearButtonEnabled(true);
     }
-
-    if (!m_appMenuModel) {
-        return;
-    }
-
-    {
-        // Find results
-        rebuildSearchCandidatesIfNeeded();
-        const auto *deco = qobject_cast<const Decoration *>(decoration());
-        const bool ignoreTopLevel = deco && deco->searchIgnoreTopLevel();
-        const bool ignoreSubMenus = deco && deco->searchIgnoreSubMenus();
-        QStringMatcher matcher(text, Qt::CaseInsensitive);
-        QList<SearchResult> results = matchSearchCandidates(matcher, ignoreTopLevel, ignoreSubMenus);
-
-        // If results are the same as last time, do nothing to prevent the freeze.
-        if (m_lastResults == results) {
-            return;
-        }
-
-        m_lastResults = std::move(results);
-    } // 'results' goes out of scope here to prevent accidental use-after-move
-
-    m_searchMenu->setUpdatesEnabled(false);
-
-    // Clear previous results
-    clearSearchResultActions();
-
-    // Add new results
-    const auto *deco = qobject_cast<const Decoration *>(decoration());
-    if (!deco) {
-        m_searchMenu->setUpdatesEnabled(true);
-        return;
-    }
-
-    int resultCount = 0;
-    // Map each *original* action group to the QActionGroup we create for its
-    // search-result proxies, so results that were mutually exclusive in the
-    // real menu (e.g. radio-button items) stay mutually exclusive here too.
-    // Without this, each proxy action got its own isolated single-member
-    // group and could show several "checked" radio results at once.
-    QHash<QActionGroup *, QActionGroup *> groupMap;
-    for (const SearchResult &result : std::as_const(m_lastResults)) {
-        if (resultCount >= MAX_SEARCH_RESULTS) { // stop after 100 results
-            break;
-        }
-
-        const ActionInfo &info = result.info;
-        QAction *action = result.action;
-        if (!info.isEffectivelyEnabled && !deco->showDisabledActions()) {
-            continue;
-        }
-        QAction *newAction = new QAction(action->icon(), info.path, m_searchMenu);
-        newAction->setEnabled(info.isEffectivelyEnabled);
-        newAction->setCheckable(action->isCheckable());
-        newAction->setChecked(action->isChecked());
-
-        if (QActionGroup *originalGroup = action->actionGroup(); originalGroup && originalGroup->isExclusive()) {
-            QActionGroup *&proxyGroup = groupMap[originalGroup];
-            if (!proxyGroup) {
-                proxyGroup = new QActionGroup(m_searchMenu);
-                proxyGroup->setExclusionPolicy(originalGroup->exclusionPolicy());
-                m_searchResultGroups.append(proxyGroup);
-            }
-            proxyGroup->addAction(newAction);
-        }
-      
-        QPointer<QAction> safeAction = action;
-        connect(newAction, &QAction::triggered, this, [safeAction, searchMenu = m_searchMenu]() {
-            if (safeAction) {
-                safeAction->trigger();
-            }
-            if (searchMenu) {
-                searchMenu->hide();
-            }
-        });
-        m_searchMenu->addAction(newAction);
-        resultCount++;
-    }
-
-    repositionSearchMenu();
-    m_searchMenu->setUpdatesEnabled(true);
-    // qCDebug(category) << "[AppMenuButtonGroup] filterMenu(" << text << ") ended";
 }
 
 void AppMenuButtonGroup::onSubMenuReady(QMenu *menu)
 {
-    m_actionTextCache.clear();
-    m_searchCandidatesDirty = true;
+    if (m_search) {
+        m_search->invalidateCandidates();
+    }
 
-    if (m_searchUiVisible && !m_lastSearchQuery.isEmpty()) {
+    if (m_searchUiVisible && m_search && !m_search->lastSearchQuery().isEmpty()) {
         if (!m_searchDebounceTimer->isActive()) {
             m_searchDebounceTimer->start();
         }
@@ -1201,219 +1100,6 @@ void AppMenuButtonGroup::onSearchTimerTimeout()
     if (m_searchLineEdit) {
         filterMenu(m_searchLineEdit->text());
     }
-}
-
-QString AppMenuButtonGroup::getActionText(QAction *action) const
-{
-    if (!action) {
-        return QString();
-    }
-    const QString rawText = action->text();
-    auto it = m_actionTextCache.find(rawText);
-    if (it != m_actionTextCache.end()) {
-        return it.value();
-    }
-    const QString cleanedText = KLocalizedString::removeAcceleratorMarker(rawText.trimmed());
-    m_actionTextCache.insert(rawText, cleanedText);
-    return cleanedText;
-}
-
-void AppMenuButtonGroup::rebuildSearchCandidatesIfNeeded()
-{
-    if (!m_searchCandidatesDirty) {
-        return;
-    }
-    m_searchCandidatesDirty = false;
-    m_searchCandidates.clear();
-
-    if (!m_appMenuModel) {
-        return;
-    }
-    QMenu *rootMenu = m_appMenuModel->menu();
-    if (!rootMenu) {
-        return;
-    }
-
-    QSet<QMenu *> visited;
-    QList<QPointer<QAction>> namedAncestors;
-    QList<QPointer<QAction>> enablementAncestors;
-    collectSearchCandidates(rootMenu, visited, namedAncestors, enablementAncestors);
-}
-
-void AppMenuButtonGroup::collectSearchCandidates(QMenu *menu, QSet<QMenu *> &visited, QList<QPointer<QAction>> &namedAncestors, QList<QPointer<QAction>> &enablementAncestors)
-{
-    if (!menu || visited.contains(menu) || m_searchCandidates.size() >= MAX_SEARCH_CANDIDATES) {
-        return;
-    }
-    visited.insert(menu);
-
-    QAction *menuAction = menu->menuAction();
-    bool addedNamed = false;
-    bool addedEnablement = false;
-    if (menuAction) {
-        // Unconditional: even an untitled submenu still gates whether its
-        // children are reachable/enabled, so its own enabled state must
-        // propagate down regardless of whether it has display text.
-        enablementAncestors.append(menuAction);
-        addedEnablement = true;
-        if (!getActionText(menuAction).isEmpty()) {
-            namedAncestors.append(menuAction);
-            addedNamed = true;
-        }
-    }
-
-    for (QAction *action : menu->actions()) {
-        if (m_searchCandidates.size() >= MAX_SEARCH_CANDIDATES) {
-            break;
-        }
-        if (action->isSeparator()) {
-            continue;
-        }
-        if (action->menu()) {
-            collectSearchCandidates(action->menu(), visited, namedAncestors, enablementAncestors);
-        } else {
-            m_searchCandidates.append({action, namedAncestors, enablementAncestors});
-        }
-    }
-
-    if (addedNamed) {
-        namedAncestors.removeLast();
-    }
-    if (addedEnablement) {
-        enablementAncestors.removeLast();
-    }
-}
-
-QList<AppMenuButtonGroup::SearchResult> AppMenuButtonGroup::matchSearchCandidates(const QStringMatcher &matcher, bool ignoreTopLevel, bool ignoreSubMenus) const
-{
-    QList<SearchResult> results;
-
-    // Two independent memoized chains, mirroring how the original recursive
-    // algorithm kept these concerns separate: a submenu's *enabled* state
-    // always propagates to its children, even if the submenu has no title
-    // of its own; its *title* only contributes to the visible path/matching
-    // when non-empty. Folding both into a single "named ancestors" chain
-    // would silently drop the disabled state of untitled submenus.
-    QHash<QAction *, bool> enabledCache; // cumulative isEnabled up to and including this ancestor
-    struct MatchState {
-        bool currentMatched;
-        QString text;
-    };
-    QHash<QAction *, MatchState> matchCache; // cumulative match state + this ancestor's text
-
-    for (const SearchCandidate &candidate : std::as_const(m_searchCandidates)) {
-        if (results.size() >= MAX_SEARCH_RESULTS) {
-            break;
-        }
-        QAction *action = candidate.action;
-        if (!action) {
-            continue; // Action was destroyed since the cache was built.
-        }
-
-        bool ancestorsStillValid = true;
-
-        // --- Enabled chain (every ancestor, named or not) ---
-        bool isCurrentEnabled = true;
-        if (!candidate.enablementAncestors.isEmpty()) {
-            QAction *deepest = candidate.enablementAncestors.last();
-            if (!deepest) {
-                ancestorsStillValid = false;
-            } else {
-                auto it = enabledCache.find(deepest);
-                if (it != enabledCache.end()) {
-                    isCurrentEnabled = it.value();
-                } else {
-                    for (QAction *ancestor : std::as_const(candidate.enablementAncestors)) {
-                        if (!ancestor) {
-                            ancestorsStillValid = false;
-                            break;
-                        }
-                        auto it2 = enabledCache.find(ancestor);
-                        if (it2 != enabledCache.end()) {
-                            isCurrentEnabled = it2.value();
-                        } else {
-                            if (!ancestor->isEnabled()) {
-                                isCurrentEnabled = false;
-                            }
-                            enabledCache.insert(ancestor, isCurrentEnabled);
-                        }
-                    }
-                }
-            }
-        }
-
-        // --- Match/text chain (only ancestors with a non-empty title) ---
-        bool currentMatched = false;
-        if (ancestorsStillValid && !candidate.namedAncestors.isEmpty()) {
-            QAction *parent = candidate.namedAncestors.last();
-            if (!parent) {
-                ancestorsStillValid = false;
-            } else {
-                auto it = matchCache.find(parent);
-                if (it != matchCache.end()) {
-                    currentMatched = it.value().currentMatched;
-                } else {
-                    for (int i = 0; i < candidate.namedAncestors.size(); ++i) {
-                        QAction *ancestor = candidate.namedAncestors.at(i);
-                        if (!ancestor) {
-                            ancestorsStillValid = false;
-                            break;
-                        }
-                        auto it2 = matchCache.find(ancestor);
-                        if (it2 != matchCache.end()) {
-                            currentMatched = it2.value().currentMatched;
-                        } else {
-                            QString ancestorText = getActionText(ancestor);
-                            if (!currentMatched && (!ignoreTopLevel || i > 0)) {
-                                if (matcher.indexIn(ancestorText) != -1) {
-                                    currentMatched = true;
-                                }
-                            }
-                            matchCache.insert(ancestor, {currentMatched, ancestorText});
-                        }
-                    }
-                }
-            }
-        }
-
-        if (!ancestorsStillValid) {
-            continue; // A submenu in the path was rebuilt/destroyed; skip until next full rebuild.
-        }
-
-        const QString itemText = getActionText(action);
-        bool match = currentMatched;
-        if (ignoreSubMenus) {
-            match = matcher.indexIn(itemText) != -1;
-        } else if (!match && (!ignoreTopLevel || !candidate.namedAncestors.isEmpty())) {
-            if (matcher.indexIn(itemText) != -1) {
-                match = true;
-            }
-        }
-
-        if (!match) {
-            continue; // Skip building path entirely for non-matching entries!
-        }
-
-        // 2. Only perform path allocation and joins for matching results
-        QStringList currentPath;
-        currentPath.reserve(candidate.namedAncestors.size() + 1);
-        for (int i = 0; i < candidate.namedAncestors.size(); ++i) {
-            QAction *ancestor = candidate.namedAncestors.at(i);
-            currentPath.append(matchCache.value(ancestor).text);
-        }
-
-        ActionInfo info;
-        info.label = itemText;
-        info.isEffectivelyEnabled = isCurrentEnabled && action->isEnabled();
-
-        currentPath.append(itemText);
-        info.path = currentPath.join(QStringLiteral(" » "));
-        info.searchablePath = (currentPath.size() > 1) ? currentPath.mid(1).join(QStringLiteral(" » ")) : itemText;
-
-        results.append({action, info});
-    }
-
-    return results;
 }
 
 AppMenuButton *AppMenuButtonGroup::getAppMenuButton(int index) const

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -515,6 +515,7 @@ void AppMenuButtonGroup::updateAppMenuModel()
         const bool wasSearchOpen = (m_currentIndex == m_searchIndex && m_searchIndex != -1);
         const bool wasOverflowOpen = (m_currentIndex == m_overflowIndex && m_overflowIndex != -1);
         QPointer<QMenu> previousMenu = m_currentMenu;
+        const QString savedQuery = m_searchLineEdit ? m_searchLineEdit->text() : QString();
 
         // Try in-place update if possible to reduce flicker and object churn
         const bool searchStateMatches = (m_searchButton.isNull() == !deco->searchEnabled());
@@ -594,6 +595,10 @@ void AppMenuButtonGroup::updateAppMenuModel()
             
             if (AppMenuButton *b = getAppMenuButton(m_currentIndex)) {
                 b->setChecked(true);
+            }
+
+            if (wasSearchOpen && !savedQuery.isEmpty()) {
+                filterMenu(savedQuery);
             }
         }
 

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -208,7 +208,7 @@ void AppMenuButtonGroup::setupSearchMenu()
     m_searchLineEdit->setPlaceholderText(i18nd("plasma_applet_org.kde.plasma.appmenu","Search")+QStringLiteral("…"));
     m_searchLineEdit->setClearButtonEnabled(false);
 
-    connect(m_search, &AppMenuSearch::repositionRequested, this, &AppMenuButtonGroup::repositionSearchMenu);
+    connect(m_search, &AppMenuSearch::repositionRequested, this, &AppMenuButtonGroup::repositionSearchMenu, Qt::UniqueConnection);
 }
 
 void AppMenuButtonGroup::repositionSearchMenu()

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -539,10 +539,6 @@ void AppMenuButtonGroup::updateAppMenuModel()
                     textButton->setVisible(true);
                 }
             }
-
-            if (wasSearchOpen && !m_search->lastSearchQuery().isEmpty()) {
-                filterMenu(m_search->lastSearchQuery());
-            }
         } else {
             resetButtons(); // Immediate reset is intended here for structural changes
 

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -84,7 +84,7 @@ AppMenuButtonGroup::AppMenuButtonGroup(Decoration *decoration)
     , m_searchLineEdit(nullptr)
     , m_searchDebounceTimer(nullptr)
     , m_searchUiVisible(false)
-    , m_search(new AppMenuSearch(m_appMenuModel, this))
+    , m_search(new Material::AppMenuSearch(m_appMenuModel, this))
 {
     m_searchDebounceTimer = new QTimer(this);
     m_searchDebounceTimer->setInterval(150);
@@ -367,10 +367,8 @@ void AppMenuButtonGroup::resetButtons()
     }
     setCurrentIndex(-1);
     m_currentMenu = nullptr;
-    if (m_search) {
-        m_search->clearLastResults();
-        m_search->clear(m_searchMenu);
-    }
+    m_search->clearLastResults();
+    m_search->clear();
     m_textButtons.clear();
     m_overflowButton = nullptr;
     m_searchButton = nullptr;
@@ -398,7 +396,7 @@ void AppMenuButtonGroup::resetButtons()
 
 void AppMenuButtonGroup::onMenuReadyForSearch()
 {
-    if (m_search && !m_search->lastSearchQuery().isEmpty() && m_searchUiVisible) {
+    if (!m_search->lastSearchQuery().isEmpty() && m_searchUiVisible) {
         filterMenu(m_search->lastSearchQuery());
     }
 }
@@ -482,9 +480,7 @@ void AppMenuButtonGroup::performDebouncedMenuUpdate()
 
 void AppMenuButtonGroup::updateAppMenuModel()
 {
-    if (m_search) {
-        m_search->invalidateCandidates();
-    }
+    m_search->invalidateCandidates();
 
     auto *deco = qobject_cast<Decoration *>(decoration());
     if (!deco) {
@@ -543,7 +539,7 @@ void AppMenuButtonGroup::updateAppMenuModel()
                 }
             }
 
-            if (wasSearchOpen && m_search && !m_search->lastSearchQuery().isEmpty()) {
+            if (wasSearchOpen && !m_search->lastSearchQuery().isEmpty()) {
                 filterMenu(m_search->lastSearchQuery());
             }
         } else {
@@ -989,9 +985,7 @@ void AppMenuButtonGroup::onMenuAboutToHide()
     if (menu == m_searchMenu && m_searchLineEdit) {
         m_searchLineEdit->clear();
         m_searchUiVisible = false;
-        if (m_search) {
-            m_search->clearLastResults();
-        }
+        m_search->clearLastResults();
     }
 
     if (AppMenuButton *currentButton = getAppMenuButton(m_currentIndex)) {
@@ -1037,14 +1031,12 @@ void AppMenuButtonGroup::filterMenu(const QString &text)
     }
 
     const auto *deco = qobject_cast<const Decoration *>(decoration());
-    AppMenuSearch::FilterOptions options;
+    Material::AppMenuSearch::FilterOptions options;
     options.ignoreTopLevel = deco && deco->searchIgnoreTopLevel();
     options.ignoreSubMenus = deco && deco->searchIgnoreSubMenus();
     options.showDisabledActions = deco && deco->showDisabledActions();
 
-    if (m_search) {
-        m_search->filter(m_searchMenu, text, options);
-    }
+    m_search->filter(m_searchMenu, text, options);
 
     if (text.isEmpty()) {
         m_searchLineEdit->setClearButtonEnabled(false);
@@ -1056,11 +1048,9 @@ void AppMenuButtonGroup::filterMenu(const QString &text)
 
 void AppMenuButtonGroup::onSubMenuReady(QMenu *menu)
 {
-    if (m_search) {
-        m_search->invalidateCandidates();
-    }
+    m_search->invalidateCandidates();
 
-    if (m_searchUiVisible && m_search && !m_search->lastSearchQuery().isEmpty()) {
+    if (m_searchUiVisible && m_searchLineEdit && !m_searchLineEdit->text().isEmpty()) {
         if (!m_searchDebounceTimer->isActive()) {
             m_searchDebounceTimer->start();
         }

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -524,9 +524,6 @@ void AppMenuButtonGroup::updateAppMenuModel()
         const bool searchStateMatches = (m_searchButton.isNull() == !deco->searchEnabled());
 
         if (m_textButtons.count() == menuActionCount && !m_textButtons.isEmpty() && searchStateMatches) {
-            if (m_search) {
-                m_search->invalidateCandidates();
-            }
             int actionIdx = 0;
             for (auto &textButton : std::as_const(m_textButtons)) {
                 if (!textButton) {
@@ -1040,12 +1037,13 @@ void AppMenuButtonGroup::filterMenu(const QString &text)
     }
 
     const auto *deco = qobject_cast<const Decoration *>(decoration());
-    const bool ignoreTopLevel = deco && deco->searchIgnoreTopLevel();
-    const bool ignoreSubMenus = deco && deco->searchIgnoreSubMenus();
-    const bool showDisabledActions = deco && deco->showDisabledActions();
+    AppMenuSearch::FilterOptions options;
+    options.ignoreTopLevel = deco && deco->searchIgnoreTopLevel();
+    options.ignoreSubMenus = deco && deco->searchIgnoreSubMenus();
+    options.showDisabledActions = deco && deco->showDisabledActions();
 
     if (m_search) {
-        m_search->filter(m_searchMenu, text, ignoreTopLevel, ignoreSubMenus, showDisabledActions);
+        m_search->filter(m_searchMenu, text, options);
     }
 
     if (text.isEmpty()) {

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -594,7 +594,7 @@ void AppMenuButtonGroup::updateAppMenuModel()
             }
 
             if (wasSearchOpen && !savedQuery.isEmpty()) {
-                filterMenu(savedQuery);
+                m_searchDebounceTimer->start();
             }
         }
 

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -1035,7 +1035,7 @@ void AppMenuButtonGroup::onShowingChanged(bool showing)
 
 void AppMenuButtonGroup::filterMenu(const QString &text)
 {
-    if (!m_searchMenu) {
+    if (!m_searchMenu || !m_searchLineEdit) {
         return;
     }
 

--- a/src/AppMenuButtonGroup.h
+++ b/src/AppMenuButtonGroup.h
@@ -45,6 +45,7 @@ class Decoration;
 class TextButton;
 class MenuOverflowButton;
 class SearchButton;
+class AppMenuSearch;
 
 class AppMenuButtonGroup : public KDecoration3::DecorationButtonGroup
 {
@@ -105,7 +106,6 @@ private:
     void onDelayedCacheTimerTimeout();
     void onShowingChanged(bool hovered);
     void filterMenu(const QString &text);
-    void clearSearchResultActions();
     void onSearchTimerTimeout();
     void onSubMenuReady(QMenu *menu);
 
@@ -143,56 +143,9 @@ private:
 
     void trigger(int index);
 
-    struct ActionInfo {
-        QString path;
-        QString searchablePath;
-        QString label;
-        bool isEffectivelyEnabled;
-    };
-
-    // A leaf action reachable from the app menu root, plus the chain of
-    // named ancestor submenu-actions leading to it. Built once per menu
-    // structure (see rebuildSearchCandidatesIfNeeded()) instead of being
-    // re-derived by walking the whole QMenu tree on every keystroke.
-    // Text and enabled-state are deliberately NOT cached here, since those
-    // can change at runtime (e.g. "Undo X" toggling label/enabled) without
-    // the structure itself changing; they are re-read fresh from the still-
-    // live QAction pointers each time matchSearchCandidates() runs.
-    struct SearchCandidate {
-        QPointer<QAction> action;
-        // Ancestors WITH display text: used for the visible path and for
-        // text matching. A submenu with empty text contributes nothing here.
-        QList<QPointer<QAction>> namedAncestors;
-        // Every ancestor menu-action, named or not: used purely to
-        // propagate the enabled/disabled chain. A submenu can be disabled
-        // while having no title of its own (e.g. a bare grouping menu), and
-        // the original recursive algorithm still honoured that: it checked
-        // menuAction->isEnabled() unconditionally, independent of whether
-        // the menu had a non-empty title. Folding this into namedAncestors
-        // would silently drop that disabled state for untitled submenus.
-        QList<QPointer<QAction>> enablementAncestors;
-    };
-
-    struct SearchResult {
-        QPointer<QAction> action;
-        ActionInfo info;
-
-        bool operator==(const SearchResult &other) const {
-            return action == other.action
-            && info.isEffectivelyEnabled == other.info.isEffectivelyEnabled
-            && info.path == other.info.path
-            && (!action || (action->isChecked() == other.action->isChecked()
-            && action->isCheckable() == other.action->isCheckable()));
-        }
-    };
-
     void resetButtons();
-    QString getActionText(QAction *action) const;
     void setupSearchMenu();
     void repositionSearchMenu();
-    void rebuildSearchCandidatesIfNeeded();
-    void collectSearchCandidates(QMenu *menu, QSet<QMenu *> &visited, QList<QPointer<QAction>> &namedAncestors, QList<QPointer<QAction>> &enablementAncestors);
-    QList<SearchResult> matchSearchCandidates(const QStringMatcher &matcher, bool ignoreTopLevel, bool ignoreSubMenus) const;
     AppMenuButton *getAppMenuButton(int index) const;
     int findNextVisibleButtonIndex(int currentIndex, bool forward) const;
 
@@ -232,24 +185,12 @@ private:
     bool m_isMenuUpdateThrottled = false;
     bool m_pendingMenuUpdate = false;
     bool m_menuLoadedOnce = false;
-    QString m_lastSearchQuery;
-    QList<SearchResult> m_lastResults;
-    // Flat, pre-walked list of searchable leaf actions. Rebuilt only when
-    // the app menu structure actually changes (see rebuildSearchCandidatesIfNeeded()),
-    // not on every keystroke.
-    QList<SearchCandidate> m_searchCandidates;
-    bool m_searchCandidatesDirty = true;
-    // QActionGroups created in filterMenu() to preserve mutual exclusivity
-    // between search-result proxies; owned here (parented to m_searchMenu)
-    // since they aren't owned by any single proxy action anymore and must
-    // be deleted explicitly when the previous results are cleared.
-    QList<QPointer<QActionGroup>> m_searchResultGroups;
+
+    AppMenuSearch *m_search;
 
     QList<QPointer<TextButton>> m_textButtons;
     QPointer<MenuOverflowButton> m_overflowButton;
     QPointer<SearchButton> m_searchButton;
-
-    mutable QHash<QString, QString> m_actionTextCache;
 
     QPointer<KDecoration3::DecorationButton> m_hoveredButton = nullptr;
 

--- a/src/AppMenuButtonGroup.h
+++ b/src/AppMenuButtonGroup.h
@@ -186,7 +186,7 @@ private:
     bool m_pendingMenuUpdate = false;
     bool m_menuLoadedOnce = false;
 
-    AppMenuSearch *m_search;
+    Material::AppMenuSearch *m_search;
 
     QList<QPointer<TextButton>> m_textButtons;
     QPointer<MenuOverflowButton> m_overflowButton;

--- a/src/AppMenuButtonGroup.h
+++ b/src/AppMenuButtonGroup.h
@@ -186,7 +186,7 @@ private:
     bool m_pendingMenuUpdate = false;
     bool m_menuLoadedOnce = false;
 
-    Material::AppMenuSearch *m_search;
+    AppMenuSearch *m_search;
 
     QList<QPointer<TextButton>> m_textButtons;
     QPointer<MenuOverflowButton> m_overflowButton;

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -104,8 +104,8 @@ void AppMenuSearch::filter(QMenu *searchMenu, const QString &text, const FilterO
         }
         QAction *newAction = new QAction(action->icon(), info.path, m_searchMenu);
         newAction->setEnabled(info.isEffectivelyEnabled);
-        newAction->setCheckable(action->isCheckable());
-        newAction->setChecked(action->isChecked());
+        newAction->setCheckable(info.isCheckable);
+        newAction->setChecked(info.isChecked);
         newAction->setProperty("isAppMenuSearchProxy", true); // Uniquely mark as a proxy result action
 
         if (QActionGroup *originalGroup = action->actionGroup(); originalGroup && originalGroup->isExclusive()) {
@@ -169,6 +169,7 @@ void AppMenuSearch::invalidateCandidates()
     m_searchCandidates.clear();
     m_actionTextCache.clear();
     m_lastResults.clear();
+    m_lastProcessedMenu = nullptr;
     m_lastShowDisabledActions = false;
     m_lastIgnoreTopLevel = false;
     m_lastIgnoreSubMenus = false;
@@ -177,6 +178,7 @@ void AppMenuSearch::invalidateCandidates()
 void AppMenuSearch::clearLastResults()
 {
     m_lastResults.clear();
+    m_lastProcessedMenu = nullptr;
     m_lastSearchQuery.clear();
     m_lastShowDisabledActions = false;
     m_lastIgnoreTopLevel = false;
@@ -380,6 +382,8 @@ QList<AppMenuSearch::SearchResult> AppMenuSearch::matchSearchCandidates(const QS
         ActionInfo info;
         info.label = itemText;
         info.isEffectivelyEnabled = isEffectivelyEnabled;
+        info.isChecked = action->isChecked();
+        info.isCheckable = action->isCheckable();
 
         currentPath.append(itemText);
         info.path = currentPath.join(QStringLiteral(" » "));

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -165,6 +165,7 @@ void AppMenuSearch::invalidateCandidates()
     m_searchCandidatesDirty = true;
     m_searchCandidates.clear();
     m_actionTextCache.clear();
+    clearLastResults();
 }
 
 void AppMenuSearch::clearLastResults()

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -39,6 +39,11 @@ AppMenuSearch::AppMenuSearch(AppMenuModel *model, QObject *parent)
 
 AppMenuSearch::~AppMenuSearch() = default;
 
+bool AppMenuSearch::isQueryTooShort(const QString &text)
+{
+    return text.length() < MINIMUM_SEARCH_LENGTH;
+}
+
 void AppMenuSearch::filter(QMenu *searchMenu, const QString &text, bool ignoreTopLevel, bool ignoreSubMenus, bool showDisabledActions)
 {
     if (!searchMenu) {
@@ -47,7 +52,7 @@ void AppMenuSearch::filter(QMenu *searchMenu, const QString &text, bool ignoreTo
     m_lastSearchQuery = text;
 
     // Clear results if search text is too short
-    if (text.length() < 3) {
+    if (isQueryTooShort(text)) {
         clear(searchMenu);
         m_lastResults.clear();
         Q_EMIT repositionRequested();

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -136,16 +136,6 @@ void AppMenuSearch::filter(QMenu *searchMenu, const QString &text, const FilterO
 
 void AppMenuSearch::clear()
 {
-    // The old proxy actions no longer reference these groups (deleteLater()
-    // above), so nothing else owns them: delete explicitly to avoid leaking
-    // one QActionGroup per exclusive result set on every keystroke.
-    for (const QPointer<QActionGroup> &oldGroup : std::as_const(m_searchResultGroups)) {
-        if (oldGroup) {
-            oldGroup->deleteLater();
-        }
-    }
-    m_searchResultGroups.clear();
-
     if (!m_searchMenu) {
         return;
     }
@@ -161,6 +151,16 @@ void AppMenuSearch::clear()
             action->deleteLater();
         }
     }
+
+    // The old proxy actions no longer reference these groups (deleteLater()
+    // above), so nothing else owns them: delete explicitly to avoid leaking
+    // one QActionGroup per exclusive result set on every keystroke.
+    for (const QPointer<QActionGroup> &oldGroup : std::as_const(m_searchResultGroups)) {
+        if (oldGroup) {
+            oldGroup->deleteLater();
+        }
+    }
+    m_searchResultGroups.clear();
 }
 
 void AppMenuSearch::invalidateCandidates()

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -1,8 +1,5 @@
 /*
  * Copyright (C) 2025 Guido Iodice <guido[dot]iodice[at]gmail[dot]com>
- * Copyright (C) 2020 Chris Holland <zrenfire@gmail.com>
- * Copyright (C) 2016 Kai Uwe Broulik <kde@privat.broulik.de>
- * Copyright (C) 2014 by Hugo Pereira Da Costa <hugo.pereira@free.fr>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -158,6 +155,7 @@ void AppMenuSearch::clear(QMenu *searchMenu)
 void AppMenuSearch::invalidateCandidates()
 {
     m_searchCandidatesDirty = true;
+    m_searchCandidates.clear();
     m_actionTextCache.clear();
 }
 

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -69,11 +69,12 @@ void AppMenuSearch::filter(QMenu *searchMenu, const QString &text, bool ignoreTo
         QStringMatcher matcher(text, Qt::CaseInsensitive);
         QList<SearchResult> results = matchSearchCandidates(matcher, ignoreTopLevel, ignoreSubMenus);
 
-        // If results are the same as last time, do nothing to prevent the freeze.
-        if (m_lastResults == results) {
+        // If results and options are the same as last time, do nothing to prevent the freeze.
+        if (m_lastResults == results && m_lastShowDisabledActions == showDisabledActions) {
             return;
         }
 
+        m_lastShowDisabledActions = showDisabledActions;
         m_lastResults = std::move(results);
     } // 'results' goes out of scope here to prevent accidental use-after-move
 
@@ -101,6 +102,7 @@ void AppMenuSearch::filter(QMenu *searchMenu, const QString &text, bool ignoreTo
         newAction->setEnabled(info.isEffectivelyEnabled);
         newAction->setCheckable(action->isCheckable());
         newAction->setChecked(action->isChecked());
+        newAction->setData(true); // Mark as a proxy result action
 
         if (QActionGroup *originalGroup = action->actionGroup(); originalGroup && originalGroup->isExclusive()) {
             QActionGroup *&proxyGroup = groupMap[originalGroup];
@@ -125,8 +127,8 @@ void AppMenuSearch::filter(QMenu *searchMenu, const QString &text, bool ignoreTo
         resultCount++;
     }
 
-    Q_EMIT repositionRequested();
     searchMenu->setUpdatesEnabled(true);
+    Q_EMIT repositionRequested();
 }
 
 void AppMenuSearch::clear(QMenu *searchMenu)
@@ -136,14 +138,15 @@ void AppMenuSearch::clear(QMenu *searchMenu)
     }
 
     const auto actions = searchMenu->actions();
-    for (int i = actions.count() - 1; i >= 2; --i) {
-        QAction *action = actions.at(i);
-        searchMenu->removeAction(action);
-        // Detach action from its group before scheduling deletion
-        if (QActionGroup *group = action->actionGroup()) {
-            group->removeAction(action);
+    for (QAction *action : actions) {
+        if (action && action->data().toBool() == true) {
+            searchMenu->removeAction(action);
+            // Detach action from its group before scheduling deletion
+            if (QActionGroup *group = action->actionGroup()) {
+                group->removeAction(action);
+            }
+            action->deleteLater();
         }
-        action->deleteLater();
     }
 
     // The old proxy actions no longer reference these groups (deleteLater()
@@ -161,13 +164,13 @@ void AppMenuSearch::invalidateCandidates()
 {
     m_searchCandidatesDirty = true;
     m_searchCandidates.clear();
-    m_actionTextCache.clear();
 }
 
 void AppMenuSearch::clearLastResults()
 {
     m_lastResults.clear();
     m_lastSearchQuery.clear();
+    m_lastShowDisabledActions = false;
 }
 
 QString AppMenuSearch::lastSearchQuery() const

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -60,6 +60,9 @@ void AppMenuSearch::filter(QMenu *searchMenu, const QString &text, bool ignoreTo
     }
 
     if (!m_appMenuModel) {
+        clear(searchMenu);
+        m_lastResults.clear();
+        Q_EMIT repositionRequested();
         return;
     }
 

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -47,21 +47,24 @@ bool AppMenuSearch::isQueryTooShort(const QString &text)
 
 void AppMenuSearch::filter(QMenu *searchMenu, const QString &text, const FilterOptions &options)
 {
-    if (!searchMenu) {
+    if (searchMenu) {
+        m_searchMenu = searchMenu;
+    }
+    if (!m_searchMenu) {
         return;
     }
     m_lastSearchQuery = text;
 
     // Clear results if search text is too short
     if (isQueryTooShort(text)) {
-        clear(searchMenu);
+        clear();
         m_lastResults.clear();
         Q_EMIT repositionRequested();
         return;
     }
 
     if (!m_appMenuModel) {
-        clear(searchMenu);
+        clear();
         m_lastResults.clear();
         Q_EMIT repositionRequested();
         return;
@@ -84,10 +87,10 @@ void AppMenuSearch::filter(QMenu *searchMenu, const QString &text, const FilterO
         m_lastResults = std::move(results);
     } // 'results' goes out of scope here to prevent accidental use-after-move
 
-    searchMenu->setUpdatesEnabled(false);
+    m_searchMenu->setUpdatesEnabled(false);
 
     // Clear previous results
-    clear(searchMenu);
+    clear();
 
     // Map each *original* action group to the QActionGroup we create for its
     // search-result proxies, so results that were mutually exclusive in the
@@ -99,7 +102,7 @@ void AppMenuSearch::filter(QMenu *searchMenu, const QString &text, const FilterO
         if (!action) {
             continue;
         }
-        QAction *newAction = new QAction(action->icon(), info.path, searchMenu);
+        QAction *newAction = new QAction(action->icon(), info.path, m_searchMenu);
         newAction->setEnabled(info.isEffectivelyEnabled);
         newAction->setCheckable(action->isCheckable());
         newAction->setChecked(action->isChecked());
@@ -108,7 +111,7 @@ void AppMenuSearch::filter(QMenu *searchMenu, const QString &text, const FilterO
         if (QActionGroup *originalGroup = action->actionGroup(); originalGroup && originalGroup->isExclusive()) {
             QActionGroup *&proxyGroup = groupMap[originalGroup];
             if (!proxyGroup) {
-                proxyGroup = new QActionGroup(searchMenu);
+                proxyGroup = new QActionGroup(m_searchMenu);
                 proxyGroup->setExclusionPolicy(originalGroup->exclusionPolicy());
                 m_searchResultGroups.append(proxyGroup);
             }
@@ -116,7 +119,7 @@ void AppMenuSearch::filter(QMenu *searchMenu, const QString &text, const FilterO
         }
       
         QPointer<QAction> safeAction = action;
-        connect(newAction, &QAction::triggered, this, [safeAction, searchMenu]() {
+        connect(newAction, &QAction::triggered, this, [safeAction, searchMenu = m_searchMenu]() {
             if (safeAction) {
                 safeAction->trigger();
             }
@@ -124,23 +127,23 @@ void AppMenuSearch::filter(QMenu *searchMenu, const QString &text, const FilterO
                 searchMenu->hide();
             }
         });
-        searchMenu->addAction(newAction);
+        m_searchMenu->addAction(newAction);
     }
 
-    searchMenu->setUpdatesEnabled(true);
+    m_searchMenu->setUpdatesEnabled(true);
     Q_EMIT repositionRequested();
 }
 
-void AppMenuSearch::clear(QMenu *searchMenu)
+void AppMenuSearch::clear()
 {
-    if (!searchMenu) {
+    if (!m_searchMenu) {
         return;
     }
 
-    const auto actions = searchMenu->actions();
+    const auto actions = m_searchMenu->actions();
     for (QAction *action : actions) {
         if (action && action->data().toString() == SEARCH_PROXY_MARKER) {
-            searchMenu->removeAction(action);
+            m_searchMenu->removeAction(action);
             // Detach action from its group before scheduling deletion
             if (QActionGroup *group = action->actionGroup()) {
                 group->removeAction(action);
@@ -165,7 +168,10 @@ void AppMenuSearch::invalidateCandidates()
     m_searchCandidatesDirty = true;
     m_searchCandidates.clear();
     m_actionTextCache.clear();
-    clearLastResults();
+    m_lastResults.clear();
+    m_lastShowDisabledActions = false;
+    m_lastIgnoreTopLevel = false;
+    m_lastIgnoreSubMenus = false;
 }
 
 void AppMenuSearch::clearLastResults()

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -27,6 +27,7 @@
 
 static constexpr int MAX_SEARCH_RESULTS = 100;
 static constexpr int MAX_SEARCH_CANDIDATES = 5000;
+static const QString SEARCH_PROXY_MARKER = QStringLiteral("AppMenuSearchProxy");
 
 namespace Material
 {
@@ -44,7 +45,7 @@ bool AppMenuSearch::isQueryTooShort(const QString &text)
     return text.length() < MINIMUM_SEARCH_LENGTH;
 }
 
-void AppMenuSearch::filter(QMenu *searchMenu, const QString &text, bool ignoreTopLevel, bool ignoreSubMenus, bool showDisabledActions)
+void AppMenuSearch::filter(QMenu *searchMenu, const QString &text, const FilterOptions &options)
 {
     if (!searchMenu) {
         return;
@@ -70,16 +71,16 @@ void AppMenuSearch::filter(QMenu *searchMenu, const QString &text, bool ignoreTo
         // Find results
         rebuildSearchCandidatesIfNeeded();
         QStringMatcher matcher(text, Qt::CaseInsensitive);
-        QList<SearchResult> results = matchSearchCandidates(matcher, ignoreTopLevel, ignoreSubMenus, showDisabledActions);
+        QList<SearchResult> results = matchSearchCandidates(matcher, options.ignoreTopLevel, options.ignoreSubMenus, options.showDisabledActions);
 
         // If results and options are the same as last time, do nothing to prevent the freeze.
-        if (m_lastResults == results && m_lastShowDisabledActions == showDisabledActions && m_lastIgnoreTopLevel == ignoreTopLevel && m_lastIgnoreSubMenus == ignoreSubMenus) {
+        if (m_lastResults == results && m_lastShowDisabledActions == options.showDisabledActions && m_lastIgnoreTopLevel == options.ignoreTopLevel && m_lastIgnoreSubMenus == options.ignoreSubMenus) {
             return;
         }
 
-        m_lastShowDisabledActions = showDisabledActions;
-        m_lastIgnoreTopLevel = ignoreTopLevel;
-        m_lastIgnoreSubMenus = ignoreSubMenus;
+        m_lastShowDisabledActions = options.showDisabledActions;
+        m_lastIgnoreTopLevel = options.ignoreTopLevel;
+        m_lastIgnoreSubMenus = options.ignoreSubMenus;
         m_lastResults = std::move(results);
     } // 'results' goes out of scope here to prevent accidental use-after-move
 
@@ -88,29 +89,21 @@ void AppMenuSearch::filter(QMenu *searchMenu, const QString &text, bool ignoreTo
     // Clear previous results
     clear(searchMenu);
 
-    int resultCount = 0;
     // Map each *original* action group to the QActionGroup we create for its
     // search-result proxies, so results that were mutually exclusive in the
     // real menu (e.g. radio-button items) stay mutually exclusive here too.
     QHash<QActionGroup *, QActionGroup *> groupMap;
     for (const SearchResult &result : std::as_const(m_lastResults)) {
-        if (resultCount >= MAX_SEARCH_RESULTS) { // stop after 100 results
-            break;
-        }
-
         const ActionInfo &info = result.info;
         QAction *action = result.action.data();
         if (!action) {
-            continue;
-        }
-        if (!info.isEffectivelyEnabled && !showDisabledActions) {
             continue;
         }
         QAction *newAction = new QAction(action->icon(), info.path, searchMenu);
         newAction->setEnabled(info.isEffectivelyEnabled);
         newAction->setCheckable(action->isCheckable());
         newAction->setChecked(action->isChecked());
-        newAction->setData(QStringLiteral("AppMenuSearchProxy")); // Uniquely mark as a proxy result action
+        newAction->setData(SEARCH_PROXY_MARKER); // Uniquely mark as a proxy result action
 
         if (QActionGroup *originalGroup = action->actionGroup(); originalGroup && originalGroup->isExclusive()) {
             QActionGroup *&proxyGroup = groupMap[originalGroup];
@@ -132,7 +125,6 @@ void AppMenuSearch::filter(QMenu *searchMenu, const QString &text, bool ignoreTo
             }
         });
         searchMenu->addAction(newAction);
-        resultCount++;
     }
 
     searchMenu->setUpdatesEnabled(true);
@@ -147,7 +139,7 @@ void AppMenuSearch::clear(QMenu *searchMenu)
 
     const auto actions = searchMenu->actions();
     for (QAction *action : actions) {
-        if (action && action->data().toString() == QStringLiteral("AppMenuSearchProxy")) {
+        if (action && action->data().toString() == SEARCH_PROXY_MARKER) {
             searchMenu->removeAction(action);
             // Detach action from its group before scheduling deletion
             if (QActionGroup *group = action->actionGroup()) {
@@ -267,8 +259,8 @@ QList<AppMenuSearch::SearchResult> AppMenuSearch::matchSearchCandidates(const QS
     // would silently drop the disabled state of untitled submenus.
     QHash<QAction *, bool> enabledCache; // cumulative isEnabled up to and including this ancestor
     struct MatchState {
-        bool currentMatched;
-        QString text;
+        bool currentMatched = false;
+        QString text = QString();
     };
     QHash<QAction *, MatchState> matchCache; // cumulative match state + this ancestor's text
 

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -76,7 +76,7 @@ void AppMenuSearch::filter(QMenu *searchMenu, const QString &text, const FilterO
         QList<SearchResult> results = matchSearchCandidates(matcher, options.ignoreTopLevel, options.ignoreSubMenus, options.showDisabledActions);
 
         // If results and options are the same as last time, do nothing to prevent the freeze.
-        if (m_lastResults == results && m_lastShowDisabledActions == options.showDisabledActions && m_lastIgnoreTopLevel == options.ignoreTopLevel && m_lastIgnoreSubMenus == options.ignoreSubMenus) {
+        if (m_lastProcessedMenu == m_searchMenu && m_lastResults == results && m_lastShowDisabledActions == options.showDisabledActions && m_lastIgnoreTopLevel == options.ignoreTopLevel && m_lastIgnoreSubMenus == options.ignoreSubMenus) {
             return;
         }
 
@@ -84,6 +84,7 @@ void AppMenuSearch::filter(QMenu *searchMenu, const QString &text, const FilterO
         m_lastIgnoreTopLevel = options.ignoreTopLevel;
         m_lastIgnoreSubMenus = options.ignoreSubMenus;
         m_lastResults = std::move(results);
+        m_lastProcessedMenu = m_searchMenu;
     } // 'results' goes out of scope here to prevent accidental use-after-move
 
     m_searchMenu->setUpdatesEnabled(false);
@@ -135,6 +136,16 @@ void AppMenuSearch::filter(QMenu *searchMenu, const QString &text, const FilterO
 
 void AppMenuSearch::clear()
 {
+    // The old proxy actions no longer reference these groups (deleteLater()
+    // above), so nothing else owns them: delete explicitly to avoid leaking
+    // one QActionGroup per exclusive result set on every keystroke.
+    for (const QPointer<QActionGroup> &oldGroup : std::as_const(m_searchResultGroups)) {
+        if (oldGroup) {
+            oldGroup->deleteLater();
+        }
+    }
+    m_searchResultGroups.clear();
+
     if (!m_searchMenu) {
         return;
     }
@@ -150,16 +161,6 @@ void AppMenuSearch::clear()
             action->deleteLater();
         }
     }
-
-    // The old proxy actions no longer reference these groups (deleteLater()
-    // above), so nothing else owns them: delete explicitly to avoid leaking
-    // one QActionGroup per exclusive result set on every keystroke.
-    for (const QPointer<QActionGroup> &oldGroup : std::as_const(m_searchResultGroups)) {
-        if (oldGroup) {
-            oldGroup->deleteLater();
-        }
-    }
-    m_searchResultGroups.clear();
 }
 
 void AppMenuSearch::invalidateCandidates()

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -27,7 +27,6 @@
 
 static constexpr int MAX_SEARCH_RESULTS = 100;
 static constexpr int MAX_SEARCH_CANDIDATES = 5000;
-static const QString SEARCH_PROXY_MARKER = QStringLiteral("AppMenuSearchProxy");
 
 namespace Material
 {
@@ -106,7 +105,7 @@ void AppMenuSearch::filter(QMenu *searchMenu, const QString &text, const FilterO
         newAction->setEnabled(info.isEffectivelyEnabled);
         newAction->setCheckable(action->isCheckable());
         newAction->setChecked(action->isChecked());
-        newAction->setData(SEARCH_PROXY_MARKER); // Uniquely mark as a proxy result action
+        newAction->setProperty("isAppMenuSearchProxy", true); // Uniquely mark as a proxy result action
 
         if (QActionGroup *originalGroup = action->actionGroup(); originalGroup && originalGroup->isExclusive()) {
             QActionGroup *&proxyGroup = groupMap[originalGroup];
@@ -142,7 +141,7 @@ void AppMenuSearch::clear()
 
     const auto actions = m_searchMenu->actions();
     for (QAction *action : actions) {
-        if (action && action->data().toString() == SEARCH_PROXY_MARKER) {
+        if (action && action->property("isAppMenuSearchProxy").toBool() == true) {
             m_searchMenu->removeAction(action);
             // Detach action from its group before scheduling deletion
             if (QActionGroup *group = action->actionGroup()) {

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -106,7 +106,7 @@ void AppMenuSearch::filter(QMenu *searchMenu, const QString &text, const FilterO
         newAction->setEnabled(info.isEffectivelyEnabled);
         newAction->setCheckable(info.isCheckable);
         newAction->setChecked(info.isChecked);
-        newAction->setProperty("isAppMenuSearchProxy", true); // Uniquely mark as a proxy result action
+        newAction->setProperty(PROPERTY_SEARCH_PROXY, true); // Uniquely mark as a proxy result action
 
         if (QActionGroup *originalGroup = action->actionGroup(); originalGroup && originalGroup->isExclusive()) {
             QActionGroup *&proxyGroup = groupMap[originalGroup];
@@ -142,7 +142,7 @@ void AppMenuSearch::clear()
 
     const auto actions = m_searchMenu->actions();
     for (QAction *action : actions) {
-        if (action && action->property("isAppMenuSearchProxy").toBool() == true) {
+        if (action && action->property(PROPERTY_SEARCH_PROXY).toBool() == true) {
             m_searchMenu->removeAction(action);
             // Detach action from its group before scheduling deletion
             if (QActionGroup *group = action->actionGroup()) {
@@ -168,18 +168,19 @@ void AppMenuSearch::invalidateCandidates()
     m_searchCandidatesDirty = true;
     m_searchCandidates.clear();
     m_actionTextCache.clear();
-    m_lastResults.clear();
-    m_lastProcessedMenu = nullptr;
-    m_lastShowDisabledActions = false;
-    m_lastIgnoreTopLevel = false;
-    m_lastIgnoreSubMenus = false;
+    resetSearchState();
 }
 
 void AppMenuSearch::clearLastResults()
 {
+    resetSearchState();
+    m_lastSearchQuery.clear();
+}
+
+void AppMenuSearch::resetSearchState()
+{
     m_lastResults.clear();
     m_lastProcessedMenu = nullptr;
-    m_lastSearchQuery.clear();
     m_lastShowDisabledActions = false;
     m_lastIgnoreTopLevel = false;
     m_lastIgnoreSubMenus = false;

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -73,11 +73,13 @@ void AppMenuSearch::filter(QMenu *searchMenu, const QString &text, bool ignoreTo
         QList<SearchResult> results = matchSearchCandidates(matcher, ignoreTopLevel, ignoreSubMenus);
 
         // If results and options are the same as last time, do nothing to prevent the freeze.
-        if (m_lastResults == results && m_lastShowDisabledActions == showDisabledActions) {
+        if (m_lastResults == results && m_lastShowDisabledActions == showDisabledActions && m_lastIgnoreTopLevel == ignoreTopLevel && m_lastIgnoreSubMenus == ignoreSubMenus) {
             return;
         }
 
         m_lastShowDisabledActions = showDisabledActions;
+        m_lastIgnoreTopLevel = ignoreTopLevel;
+        m_lastIgnoreSubMenus = ignoreSubMenus;
         m_lastResults = std::move(results);
     } // 'results' goes out of scope here to prevent accidental use-after-move
 
@@ -105,7 +107,7 @@ void AppMenuSearch::filter(QMenu *searchMenu, const QString &text, bool ignoreTo
         newAction->setEnabled(info.isEffectivelyEnabled);
         newAction->setCheckable(action->isCheckable());
         newAction->setChecked(action->isChecked());
-        newAction->setData(true); // Mark as a proxy result action
+        newAction->setData(QStringLiteral("AppMenuSearchProxy")); // Uniquely mark as a proxy result action
 
         if (QActionGroup *originalGroup = action->actionGroup(); originalGroup && originalGroup->isExclusive()) {
             QActionGroup *&proxyGroup = groupMap[originalGroup];
@@ -142,7 +144,7 @@ void AppMenuSearch::clear(QMenu *searchMenu)
 
     const auto actions = searchMenu->actions();
     for (QAction *action : actions) {
-        if (action && action->data().toBool() == true) {
+        if (action && action->data().toString() == QStringLiteral("AppMenuSearchProxy")) {
             searchMenu->removeAction(action);
             // Detach action from its group before scheduling deletion
             if (QActionGroup *group = action->actionGroup()) {
@@ -174,6 +176,8 @@ void AppMenuSearch::clearLastResults()
     m_lastResults.clear();
     m_lastSearchQuery.clear();
     m_lastShowDisabledActions = false;
+    m_lastIgnoreTopLevel = false;
+    m_lastIgnoreSubMenus = false;
 }
 
 QString AppMenuSearch::lastSearchQuery() const

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -70,7 +70,7 @@ void AppMenuSearch::filter(QMenu *searchMenu, const QString &text, bool ignoreTo
         // Find results
         rebuildSearchCandidatesIfNeeded();
         QStringMatcher matcher(text, Qt::CaseInsensitive);
-        QList<SearchResult> results = matchSearchCandidates(matcher, ignoreTopLevel, ignoreSubMenus);
+        QList<SearchResult> results = matchSearchCandidates(matcher, ignoreTopLevel, ignoreSubMenus, showDisabledActions);
 
         // If results and options are the same as last time, do nothing to prevent the freeze.
         if (m_lastResults == results && m_lastShowDisabledActions == showDisabledActions && m_lastIgnoreTopLevel == ignoreTopLevel && m_lastIgnoreSubMenus == ignoreSubMenus) {
@@ -99,7 +99,10 @@ void AppMenuSearch::filter(QMenu *searchMenu, const QString &text, bool ignoreTo
         }
 
         const ActionInfo &info = result.info;
-        QAction *action = result.action;
+        QAction *action = result.action.data();
+        if (!action) {
+            continue;
+        }
         if (!info.isEffectivelyEnabled && !showDisabledActions) {
             continue;
         }
@@ -169,6 +172,7 @@ void AppMenuSearch::invalidateCandidates()
 {
     m_searchCandidatesDirty = true;
     m_searchCandidates.clear();
+    m_actionTextCache.clear();
 }
 
 void AppMenuSearch::clearLastResults()
@@ -251,7 +255,7 @@ void AppMenuSearch::collectSearchCandidates(QMenu *menu, QSet<QMenu *> &visited,
     }
 }
 
-QList<AppMenuSearch::SearchResult> AppMenuSearch::matchSearchCandidates(const QStringMatcher &matcher, bool ignoreTopLevel, bool ignoreSubMenus) const
+QList<AppMenuSearch::SearchResult> AppMenuSearch::matchSearchCandidates(const QStringMatcher &matcher, bool ignoreTopLevel, bool ignoreSubMenus, bool showDisabledActions) const
 {
     QList<SearchResult> results;
 
@@ -361,6 +365,11 @@ QList<AppMenuSearch::SearchResult> AppMenuSearch::matchSearchCandidates(const QS
             continue; // Skip building path entirely for non-matching entries!
         }
 
+        const bool isEffectivelyEnabled = isCurrentEnabled && action->isEnabled();
+        if (!isEffectivelyEnabled && !showDisabledActions) {
+            continue;
+        }
+
         // 2. Only perform path allocation and joins for matching results
         QStringList currentPath;
         currentPath.reserve(candidate.namedAncestors.size() + 1);
@@ -371,11 +380,10 @@ QList<AppMenuSearch::SearchResult> AppMenuSearch::matchSearchCandidates(const QS
 
         ActionInfo info;
         info.label = itemText;
-        info.isEffectivelyEnabled = isCurrentEnabled && action->isEnabled();
+        info.isEffectivelyEnabled = isEffectivelyEnabled;
 
         currentPath.append(itemText);
         info.path = currentPath.join(QStringLiteral(" » "));
-        info.searchablePath = (currentPath.size() > 1) ? currentPath.mid(1).join(QStringLiteral(" » ")) : itemText;
 
         results.append({action, info});
     }

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -57,14 +57,14 @@ void AppMenuSearch::filter(QMenu *searchMenu, const QString &text, const FilterO
     // Clear results if search text is too short
     if (isQueryTooShort(text)) {
         clear();
-        m_lastResults.clear();
+        resetSearchState();
         Q_EMIT repositionRequested();
         return;
     }
 
     if (!m_appMenuModel) {
         clear();
-        m_lastResults.clear();
+        resetSearchState();
         Q_EMIT repositionRequested();
         return;
     }
@@ -167,7 +167,6 @@ void AppMenuSearch::invalidateCandidates()
 {
     m_searchCandidatesDirty = true;
     m_searchCandidates.clear();
-    m_actionTextCache.clear();
     resetSearchState();
 }
 
@@ -175,6 +174,7 @@ void AppMenuSearch::clearLastResults()
 {
     resetSearchState();
     m_lastSearchQuery.clear();
+    m_actionTextCache.clear();
 }
 
 void AppMenuSearch::resetSearchState()

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -1,0 +1,388 @@
+/*
+ * Copyright (C) 2025 Guido Iodice <guido[dot]iodice[at]gmail[dot]com>
+ * Copyright (C) 2020 Chris Holland <zrenfire@gmail.com>
+ * Copyright (C) 2016 Kai Uwe Broulik <kde@privat.broulik.de>
+ * Copyright (C) 2014 by Hugo Pereira Da Costa <hugo.pereira@free.fr>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AppMenuSearch.h"
+#include "AppMenuModel.h"
+
+// KF
+#include <KLocalizedString>
+
+// Qt
+#include <QDebug>
+#include <utility>
+
+static constexpr int MAX_SEARCH_RESULTS = 100;
+static constexpr int MAX_SEARCH_CANDIDATES = 5000;
+
+namespace Material
+{
+
+AppMenuSearch::AppMenuSearch(AppMenuModel *model, QObject *parent)
+    : QObject(parent)
+    , m_appMenuModel(model)
+{
+}
+
+AppMenuSearch::~AppMenuSearch() = default;
+
+void AppMenuSearch::filter(QMenu *searchMenu, const QString &text, bool ignoreTopLevel, bool ignoreSubMenus, bool showDisabledActions)
+{
+    if (!searchMenu) {
+        return;
+    }
+    m_lastSearchQuery = text;
+
+    // Clear results if search text is too short
+    if (text.length() < 3) {
+        clear(searchMenu);
+        m_lastResults.clear();
+        Q_EMIT repositionRequested();
+        return;
+    }
+
+    if (!m_appMenuModel) {
+        return;
+    }
+
+    {
+        // Find results
+        rebuildSearchCandidatesIfNeeded();
+        QStringMatcher matcher(text, Qt::CaseInsensitive);
+        QList<SearchResult> results = matchSearchCandidates(matcher, ignoreTopLevel, ignoreSubMenus);
+
+        // If results are the same as last time, do nothing to prevent the freeze.
+        if (m_lastResults == results) {
+            return;
+        }
+
+        m_lastResults = std::move(results);
+    } // 'results' goes out of scope here to prevent accidental use-after-move
+
+    searchMenu->setUpdatesEnabled(false);
+
+    // Clear previous results
+    clear(searchMenu);
+
+    int resultCount = 0;
+    // Map each *original* action group to the QActionGroup we create for its
+    // search-result proxies, so results that were mutually exclusive in the
+    // real menu (e.g. radio-button items) stay mutually exclusive here too.
+    QHash<QActionGroup *, QActionGroup *> groupMap;
+    for (const SearchResult &result : std::as_const(m_lastResults)) {
+        if (resultCount >= MAX_SEARCH_RESULTS) { // stop after 100 results
+            break;
+        }
+
+        const ActionInfo &info = result.info;
+        QAction *action = result.action;
+        if (!info.isEffectivelyEnabled && !showDisabledActions) {
+            continue;
+        }
+        QAction *newAction = new QAction(action->icon(), info.path, searchMenu);
+        newAction->setEnabled(info.isEffectivelyEnabled);
+        newAction->setCheckable(action->isCheckable());
+        newAction->setChecked(action->isChecked());
+
+        if (QActionGroup *originalGroup = action->actionGroup(); originalGroup && originalGroup->isExclusive()) {
+            QActionGroup *&proxyGroup = groupMap[originalGroup];
+            if (!proxyGroup) {
+                proxyGroup = new QActionGroup(searchMenu);
+                proxyGroup->setExclusionPolicy(originalGroup->exclusionPolicy());
+                m_searchResultGroups.append(proxyGroup);
+            }
+            proxyGroup->addAction(newAction);
+        }
+      
+        QPointer<QAction> safeAction = action;
+        connect(newAction, &QAction::triggered, this, [safeAction, searchMenu]() {
+            if (safeAction) {
+                safeAction->trigger();
+            }
+            if (searchMenu) {
+                searchMenu->hide();
+            }
+        });
+        searchMenu->addAction(newAction);
+        resultCount++;
+    }
+
+    Q_EMIT repositionRequested();
+    searchMenu->setUpdatesEnabled(true);
+}
+
+void AppMenuSearch::clear(QMenu *searchMenu)
+{
+    if (!searchMenu) {
+        return;
+    }
+
+    const auto actions = searchMenu->actions();
+    for (int i = actions.count() - 1; i >= 2; --i) {
+        QAction *action = actions.at(i);
+        searchMenu->removeAction(action);
+        // Detach action from its group before scheduling deletion
+        if (QActionGroup *group = action->actionGroup()) {
+            group->removeAction(action);
+        }
+        action->deleteLater();
+    }
+
+    // The old proxy actions no longer reference these groups (deleteLater()
+    // above), so nothing else owns them: delete explicitly to avoid leaking
+    // one QActionGroup per exclusive result set on every keystroke.
+    for (const QPointer<QActionGroup> &oldGroup : std::as_const(m_searchResultGroups)) {
+        if (oldGroup) {
+            oldGroup->deleteLater();
+        }
+    }
+    m_searchResultGroups.clear();
+}
+
+void AppMenuSearch::invalidateCandidates()
+{
+    m_searchCandidatesDirty = true;
+    m_actionTextCache.clear();
+}
+
+void AppMenuSearch::clearLastResults()
+{
+    m_lastResults.clear();
+    m_lastSearchQuery.clear();
+}
+
+QString AppMenuSearch::lastSearchQuery() const
+{
+    return m_lastSearchQuery;
+}
+
+void AppMenuSearch::rebuildSearchCandidatesIfNeeded()
+{
+    if (!m_searchCandidatesDirty) {
+        return;
+    }
+    m_searchCandidatesDirty = false;
+    m_searchCandidates.clear();
+
+    if (!m_appMenuModel) {
+        return;
+    }
+    QMenu *rootMenu = m_appMenuModel->menu();
+    if (!rootMenu) {
+        return;
+    }
+
+    QSet<QMenu *> visited;
+    QList<QPointer<QAction>> namedAncestors;
+    QList<QPointer<QAction>> enablementAncestors;
+    collectSearchCandidates(rootMenu, visited, namedAncestors, enablementAncestors);
+}
+
+void AppMenuSearch::collectSearchCandidates(QMenu *menu, QSet<QMenu *> &visited, QList<QPointer<QAction>> &namedAncestors, QList<QPointer<QAction>> &enablementAncestors)
+{
+    if (!menu || visited.contains(menu) || m_searchCandidates.size() >= MAX_SEARCH_CANDIDATES) {
+        return;
+    }
+    visited.insert(menu);
+
+    QAction *menuAction = menu->menuAction();
+    bool addedNamed = false;
+    bool addedEnablement = false;
+    if (menuAction) {
+        // Unconditional: even an untitled submenu still gates whether its
+        // children are reachable/enabled, so its own enabled state must
+        // propagate down regardless of whether it has display text.
+        enablementAncestors.append(menuAction);
+        addedEnablement = true;
+        if (!getActionText(menuAction).isEmpty()) {
+            namedAncestors.append(menuAction);
+            addedNamed = true;
+        }
+    }
+
+    for (QAction *action : menu->actions()) {
+        if (m_searchCandidates.size() >= MAX_SEARCH_CANDIDATES) {
+            break;
+        }
+        if (action->isSeparator()) {
+            continue;
+        }
+        if (action->menu()) {
+            collectSearchCandidates(action->menu(), visited, namedAncestors, enablementAncestors);
+        } else {
+            m_searchCandidates.append({action, namedAncestors, enablementAncestors});
+        }
+    }
+
+    if (addedNamed) {
+        namedAncestors.removeLast();
+    }
+    if (addedEnablement) {
+        enablementAncestors.removeLast();
+    }
+}
+
+QList<AppMenuSearch::SearchResult> AppMenuSearch::matchSearchCandidates(const QStringMatcher &matcher, bool ignoreTopLevel, bool ignoreSubMenus) const
+{
+    QList<SearchResult> results;
+
+    // Two independent memoized chains, mirroring how the original recursive
+    // algorithm kept these concerns separate: a submenu's *enabled* state
+    // always propagates to its children, even if the submenu has no title
+    // of its own; its *title* only contributes to the visible path/matching
+    // when non-empty. Folding both into a single "named ancestors" chain
+    // would silently drop the disabled state of untitled submenus.
+    QHash<QAction *, bool> enabledCache; // cumulative isEnabled up to and including this ancestor
+    struct MatchState {
+        bool currentMatched;
+        QString text;
+    };
+    QHash<QAction *, MatchState> matchCache; // cumulative match state + this ancestor's text
+
+    for (const SearchCandidate &candidate : std::as_const(m_searchCandidates)) {
+        if (results.size() >= MAX_SEARCH_RESULTS) {
+            break;
+        }
+        QAction *action = candidate.action;
+        if (!action) {
+            continue; // Action was destroyed since the cache was built.
+        }
+
+        bool ancestorsStillValid = true;
+
+        // --- Enabled chain (every ancestor, named or not) ---
+        bool isCurrentEnabled = true;
+        if (!candidate.enablementAncestors.isEmpty()) {
+            QAction *deepest = candidate.enablementAncestors.last();
+            if (!deepest) {
+                ancestorsStillValid = false;
+            } else {
+                auto it = enabledCache.find(deepest);
+                if (it != enabledCache.end()) {
+                    isCurrentEnabled = it.value();
+                } else {
+                    for (QAction *ancestor : std::as_const(candidate.enablementAncestors)) {
+                        if (!ancestor) {
+                            ancestorsStillValid = false;
+                            break;
+                        }
+                        auto it2 = enabledCache.find(ancestor);
+                        if (it2 != enabledCache.end()) {
+                            isCurrentEnabled = it2.value();
+                        } else {
+                            if (!ancestor->isEnabled()) {
+                                isCurrentEnabled = false;
+                            }
+                            enabledCache.insert(ancestor, isCurrentEnabled);
+                        }
+                    }
+                }
+            }
+        }
+
+        // --- Match/text chain (only ancestors with a non-empty title) ---
+        bool currentMatched = false;
+        if (ancestorsStillValid && !candidate.namedAncestors.isEmpty()) {
+            QAction *parent = candidate.namedAncestors.last();
+            if (!parent) {
+                ancestorsStillValid = false;
+            } else {
+                auto it = matchCache.find(parent);
+                if (it != matchCache.end()) {
+                    currentMatched = it.value().currentMatched;
+                } else {
+                    for (int i = 0; i < candidate.namedAncestors.size(); ++i) {
+                        QAction *ancestor = candidate.namedAncestors.at(i);
+                        if (!ancestor) {
+                            ancestorsStillValid = false;
+                            break;
+                        }
+                        auto it2 = matchCache.find(ancestor);
+                        if (it2 != matchCache.end()) {
+                            currentMatched = it2.value().currentMatched;
+                        } else {
+                            QString ancestorText = getActionText(ancestor);
+                            if (!currentMatched && (!ignoreTopLevel || i > 0)) {
+                                if (matcher.indexIn(ancestorText) != -1) {
+                                    currentMatched = true;
+                                }
+                            }
+                            matchCache.insert(ancestor, {currentMatched, ancestorText});
+                        }
+                    }
+                }
+            }
+        }
+
+        if (!ancestorsStillValid) {
+            continue; // A submenu in the path was rebuilt/destroyed; skip until next full rebuild.
+        }
+
+        const QString itemText = getActionText(action);
+        bool match = currentMatched;
+        if (ignoreSubMenus) {
+            match = matcher.indexIn(itemText) != -1;
+        } else if (!match && (!ignoreTopLevel || !candidate.namedAncestors.isEmpty())) {
+            if (matcher.indexIn(itemText) != -1) {
+                match = true;
+            }
+        }
+
+        if (!match) {
+            continue; // Skip building path entirely for non-matching entries!
+        }
+
+        // 2. Only perform path allocation and joins for matching results
+        QStringList currentPath;
+        currentPath.reserve(candidate.namedAncestors.size() + 1);
+        for (int i = 0; i < candidate.namedAncestors.size(); ++i) {
+            QAction *ancestor = candidate.namedAncestors.at(i);
+            currentPath.append(matchCache.value(ancestor).text);
+        }
+
+        ActionInfo info;
+        info.label = itemText;
+        info.isEffectivelyEnabled = isCurrentEnabled && action->isEnabled();
+
+        currentPath.append(itemText);
+        info.path = currentPath.join(QStringLiteral(" » "));
+        info.searchablePath = (currentPath.size() > 1) ? currentPath.mid(1).join(QStringLiteral(" » ")) : itemText;
+
+        results.append({action, info});
+    }
+
+    return results;
+}
+
+QString AppMenuSearch::getActionText(QAction *action) const
+{
+    if (!action) {
+        return QString();
+    }
+    const QString rawText = action->text();
+    auto it = m_actionTextCache.find(rawText);
+    if (it != m_actionTextCache.end()) {
+        return it.value();
+    }
+    const QString cleanedText = KLocalizedString::removeAcceleratorMarker(rawText.trimmed());
+    m_actionTextCache.insert(rawText, cleanedText);
+    return cleanedText;
+}
+
+} // namespace Material

--- a/src/AppMenuSearch.h
+++ b/src/AppMenuSearch.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (C) 2025 Guido Iodice <guido[dot]iodice[at]gmail[dot]com>
- * Copyright (C) 2020 Chris Holland <zrenfire@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/AppMenuSearch.h
+++ b/src/AppMenuSearch.h
@@ -48,7 +48,7 @@ public:
         QString path;
         QString searchablePath;
         QString label;
-        bool isEffectivelyEnabled;
+        bool isEffectivelyEnabled = false;
     };
 
     struct SearchCandidate {
@@ -89,6 +89,7 @@ private:
 
     QPointer<AppMenuModel> m_appMenuModel;
     QString m_lastSearchQuery;
+    bool m_lastShowDisabledActions = false;
     QList<SearchResult> m_lastResults;
     QList<SearchCandidate> m_searchCandidates;
     bool m_searchCandidatesDirty = true;

--- a/src/AppMenuSearch.h
+++ b/src/AppMenuSearch.h
@@ -42,6 +42,7 @@ public:
     ~AppMenuSearch() override;
 
     static constexpr int MINIMUM_SEARCH_LENGTH = 3;
+    static constexpr const char PROPERTY_SEARCH_PROXY[] = "isAppMenuSearchProxy";
     static bool isQueryTooShort(const QString &text);
 
     struct ActionInfo {
@@ -93,6 +94,7 @@ private:
     void collectSearchCandidates(QMenu *menu, QSet<QMenu *> &visited, QList<QPointer<QAction>> &namedAncestors, QList<QPointer<QAction>> &enablementAncestors);
     QList<SearchResult> matchSearchCandidates(const QStringMatcher &matcher, bool ignoreTopLevel, bool ignoreSubMenus, bool showDisabledActions) const;
     QString getActionText(QAction *action) const;
+    void resetSearchState();
 
     QPointer<AppMenuModel> m_appMenuModel;
     QPointer<QMenu> m_searchMenu;

--- a/src/AppMenuSearch.h
+++ b/src/AppMenuSearch.h
@@ -90,6 +90,8 @@ private:
     QPointer<AppMenuModel> m_appMenuModel;
     QString m_lastSearchQuery;
     bool m_lastShowDisabledActions = false;
+    bool m_lastIgnoreTopLevel = false;
+    bool m_lastIgnoreSubMenus = false;
     QList<SearchResult> m_lastResults;
     QList<SearchCandidate> m_searchCandidates;
     bool m_searchCandidatesDirty = true;

--- a/src/AppMenuSearch.h
+++ b/src/AppMenuSearch.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2025 Guido Iodice <guido[dot]iodice[at]gmail[dot]com>
+ * Copyright (C) 2020 Chris Holland <zrenfire@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QObject>
+#include <QMenu>
+#include <QAction>
+#include <QActionGroup>
+#include <QPointer>
+#include <QList>
+#include <QSet>
+#include <QHash>
+#include <QStringList>
+#include <QStringMatcher>
+
+namespace Material
+{
+
+class AppMenuModel;
+
+class AppMenuSearch : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit AppMenuSearch(AppMenuModel *model, QObject *parent = nullptr);
+    ~AppMenuSearch() override;
+
+    struct ActionInfo {
+        QString path;
+        QString searchablePath;
+        QString label;
+        bool isEffectivelyEnabled;
+    };
+
+    struct SearchCandidate {
+        QPointer<QAction> action;
+        QList<QPointer<QAction>> namedAncestors;
+        QList<QPointer<QAction>> enablementAncestors;
+    };
+
+    struct SearchResult {
+        QPointer<QAction> action;
+        ActionInfo info;
+
+        bool operator==(const SearchResult &other) const {
+            return action == other.action
+            && info.isEffectivelyEnabled == other.info.isEffectivelyEnabled
+            && info.path == other.info.path
+            && (!action || (action->isChecked() == other.action->isChecked()
+            && action->isCheckable() == other.action->isCheckable()));
+        }
+    };
+
+    void filter(QMenu *searchMenu, const QString &text, bool ignoreTopLevel, bool ignoreSubMenus, bool showDisabledActions);
+    void clear(QMenu *searchMenu);
+    
+    void invalidateCandidates();
+    void clearLastResults();
+    
+    QString lastSearchQuery() const;
+
+signals:
+    void repositionRequested();
+
+private:
+    void rebuildSearchCandidatesIfNeeded();
+    void collectSearchCandidates(QMenu *menu, QSet<QMenu *> &visited, QList<QPointer<QAction>> &namedAncestors, QList<QPointer<QAction>> &enablementAncestors);
+    QList<SearchResult> matchSearchCandidates(const QStringMatcher &matcher, bool ignoreTopLevel, bool ignoreSubMenus) const;
+    QString getActionText(QAction *action) const;
+
+    AppMenuModel *m_appMenuModel;
+    QString m_lastSearchQuery;
+    QList<SearchResult> m_lastResults;
+    QList<SearchCandidate> m_searchCandidates;
+    bool m_searchCandidatesDirty = true;
+    QList<QPointer<QActionGroup>> m_searchResultGroups;
+    mutable QHash<QString, QString> m_actionTextCache;
+};
+
+} // namespace Material

--- a/src/AppMenuSearch.h
+++ b/src/AppMenuSearch.h
@@ -48,6 +48,8 @@ public:
         QString path;
         QString label;
         bool isEffectivelyEnabled = false;
+        bool isChecked = false;
+        bool isCheckable = false;
     };
 
     struct SearchCandidate {
@@ -64,8 +66,8 @@ public:
             return action == other.action
             && info.isEffectivelyEnabled == other.info.isEffectivelyEnabled
             && info.path == other.info.path
-            && (!action || (action->isChecked() == other.action->isChecked()
-            && action->isCheckable() == other.action->isCheckable()));
+            && info.isChecked == other.info.isChecked
+            && info.isCheckable == other.info.isCheckable;
         }
     };
 

--- a/src/AppMenuSearch.h
+++ b/src/AppMenuSearch.h
@@ -46,7 +46,6 @@ public:
 
     struct ActionInfo {
         QString path;
-        QString searchablePath;
         QString label;
         bool isEffectivelyEnabled = false;
     };
@@ -84,7 +83,7 @@ signals:
 private:
     void rebuildSearchCandidatesIfNeeded();
     void collectSearchCandidates(QMenu *menu, QSet<QMenu *> &visited, QList<QPointer<QAction>> &namedAncestors, QList<QPointer<QAction>> &enablementAncestors);
-    QList<SearchResult> matchSearchCandidates(const QStringMatcher &matcher, bool ignoreTopLevel, bool ignoreSubMenus) const;
+    QList<SearchResult> matchSearchCandidates(const QStringMatcher &matcher, bool ignoreTopLevel, bool ignoreSubMenus, bool showDisabledActions) const;
     QString getActionText(QAction *action) const;
 
     QPointer<AppMenuModel> m_appMenuModel;

--- a/src/AppMenuSearch.h
+++ b/src/AppMenuSearch.h
@@ -41,6 +41,9 @@ public:
     explicit AppMenuSearch(AppMenuModel *model, QObject *parent = nullptr);
     ~AppMenuSearch() override;
 
+    static constexpr int MINIMUM_SEARCH_LENGTH = 3;
+    static bool isQueryTooShort(const QString &text);
+
     struct ActionInfo {
         QString path;
         QString searchablePath;
@@ -84,7 +87,7 @@ private:
     QList<SearchResult> matchSearchCandidates(const QStringMatcher &matcher, bool ignoreTopLevel, bool ignoreSubMenus) const;
     QString getActionText(QAction *action) const;
 
-    AppMenuModel *m_appMenuModel;
+    QPointer<AppMenuModel> m_appMenuModel;
     QString m_lastSearchQuery;
     QList<SearchResult> m_lastResults;
     QList<SearchCandidate> m_searchCandidates;

--- a/src/AppMenuSearch.h
+++ b/src/AppMenuSearch.h
@@ -76,7 +76,7 @@ public:
     };
 
     void filter(QMenu *searchMenu, const QString &text, const FilterOptions &options);
-    void clear(QMenu *searchMenu);
+    void clear();
     
     void invalidateCandidates();
     void clearLastResults();
@@ -93,6 +93,7 @@ private:
     QString getActionText(QAction *action) const;
 
     QPointer<AppMenuModel> m_appMenuModel;
+    QPointer<QMenu> m_searchMenu;
     QString m_lastSearchQuery;
     bool m_lastShowDisabledActions = false;
     bool m_lastIgnoreTopLevel = false;

--- a/src/AppMenuSearch.h
+++ b/src/AppMenuSearch.h
@@ -69,7 +69,13 @@ public:
         }
     };
 
-    void filter(QMenu *searchMenu, const QString &text, bool ignoreTopLevel, bool ignoreSubMenus, bool showDisabledActions);
+    struct FilterOptions {
+        bool ignoreTopLevel = false;
+        bool ignoreSubMenus = false;
+        bool showDisabledActions = false;
+    };
+
+    void filter(QMenu *searchMenu, const QString &text, const FilterOptions &options);
     void clear(QMenu *searchMenu);
     
     void invalidateCandidates();

--- a/src/AppMenuSearch.h
+++ b/src/AppMenuSearch.h
@@ -99,6 +99,7 @@ private:
     bool m_lastIgnoreTopLevel = false;
     bool m_lastIgnoreSubMenus = false;
     QList<SearchResult> m_lastResults;
+    QPointer<QMenu> m_lastProcessedMenu;
     QList<SearchCandidate> m_searchCandidates;
     bool m_searchCandidatesDirty = true;
     QList<QPointer<QActionGroup>> m_searchResultGroups;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,6 +53,8 @@ endif()
 
 configure_file(BuildConfig.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/BuildConfig.h)
 
+set(CMAKE_AUTOMOC ON)
+
 set (decoration_SRCS
     AppMenuModel.cc
     AppMenuSearch.cc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,6 +55,7 @@ configure_file(BuildConfig.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/BuildConfig.h)
 
 set (decoration_SRCS
     AppMenuModel.cc
+    AppMenuSearch.cc
     NavigableMenu.cc
     AppMenuButton.cc
     AppMenuButtonGroup.cc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,8 +53,6 @@ endif()
 
 configure_file(BuildConfig.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/BuildConfig.h)
 
-set(CMAKE_AUTOMOC ON)
-
 set (decoration_SRCS
     AppMenuModel.cc
     AppMenuSearch.cc
@@ -77,6 +75,8 @@ kconfig_add_kcfg_files(decoration_SRCS
 add_library (materialdecoration MODULE
     ${decoration_SRCS}
 )
+
+set_target_properties(materialdecoration PROPERTIES AUTOMOC ON)
 
 target_include_directories(materialdecoration PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 


### PR DESCRIPTION
## Summary by Sourcery

Introdurre un componente dedicato `AppMenuSearch` per incapsulare il comportamento di ricerca nel menu dell’app e collegarlo al gruppo di pulsanti esistente.

Nuove funzionalità:
- Aggiungere la classe `AppMenuSearch` per gestire le query di ricerca del menu dell’app, la scoperta dei candidati e la presentazione dei risultati con opzioni di filtro configurabili.

Miglioramenti:
- Rifattorizzare `AppMenuButtonGroup` per delegare tutto lo stato e la logica relativi alla ricerca a `AppMenuSearch`, semplificando il gruppo di pulsanti e migliorando la separazione delle responsabilità.
- Garantire che i risultati della ricerca vengano aggiornati in modo efficiente solo quando cambiano le query, le opzioni o il menu sottostante, per evitare blocchi e ridurre il churn.
- Preservare la mutua esclusività delle azioni raggruppate nei risultati di ricerca gestendo gruppi di azioni `QActionGroup` proxy all’interno di `AppMenuSearch`.
- Attivare il riposizionamento del menu di ricerca tramite un segnale dedicato da `AppMenuSearch` quando i risultati cambiano.

Build:
- Includere i sorgenti di `AppMenuSearch` nel modulo `materialdecoration` e abilitare `AUTOMOC` per il target.

Documentazione:
- Rimuovere il badge di revisione esterno CodeRabbit dal README.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated AppMenuSearch component to encapsulate app menu search behavior and wire it into the existing button group.

New Features:
- Add AppMenuSearch class to manage app menu search queries, candidate discovery, and result presentation with configurable filter options.

Enhancements:
- Refactor AppMenuButtonGroup to delegate all search-related state and logic to AppMenuSearch, simplifying the button group and improving separation of concerns.
- Ensure search results are efficiently updated only when queries, options, or the underlying menu change to avoid freezes and reduce churn.
- Preserve mutual exclusivity of grouped actions in search results by managing proxy QActionGroups inside AppMenuSearch.
- Trigger repositioning of the search menu via a dedicated signal from AppMenuSearch when results change.

Build:
- Include AppMenuSearch sources in the materialdecoration module and enable AUTOMOC for the target.

Documentation:
- Remove the external CodeRabbit review badge from the README.

</details>