### PR TITLE
Search decouplig 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ for Arch and derivatives, please install the AUR package
 NOTE: the master branch is aligned with the latest Plasma version. For earlier
 ones, see the other branches.
 
-![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/guiodic/material-decoration?utm_source=oss&utm_medium=github&utm_campaign=guiodic%2Fmaterial-decoration&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)
 
 ....
 

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -398,8 +398,11 @@ void AppMenuButtonGroup::resetButtons()
 
 void AppMenuButtonGroup::onMenuReadyForSearch()
 {
-    if (m_search && m_searchUiVisible && m_search->hasValidQuery()) {
-        filterMenu(m_search->lastSearchQuery());
+    if (m_search && m_searchUiVisible && m_searchLineEdit) {
+        const QString currentText = m_searchLineEdit->text();
+        if (!AppMenuSearch::isQueryTooShort(currentText)) {
+            filterMenu(currentText);
+        }
     }
 }
 

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -20,6 +20,7 @@
 
 // own
 #include "AppMenuButtonGroup.h"
+#include "AppMenuSearch.h"
 #include "Material.h"
 #include "BuildConfig.h"
 #include "AppMenuModel.h"
@@ -83,6 +84,7 @@ AppMenuButtonGroup::AppMenuButtonGroup(Decoration *decoration)
     , m_searchLineEdit(nullptr)
     , m_searchDebounceTimer(nullptr)
     , m_searchUiVisible(false)
+    , m_search(new AppMenuSearch(m_appMenuModel, this))
 {
     m_searchDebounceTimer = new QTimer(this);
     m_searchDebounceTimer->setInterval(150);
@@ -205,6 +207,8 @@ void AppMenuButtonGroup::setupSearchMenu()
     m_searchLineEdit->setFocusPolicy(Qt::StrongFocus);
     m_searchLineEdit->setPlaceholderText(i18nd("plasma_applet_org.kde.plasma.appmenu","Search")+QStringLiteral("…"));
     m_searchLineEdit->setClearButtonEnabled(false);
+
+    connect(m_search, &AppMenuSearch::repositionRequested, this, &AppMenuButtonGroup::repositionSearchMenu, Qt::UniqueConnection);
 }
 
 void AppMenuButtonGroup::repositionSearchMenu()
@@ -363,9 +367,8 @@ void AppMenuButtonGroup::resetButtons()
     }
     setCurrentIndex(-1);
     m_currentMenu = nullptr;
-    m_lastResults.clear();
-    m_lastSearchQuery.clear();
-    m_actionTextCache.clear();
+    m_search->clearLastResults();
+    m_search->clear();
     m_textButtons.clear();
     m_overflowButton = nullptr;
     m_searchButton = nullptr;
@@ -393,8 +396,8 @@ void AppMenuButtonGroup::resetButtons()
 
 void AppMenuButtonGroup::onMenuReadyForSearch()
 {
-    if (!m_lastSearchQuery.isEmpty() && m_searchUiVisible) {
-        filterMenu(m_lastSearchQuery);
+    if (m_searchLineEdit && !m_searchLineEdit->text().isEmpty() && m_searchUiVisible) {
+        filterMenu(m_searchLineEdit->text());
     }
 }
 
@@ -477,7 +480,7 @@ void AppMenuButtonGroup::performDebouncedMenuUpdate()
 
 void AppMenuButtonGroup::updateAppMenuModel()
 {
-    m_searchCandidatesDirty = true;
+    m_search->invalidateCandidates();
 
     auto *deco = qobject_cast<Decoration *>(decoration());
     if (!deco) {
@@ -512,12 +515,12 @@ void AppMenuButtonGroup::updateAppMenuModel()
         const bool wasSearchOpen = (m_currentIndex == m_searchIndex && m_searchIndex != -1);
         const bool wasOverflowOpen = (m_currentIndex == m_overflowIndex && m_overflowIndex != -1);
         QPointer<QMenu> previousMenu = m_currentMenu;
+        const QString savedQuery = m_searchLineEdit ? m_searchLineEdit->text() : QString();
 
         // Try in-place update if possible to reduce flicker and object churn
         const bool searchStateMatches = (m_searchButton.isNull() == !deco->searchEnabled());
 
         if (m_textButtons.count() == menuActionCount && !m_textButtons.isEmpty() && searchStateMatches) {
-            m_actionTextCache.clear();
             int actionIdx = 0;
             for (auto &textButton : std::as_const(m_textButtons)) {
                 if (!textButton) {
@@ -535,10 +538,6 @@ void AppMenuButtonGroup::updateAppMenuModel()
                     textButton->setEnabled(itemAction->isEnabled());
                     textButton->setVisible(true);
                 }
-            }
-
-            if (wasSearchOpen && !m_lastSearchQuery.isEmpty()) {
-                filterMenu(m_lastSearchQuery);
             }
         } else {
             resetButtons(); // Immediate reset is intended here for structural changes
@@ -589,9 +588,14 @@ void AppMenuButtonGroup::updateAppMenuModel()
         if (indexToRestore != -1) {
             setCurrentIndex(indexToRestore);
             m_currentMenu = previousMenu;
-            
+
             if (AppMenuButton *b = getAppMenuButton(m_currentIndex)) {
                 b->setChecked(true);
+            }
+
+            if (wasSearchOpen && !savedQuery.isEmpty() && m_searchLineEdit) {
+                m_searchLineEdit->setText(savedQuery);
+                m_searchDebounceTimer->start();
             }
         }
 
@@ -983,8 +987,7 @@ void AppMenuButtonGroup::onMenuAboutToHide()
     if (menu == m_searchMenu && m_searchLineEdit) {
         m_searchLineEdit->clear();
         m_searchUiVisible = false;
-        m_lastResults.clear();
-        m_lastSearchQuery.clear();
+        m_search->clearLastResults();
     }
 
     if (AppMenuButton *currentButton = getAppMenuButton(m_currentIndex)) {
@@ -1023,147 +1026,33 @@ void AppMenuButtonGroup::onShowingChanged(bool showing)
     }
 }
 
-void AppMenuButtonGroup::clearSearchResultActions()
-{
-    if (!m_searchMenu) {
-        return;
-    }
-
-    const auto actions = m_searchMenu->actions();
-    for (int i = actions.count() - 1; i >= 2; --i) {
-        QAction *action = actions.at(i);
-        m_searchMenu->removeAction(action);
-        // Detach action from its group before scheduling deletion
-        if (QActionGroup *group = action->actionGroup()) {
-            group->removeAction(action);
-        }
-        action->deleteLater();
-    }
-
-    // The old proxy actions no longer reference these groups (deleteLater()
-    // above), so nothing else owns them: delete explicitly to avoid leaking
-    // one QActionGroup per exclusive result set on every keystroke.
-    for (const QPointer<QActionGroup> &oldGroup : std::as_const(m_searchResultGroups)) {
-        if (oldGroup) {
-            oldGroup->deleteLater();
-        }
-    }
-    m_searchResultGroups.clear();
-}
-
 void AppMenuButtonGroup::filterMenu(const QString &text)
 {
-    if (!m_searchMenu) {
-            return;
-    }
-    m_lastSearchQuery = text;
-
-    // Clear results if search text is too short
-    if (text.length() < 3) {
-        clearSearchResultActions();
-        m_lastResults.clear();
-        repositionSearchMenu();
-
-        if (text.isEmpty()) {
-            m_searchLineEdit->setClearButtonEnabled(false);
-            m_searchLineEdit->setPlaceholderText(i18nd("plasma_applet_org.kde.plasma.appmenu", "Search") + QStringLiteral("…"));
-            return;
-        }
-        m_searchLineEdit->setClearButtonEnabled(true);
+    if (!m_searchMenu || !m_searchLineEdit) {
         return;
+    }
+
+    const auto *deco = qobject_cast<const Decoration *>(decoration());
+    AppMenuSearch::FilterOptions options;
+    options.ignoreTopLevel = deco && deco->searchIgnoreTopLevel();
+    options.ignoreSubMenus = deco && deco->searchIgnoreSubMenus();
+    options.showDisabledActions = deco && deco->showDisabledActions();
+
+    m_search->filter(m_searchMenu, text, options);
+
+    if (text.isEmpty()) {
+        m_searchLineEdit->setClearButtonEnabled(false);
+        m_searchLineEdit->setPlaceholderText(i18nd("plasma_applet_org.kde.plasma.appmenu", "Search") + QStringLiteral("…"));
     } else {
         m_searchLineEdit->setClearButtonEnabled(true);
     }
-
-    if (!m_appMenuModel) {
-        return;
-    }
-
-    {
-        // Find results
-        rebuildSearchCandidatesIfNeeded();
-        const auto *deco = qobject_cast<const Decoration *>(decoration());
-        const bool ignoreTopLevel = deco && deco->searchIgnoreTopLevel();
-        const bool ignoreSubMenus = deco && deco->searchIgnoreSubMenus();
-        QStringMatcher matcher(text, Qt::CaseInsensitive);
-        QList<SearchResult> results = matchSearchCandidates(matcher, ignoreTopLevel, ignoreSubMenus);
-
-        // If results are the same as last time, do nothing to prevent the freeze.
-        if (m_lastResults == results) {
-            return;
-        }
-
-        m_lastResults = std::move(results);
-    } // 'results' goes out of scope here to prevent accidental use-after-move
-
-    m_searchMenu->setUpdatesEnabled(false);
-
-    // Clear previous results
-    clearSearchResultActions();
-
-    // Add new results
-    const auto *deco = qobject_cast<const Decoration *>(decoration());
-    if (!deco) {
-        m_searchMenu->setUpdatesEnabled(true);
-        return;
-    }
-
-    int resultCount = 0;
-    // Map each *original* action group to the QActionGroup we create for its
-    // search-result proxies, so results that were mutually exclusive in the
-    // real menu (e.g. radio-button items) stay mutually exclusive here too.
-    // Without this, each proxy action got its own isolated single-member
-    // group and could show several "checked" radio results at once.
-    QHash<QActionGroup *, QActionGroup *> groupMap;
-    for (const SearchResult &result : std::as_const(m_lastResults)) {
-        if (resultCount >= MAX_SEARCH_RESULTS) { // stop after 100 results
-            break;
-        }
-
-        const ActionInfo &info = result.info;
-        QAction *action = result.action;
-        if (!info.isEffectivelyEnabled && !deco->showDisabledActions()) {
-            continue;
-        }
-        QAction *newAction = new QAction(action->icon(), info.path, m_searchMenu);
-        newAction->setEnabled(info.isEffectivelyEnabled);
-        newAction->setCheckable(action->isCheckable());
-        newAction->setChecked(action->isChecked());
-
-        if (QActionGroup *originalGroup = action->actionGroup(); originalGroup && originalGroup->isExclusive()) {
-            QActionGroup *&proxyGroup = groupMap[originalGroup];
-            if (!proxyGroup) {
-                proxyGroup = new QActionGroup(m_searchMenu);
-                proxyGroup->setExclusionPolicy(originalGroup->exclusionPolicy());
-                m_searchResultGroups.append(proxyGroup);
-            }
-            proxyGroup->addAction(newAction);
-        }
-      
-        QPointer<QAction> safeAction = action;
-        connect(newAction, &QAction::triggered, this, [safeAction, searchMenu = m_searchMenu]() {
-            if (safeAction) {
-                safeAction->trigger();
-            }
-            if (searchMenu) {
-                searchMenu->hide();
-            }
-        });
-        m_searchMenu->addAction(newAction);
-        resultCount++;
-    }
-
-    repositionSearchMenu();
-    m_searchMenu->setUpdatesEnabled(true);
-    // qCDebug(category) << "[AppMenuButtonGroup] filterMenu(" << text << ") ended";
 }
 
 void AppMenuButtonGroup::onSubMenuReady(QMenu *menu)
 {
-    m_actionTextCache.clear();
-    m_searchCandidatesDirty = true;
+    m_search->invalidateCandidates();
 
-    if (m_searchUiVisible && !m_lastSearchQuery.isEmpty()) {
+    if (m_searchUiVisible && m_searchLineEdit && !m_searchLineEdit->text().isEmpty()) {
         if (!m_searchDebounceTimer->isActive()) {
             m_searchDebounceTimer->start();
         }
@@ -1201,219 +1090,6 @@ void AppMenuButtonGroup::onSearchTimerTimeout()
     if (m_searchLineEdit) {
         filterMenu(m_searchLineEdit->text());
     }
-}
-
-QString AppMenuButtonGroup::getActionText(QAction *action) const
-{
-    if (!action) {
-        return QString();
-    }
-    const QString rawText = action->text();
-    auto it = m_actionTextCache.find(rawText);
-    if (it != m_actionTextCache.end()) {
-        return it.value();
-    }
-    const QString cleanedText = KLocalizedString::removeAcceleratorMarker(rawText.trimmed());
-    m_actionTextCache.insert(rawText, cleanedText);
-    return cleanedText;
-}
-
-void AppMenuButtonGroup::rebuildSearchCandidatesIfNeeded()
-{
-    if (!m_searchCandidatesDirty) {
-        return;
-    }
-    m_searchCandidatesDirty = false;
-    m_searchCandidates.clear();
-
-    if (!m_appMenuModel) {
-        return;
-    }
-    QMenu *rootMenu = m_appMenuModel->menu();
-    if (!rootMenu) {
-        return;
-    }
-
-    QSet<QMenu *> visited;
-    QList<QPointer<QAction>> namedAncestors;
-    QList<QPointer<QAction>> enablementAncestors;
-    collectSearchCandidates(rootMenu, visited, namedAncestors, enablementAncestors);
-}
-
-void AppMenuButtonGroup::collectSearchCandidates(QMenu *menu, QSet<QMenu *> &visited, QList<QPointer<QAction>> &namedAncestors, QList<QPointer<QAction>> &enablementAncestors)
-{
-    if (!menu || visited.contains(menu) || m_searchCandidates.size() >= MAX_SEARCH_CANDIDATES) {
-        return;
-    }
-    visited.insert(menu);
-
-    QAction *menuAction = menu->menuAction();
-    bool addedNamed = false;
-    bool addedEnablement = false;
-    if (menuAction) {
-        // Unconditional: even an untitled submenu still gates whether its
-        // children are reachable/enabled, so its own enabled state must
-        // propagate down regardless of whether it has display text.
-        enablementAncestors.append(menuAction);
-        addedEnablement = true;
-        if (!getActionText(menuAction).isEmpty()) {
-            namedAncestors.append(menuAction);
-            addedNamed = true;
-        }
-    }
-
-    for (QAction *action : menu->actions()) {
-        if (m_searchCandidates.size() >= MAX_SEARCH_CANDIDATES) {
-            break;
-        }
-        if (action->isSeparator()) {
-            continue;
-        }
-        if (action->menu()) {
-            collectSearchCandidates(action->menu(), visited, namedAncestors, enablementAncestors);
-        } else {
-            m_searchCandidates.append({action, namedAncestors, enablementAncestors});
-        }
-    }
-
-    if (addedNamed) {
-        namedAncestors.removeLast();
-    }
-    if (addedEnablement) {
-        enablementAncestors.removeLast();
-    }
-}
-
-QList<AppMenuButtonGroup::SearchResult> AppMenuButtonGroup::matchSearchCandidates(const QStringMatcher &matcher, bool ignoreTopLevel, bool ignoreSubMenus) const
-{
-    QList<SearchResult> results;
-
-    // Two independent memoized chains, mirroring how the original recursive
-    // algorithm kept these concerns separate: a submenu's *enabled* state
-    // always propagates to its children, even if the submenu has no title
-    // of its own; its *title* only contributes to the visible path/matching
-    // when non-empty. Folding both into a single "named ancestors" chain
-    // would silently drop the disabled state of untitled submenus.
-    QHash<QAction *, bool> enabledCache; // cumulative isEnabled up to and including this ancestor
-    struct MatchState {
-        bool currentMatched;
-        QString text;
-    };
-    QHash<QAction *, MatchState> matchCache; // cumulative match state + this ancestor's text
-
-    for (const SearchCandidate &candidate : std::as_const(m_searchCandidates)) {
-        if (results.size() >= MAX_SEARCH_RESULTS) {
-            break;
-        }
-        QAction *action = candidate.action;
-        if (!action) {
-            continue; // Action was destroyed since the cache was built.
-        }
-
-        bool ancestorsStillValid = true;
-
-        // --- Enabled chain (every ancestor, named or not) ---
-        bool isCurrentEnabled = true;
-        if (!candidate.enablementAncestors.isEmpty()) {
-            QAction *deepest = candidate.enablementAncestors.last();
-            if (!deepest) {
-                ancestorsStillValid = false;
-            } else {
-                auto it = enabledCache.find(deepest);
-                if (it != enabledCache.end()) {
-                    isCurrentEnabled = it.value();
-                } else {
-                    for (QAction *ancestor : std::as_const(candidate.enablementAncestors)) {
-                        if (!ancestor) {
-                            ancestorsStillValid = false;
-                            break;
-                        }
-                        auto it2 = enabledCache.find(ancestor);
-                        if (it2 != enabledCache.end()) {
-                            isCurrentEnabled = it2.value();
-                        } else {
-                            if (!ancestor->isEnabled()) {
-                                isCurrentEnabled = false;
-                            }
-                            enabledCache.insert(ancestor, isCurrentEnabled);
-                        }
-                    }
-                }
-            }
-        }
-
-        // --- Match/text chain (only ancestors with a non-empty title) ---
-        bool currentMatched = false;
-        if (ancestorsStillValid && !candidate.namedAncestors.isEmpty()) {
-            QAction *parent = candidate.namedAncestors.last();
-            if (!parent) {
-                ancestorsStillValid = false;
-            } else {
-                auto it = matchCache.find(parent);
-                if (it != matchCache.end()) {
-                    currentMatched = it.value().currentMatched;
-                } else {
-                    for (int i = 0; i < candidate.namedAncestors.size(); ++i) {
-                        QAction *ancestor = candidate.namedAncestors.at(i);
-                        if (!ancestor) {
-                            ancestorsStillValid = false;
-                            break;
-                        }
-                        auto it2 = matchCache.find(ancestor);
-                        if (it2 != matchCache.end()) {
-                            currentMatched = it2.value().currentMatched;
-                        } else {
-                            QString ancestorText = getActionText(ancestor);
-                            if (!currentMatched && (!ignoreTopLevel || i > 0)) {
-                                if (matcher.indexIn(ancestorText) != -1) {
-                                    currentMatched = true;
-                                }
-                            }
-                            matchCache.insert(ancestor, {currentMatched, ancestorText});
-                        }
-                    }
-                }
-            }
-        }
-
-        if (!ancestorsStillValid) {
-            continue; // A submenu in the path was rebuilt/destroyed; skip until next full rebuild.
-        }
-
-        const QString itemText = getActionText(action);
-        bool match = currentMatched;
-        if (ignoreSubMenus) {
-            match = matcher.indexIn(itemText) != -1;
-        } else if (!match && (!ignoreTopLevel || !candidate.namedAncestors.isEmpty())) {
-            if (matcher.indexIn(itemText) != -1) {
-                match = true;
-            }
-        }
-
-        if (!match) {
-            continue; // Skip building path entirely for non-matching entries!
-        }
-
-        // 2. Only perform path allocation and joins for matching results
-        QStringList currentPath;
-        currentPath.reserve(candidate.namedAncestors.size() + 1);
-        for (int i = 0; i < candidate.namedAncestors.size(); ++i) {
-            QAction *ancestor = candidate.namedAncestors.at(i);
-            currentPath.append(matchCache.value(ancestor).text);
-        }
-
-        ActionInfo info;
-        info.label = itemText;
-        info.isEffectivelyEnabled = isCurrentEnabled && action->isEnabled();
-
-        currentPath.append(itemText);
-        info.path = currentPath.join(QStringLiteral(" » "));
-        info.searchablePath = (currentPath.size() > 1) ? currentPath.mid(1).join(QStringLiteral(" » ")) : itemText;
-
-        results.append({action, info});
-    }
-
-    return results;
 }
 
 AppMenuButton *AppMenuButtonGroup::getAppMenuButton(int index) const

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -1049,7 +1049,7 @@ void AppMenuButtonGroup::onSubMenuReady(QMenu *menu)
 {
     m_search->invalidateCandidates();
 
-    if (m_search && m_searchUiVisible && m_search->hasValidQuery()) {
+    if (m_searchUiVisible && m_search->hasValidQuery()) {
         if (!m_searchDebounceTimer->isActive()) {
             m_searchDebounceTimer->start();
         }

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -208,6 +208,8 @@ void AppMenuButtonGroup::setupSearchMenu()
     m_searchLineEdit->setPlaceholderText(i18nd("plasma_applet_org.kde.plasma.appmenu","Search")+QStringLiteral("…"));
     m_searchLineEdit->setClearButtonEnabled(false);
 
+    m_search->setSearchMenu(m_searchMenu);
+
     connect(m_search, &AppMenuSearch::repositionRequested, this, &AppMenuButtonGroup::repositionSearchMenu, Qt::UniqueConnection);
 }
 
@@ -396,8 +398,8 @@ void AppMenuButtonGroup::resetButtons()
 
 void AppMenuButtonGroup::onMenuReadyForSearch()
 {
-    if (m_searchLineEdit && !m_searchLineEdit->text().isEmpty() && m_searchUiVisible) {
-        filterMenu(m_searchLineEdit->text());
+    if (m_search && m_searchUiVisible && m_search->hasValidQuery()) {
+        filterMenu(m_search->lastSearchQuery());
     }
 }
 
@@ -1038,7 +1040,7 @@ void AppMenuButtonGroup::filterMenu(const QString &text)
     options.ignoreSubMenus = deco && deco->searchIgnoreSubMenus();
     options.showDisabledActions = deco && deco->showDisabledActions();
 
-    m_search->filter(m_searchMenu, text, options);
+    m_search->filter(text, options);
 
     m_searchLineEdit->setClearButtonEnabled(!text.isEmpty());
 }
@@ -1047,7 +1049,7 @@ void AppMenuButtonGroup::onSubMenuReady(QMenu *menu)
 {
     m_search->invalidateCandidates();
 
-    if (m_searchUiVisible && m_searchLineEdit && !m_searchLineEdit->text().isEmpty()) {
+    if (m_search && m_searchUiVisible && m_search->hasValidQuery()) {
         if (!m_searchDebounceTimer->isActive()) {
             m_searchDebounceTimer->start();
         }

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -1040,12 +1040,7 @@ void AppMenuButtonGroup::filterMenu(const QString &text)
 
     m_search->filter(m_searchMenu, text, options);
 
-    if (text.isEmpty()) {
-        m_searchLineEdit->setClearButtonEnabled(false);
-        m_searchLineEdit->setPlaceholderText(i18nd("plasma_applet_org.kde.plasma.appmenu", "Search") + QStringLiteral("…"));
-    } else {
-        m_searchLineEdit->setClearButtonEnabled(true);
-    }
+    m_searchLineEdit->setClearButtonEnabled(!text.isEmpty());
 }
 
 void AppMenuButtonGroup::onSubMenuReady(QMenu *menu)

--- a/src/AppMenuButtonGroup.h
+++ b/src/AppMenuButtonGroup.h
@@ -45,6 +45,7 @@ class Decoration;
 class TextButton;
 class MenuOverflowButton;
 class SearchButton;
+class AppMenuSearch;
 
 class AppMenuButtonGroup : public KDecoration3::DecorationButtonGroup
 {
@@ -105,7 +106,6 @@ private:
     void onDelayedCacheTimerTimeout();
     void onShowingChanged(bool hovered);
     void filterMenu(const QString &text);
-    void clearSearchResultActions();
     void onSearchTimerTimeout();
     void onSubMenuReady(QMenu *menu);
 
@@ -143,56 +143,9 @@ private:
 
     void trigger(int index);
 
-    struct ActionInfo {
-        QString path;
-        QString searchablePath;
-        QString label;
-        bool isEffectivelyEnabled;
-    };
-
-    // A leaf action reachable from the app menu root, plus the chain of
-    // named ancestor submenu-actions leading to it. Built once per menu
-    // structure (see rebuildSearchCandidatesIfNeeded()) instead of being
-    // re-derived by walking the whole QMenu tree on every keystroke.
-    // Text and enabled-state are deliberately NOT cached here, since those
-    // can change at runtime (e.g. "Undo X" toggling label/enabled) without
-    // the structure itself changing; they are re-read fresh from the still-
-    // live QAction pointers each time matchSearchCandidates() runs.
-    struct SearchCandidate {
-        QPointer<QAction> action;
-        // Ancestors WITH display text: used for the visible path and for
-        // text matching. A submenu with empty text contributes nothing here.
-        QList<QPointer<QAction>> namedAncestors;
-        // Every ancestor menu-action, named or not: used purely to
-        // propagate the enabled/disabled chain. A submenu can be disabled
-        // while having no title of its own (e.g. a bare grouping menu), and
-        // the original recursive algorithm still honoured that: it checked
-        // menuAction->isEnabled() unconditionally, independent of whether
-        // the menu had a non-empty title. Folding this into namedAncestors
-        // would silently drop that disabled state for untitled submenus.
-        QList<QPointer<QAction>> enablementAncestors;
-    };
-
-    struct SearchResult {
-        QPointer<QAction> action;
-        ActionInfo info;
-
-        bool operator==(const SearchResult &other) const {
-            return action == other.action
-            && info.isEffectivelyEnabled == other.info.isEffectivelyEnabled
-            && info.path == other.info.path
-            && (!action || (action->isChecked() == other.action->isChecked()
-            && action->isCheckable() == other.action->isCheckable()));
-        }
-    };
-
     void resetButtons();
-    QString getActionText(QAction *action) const;
     void setupSearchMenu();
     void repositionSearchMenu();
-    void rebuildSearchCandidatesIfNeeded();
-    void collectSearchCandidates(QMenu *menu, QSet<QMenu *> &visited, QList<QPointer<QAction>> &namedAncestors, QList<QPointer<QAction>> &enablementAncestors);
-    QList<SearchResult> matchSearchCandidates(const QStringMatcher &matcher, bool ignoreTopLevel, bool ignoreSubMenus) const;
     AppMenuButton *getAppMenuButton(int index) const;
     int findNextVisibleButtonIndex(int currentIndex, bool forward) const;
 
@@ -232,24 +185,12 @@ private:
     bool m_isMenuUpdateThrottled = false;
     bool m_pendingMenuUpdate = false;
     bool m_menuLoadedOnce = false;
-    QString m_lastSearchQuery;
-    QList<SearchResult> m_lastResults;
-    // Flat, pre-walked list of searchable leaf actions. Rebuilt only when
-    // the app menu structure actually changes (see rebuildSearchCandidatesIfNeeded()),
-    // not on every keystroke.
-    QList<SearchCandidate> m_searchCandidates;
-    bool m_searchCandidatesDirty = true;
-    // QActionGroups created in filterMenu() to preserve mutual exclusivity
-    // between search-result proxies; owned here (parented to m_searchMenu)
-    // since they aren't owned by any single proxy action anymore and must
-    // be deleted explicitly when the previous results are cleared.
-    QList<QPointer<QActionGroup>> m_searchResultGroups;
+
+    AppMenuSearch *m_search;
 
     QList<QPointer<TextButton>> m_textButtons;
     QPointer<MenuOverflowButton> m_overflowButton;
     QPointer<SearchButton> m_searchButton;
-
-    mutable QHash<QString, QString> m_actionTextCache;
 
     QPointer<KDecoration3::DecorationButton> m_hoveredButton = nullptr;
 

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -44,19 +44,27 @@ bool AppMenuSearch::isQueryTooShort(const QString &text)
     return text.length() < MINIMUM_SEARCH_LENGTH;
 }
 
-void AppMenuSearch::filter(QMenu *searchMenu, const QString &text, const FilterOptions &options)
+void AppMenuSearch::setSearchMenu(QMenu *searchMenu)
 {
-    if (searchMenu) {
-        m_searchMenu = searchMenu;
-    }
+    m_searchMenu = searchMenu;
+}
+
+void AppMenuSearch::filter(const QString &text, const FilterOptions &options)
+{
     if (!m_searchMenu) {
         return;
     }
 
+    m_lastSearchQuery = text;
+
     // Clear results if search text is too short
     if (isQueryTooShort(text)) {
         clear();
-        resetSearchState();
+        m_lastResults.clear();
+        m_lastProcessedMenu = nullptr;
+        m_lastShowDisabledActions = false;
+        m_lastIgnoreTopLevel = false;
+        m_lastIgnoreSubMenus = false;
         Q_EMIT repositionRequested();
         return;
     }
@@ -175,8 +183,19 @@ void AppMenuSearch::clearLastResults()
     m_actionTextCache.clear();
 }
 
+QString AppMenuSearch::lastSearchQuery() const
+{
+    return m_lastSearchQuery;
+}
+
+bool AppMenuSearch::hasValidQuery() const
+{
+    return !m_lastSearchQuery.isEmpty() && !isQueryTooShort(m_lastSearchQuery);
+}
+
 void AppMenuSearch::resetSearchState()
 {
+    m_lastSearchQuery.clear();
     m_lastResults.clear();
     m_lastProcessedMenu = nullptr;
     m_lastShowDisabledActions = false;

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -60,11 +60,7 @@ void AppMenuSearch::filter(const QString &text, const FilterOptions &options)
     // Clear results if search text is too short
     if (isQueryTooShort(text)) {
         clear();
-        m_lastResults.clear();
-        m_lastProcessedMenu = nullptr;
-        m_lastShowDisabledActions = false;
-        m_lastIgnoreTopLevel = false;
-        m_lastIgnoreSubMenus = false;
+        resetSearchState();
         Q_EMIT repositionRequested();
         return;
     }
@@ -83,7 +79,7 @@ void AppMenuSearch::filter(const QString &text, const FilterOptions &options)
         QList<SearchResult> results = matchSearchCandidates(matcher, options.ignoreTopLevel, options.ignoreSubMenus, options.showDisabledActions);
 
         // If results and options are the same as last time, do nothing to prevent the freeze.
-        if (m_lastProcessedMenu == m_searchMenu && m_lastResults == results && m_lastShowDisabledActions == options.showDisabledActions && m_lastIgnoreTopLevel == options.ignoreTopLevel && m_lastIgnoreSubMenus == options.ignoreSubMenus) {
+        if (m_menuIsRendered && m_lastProcessedMenu == m_searchMenu && m_lastResults == results && m_lastShowDisabledActions == options.showDisabledActions && m_lastIgnoreTopLevel == options.ignoreTopLevel && m_lastIgnoreSubMenus == options.ignoreSubMenus) {
             return;
         }
 
@@ -137,6 +133,7 @@ void AppMenuSearch::filter(const QString &text, const FilterOptions &options)
         m_searchMenu->addAction(newAction);
     }
 
+    m_menuIsRendered = true;
     m_searchMenu->setUpdatesEnabled(true);
     Q_EMIT repositionRequested();
 }
@@ -146,6 +143,8 @@ void AppMenuSearch::clear()
     if (!m_searchMenu) {
         return;
     }
+
+    m_menuIsRendered = false;
 
     const auto actions = m_searchMenu->actions();
     for (QAction *action : actions) {
@@ -173,6 +172,7 @@ void AppMenuSearch::clear()
 void AppMenuSearch::invalidateCandidates()
 {
     m_searchCandidatesDirty = true;
+    m_candidateTruncationLogged = false;
     m_searchCandidates.clear();
     m_lastResults.clear();
     m_lastProcessedMenu = nullptr;
@@ -213,6 +213,7 @@ void AppMenuSearch::rebuildSearchCandidatesIfNeeded()
         return;
     }
     m_searchCandidates.clear();
+    m_candidateTruncationLogged = false;
 
     if (!m_appMenuModel) {
         return;
@@ -253,6 +254,10 @@ void AppMenuSearch::collectSearchCandidates(QMenu *menu, QSet<QMenu *> &visited,
 
     for (QAction *action : menu->actions()) {
         if (m_searchCandidates.size() >= MAX_SEARCH_CANDIDATES) {
+            if (!m_candidateTruncationLogged) {
+                qWarning() << "AppMenuSearch: Maximum search candidates limit reached (" << MAX_SEARCH_CANDIDATES << "), remaining candidates will be discarded";
+                m_candidateTruncationLogged = true;
+            }
             break;
         }
         if (action->isSeparator()) {

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -1,0 +1,413 @@
+/*
+ * Copyright (C) 2025 Guido Iodice <guido[dot]iodice[at]gmail[dot]com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AppMenuSearch.h"
+#include "AppMenuModel.h"
+
+// KF
+#include <KLocalizedString>
+
+// Qt
+#include <QDebug>
+#include <utility>
+
+static constexpr int MAX_SEARCH_RESULTS = 100;
+static constexpr int MAX_SEARCH_CANDIDATES = 5000;
+
+namespace Material
+{
+
+AppMenuSearch::AppMenuSearch(AppMenuModel *model, QObject *parent)
+    : QObject(parent)
+    , m_appMenuModel(model)
+{
+}
+
+AppMenuSearch::~AppMenuSearch() = default;
+
+bool AppMenuSearch::isQueryTooShort(const QString &text)
+{
+    return text.length() < MINIMUM_SEARCH_LENGTH;
+}
+
+void AppMenuSearch::filter(QMenu *searchMenu, const QString &text, const FilterOptions &options)
+{
+    if (searchMenu) {
+        m_searchMenu = searchMenu;
+    }
+    if (!m_searchMenu) {
+        return;
+    }
+    m_lastSearchQuery = text;
+
+    // Clear results if search text is too short
+    if (isQueryTooShort(text)) {
+        clear();
+        resetSearchState();
+        Q_EMIT repositionRequested();
+        return;
+    }
+
+    if (!m_appMenuModel) {
+        clear();
+        resetSearchState();
+        Q_EMIT repositionRequested();
+        return;
+    }
+
+    {
+        // Find results
+        rebuildSearchCandidatesIfNeeded();
+        QStringMatcher matcher(text, Qt::CaseInsensitive);
+        QList<SearchResult> results = matchSearchCandidates(matcher, options.ignoreTopLevel, options.ignoreSubMenus, options.showDisabledActions);
+
+        // If results and options are the same as last time, do nothing to prevent the freeze.
+        if (m_lastProcessedMenu == m_searchMenu && m_lastResults == results && m_lastShowDisabledActions == options.showDisabledActions && m_lastIgnoreTopLevel == options.ignoreTopLevel && m_lastIgnoreSubMenus == options.ignoreSubMenus) {
+            return;
+        }
+
+        m_lastShowDisabledActions = options.showDisabledActions;
+        m_lastIgnoreTopLevel = options.ignoreTopLevel;
+        m_lastIgnoreSubMenus = options.ignoreSubMenus;
+        m_lastResults = std::move(results);
+        m_lastProcessedMenu = m_searchMenu;
+    } // 'results' goes out of scope here to prevent accidental use-after-move
+
+    m_searchMenu->setUpdatesEnabled(false);
+
+    // Clear previous results
+    clear();
+
+    // Map each *original* action group to the QActionGroup we create for its
+    // search-result proxies, so results that were mutually exclusive in the
+    // real menu (e.g. radio-button items) stay mutually exclusive here too.
+    QHash<QActionGroup *, QActionGroup *> groupMap;
+    for (const SearchResult &result : std::as_const(m_lastResults)) {
+        const ActionInfo &info = result.info;
+        QAction *action = result.action.data();
+        if (!action) {
+            continue;
+        }
+        QAction *newAction = new QAction(action->icon(), info.path, m_searchMenu);
+        newAction->setEnabled(info.isEffectivelyEnabled);
+        newAction->setCheckable(info.isCheckable);
+        newAction->setChecked(info.isChecked);
+        newAction->setProperty(PROPERTY_SEARCH_PROXY, true); // Uniquely mark as a proxy result action
+
+        if (QActionGroup *originalGroup = action->actionGroup(); originalGroup && originalGroup->isExclusive()) {
+            QActionGroup *&proxyGroup = groupMap[originalGroup];
+            if (!proxyGroup) {
+                proxyGroup = new QActionGroup(m_searchMenu);
+                proxyGroup->setExclusionPolicy(originalGroup->exclusionPolicy());
+                m_searchResultGroups.append(proxyGroup);
+            }
+            proxyGroup->addAction(newAction);
+        }
+      
+        QPointer<QAction> safeAction = action;
+        connect(newAction, &QAction::triggered, this, [safeAction, searchMenu = m_searchMenu]() {
+            if (safeAction) {
+                safeAction->trigger();
+            }
+            if (searchMenu) {
+                searchMenu->hide();
+            }
+        });
+        m_searchMenu->addAction(newAction);
+    }
+
+    m_searchMenu->setUpdatesEnabled(true);
+    Q_EMIT repositionRequested();
+}
+
+void AppMenuSearch::clear()
+{
+    if (!m_searchMenu) {
+        return;
+    }
+
+    const auto actions = m_searchMenu->actions();
+    for (QAction *action : actions) {
+        if (action && action->property(PROPERTY_SEARCH_PROXY).toBool() == true) {
+            m_searchMenu->removeAction(action);
+            // Detach action from its group before scheduling deletion
+            if (QActionGroup *group = action->actionGroup()) {
+                group->removeAction(action);
+            }
+            action->deleteLater();
+        }
+    }
+
+    // The old proxy actions no longer reference these groups (deleteLater()
+    // above), so nothing else owns them: delete explicitly to avoid leaking
+    // one QActionGroup per exclusive result set on every keystroke.
+    for (const QPointer<QActionGroup> &oldGroup : std::as_const(m_searchResultGroups)) {
+        if (oldGroup) {
+            oldGroup->deleteLater();
+        }
+    }
+    m_searchResultGroups.clear();
+}
+
+void AppMenuSearch::invalidateCandidates()
+{
+    m_searchCandidatesDirty = true;
+    m_searchCandidates.clear();
+    resetSearchState();
+}
+
+void AppMenuSearch::clearLastResults()
+{
+    resetSearchState();
+    m_lastSearchQuery.clear();
+    m_actionTextCache.clear();
+}
+
+void AppMenuSearch::resetSearchState()
+{
+    m_lastResults.clear();
+    m_lastProcessedMenu = nullptr;
+    m_lastShowDisabledActions = false;
+    m_lastIgnoreTopLevel = false;
+    m_lastIgnoreSubMenus = false;
+}
+
+QString AppMenuSearch::lastSearchQuery() const
+{
+    return m_lastSearchQuery;
+}
+
+void AppMenuSearch::rebuildSearchCandidatesIfNeeded()
+{
+    if (!m_searchCandidatesDirty) {
+        return;
+    }
+    m_searchCandidatesDirty = false;
+    m_searchCandidates.clear();
+
+    if (!m_appMenuModel) {
+        return;
+    }
+    QMenu *rootMenu = m_appMenuModel->menu();
+    if (!rootMenu) {
+        return;
+    }
+
+    QSet<QMenu *> visited;
+    QList<QPointer<QAction>> namedAncestors;
+    QList<QPointer<QAction>> enablementAncestors;
+    collectSearchCandidates(rootMenu, visited, namedAncestors, enablementAncestors);
+}
+
+void AppMenuSearch::collectSearchCandidates(QMenu *menu, QSet<QMenu *> &visited, QList<QPointer<QAction>> &namedAncestors, QList<QPointer<QAction>> &enablementAncestors)
+{
+    if (!menu || visited.contains(menu) || m_searchCandidates.size() >= MAX_SEARCH_CANDIDATES) {
+        return;
+    }
+    visited.insert(menu);
+
+    QAction *menuAction = menu->menuAction();
+    bool addedNamed = false;
+    bool addedEnablement = false;
+    if (menuAction) {
+        // Unconditional: even an untitled submenu still gates whether its
+        // children are reachable/enabled, so its own enabled state must
+        // propagate down regardless of whether it has display text.
+        enablementAncestors.append(menuAction);
+        addedEnablement = true;
+        if (!getActionText(menuAction).isEmpty()) {
+            namedAncestors.append(menuAction);
+            addedNamed = true;
+        }
+    }
+
+    for (QAction *action : menu->actions()) {
+        if (m_searchCandidates.size() >= MAX_SEARCH_CANDIDATES) {
+            break;
+        }
+        if (action->isSeparator()) {
+            continue;
+        }
+        if (action->menu()) {
+            collectSearchCandidates(action->menu(), visited, namedAncestors, enablementAncestors);
+        } else {
+            m_searchCandidates.append({action, namedAncestors, enablementAncestors});
+        }
+    }
+
+    if (addedNamed) {
+        namedAncestors.removeLast();
+    }
+    if (addedEnablement) {
+        enablementAncestors.removeLast();
+    }
+}
+
+QList<AppMenuSearch::SearchResult> AppMenuSearch::matchSearchCandidates(const QStringMatcher &matcher, bool ignoreTopLevel, bool ignoreSubMenus, bool showDisabledActions) const
+{
+    QList<SearchResult> results;
+
+    // Two independent memoized chains, mirroring how the original recursive
+    // algorithm kept these concerns separate: a submenu's *enabled* state
+    // always propagates to its children, even if the submenu has no title
+    // of its own; its *title* only contributes to the visible path/matching
+    // when non-empty. Folding both into a single "named ancestors" chain
+    // would silently drop the disabled state of untitled submenus.
+    QHash<QAction *, bool> enabledCache; // cumulative isEnabled up to and including this ancestor
+    struct MatchState {
+        bool currentMatched = false;
+        QString text = QString();
+    };
+    QHash<QAction *, MatchState> matchCache; // cumulative match state + this ancestor's text
+
+    for (const SearchCandidate &candidate : std::as_const(m_searchCandidates)) {
+        if (results.size() >= MAX_SEARCH_RESULTS) {
+            break;
+        }
+        QAction *action = candidate.action;
+        if (!action) {
+            continue; // Action was destroyed since the cache was built.
+        }
+
+        bool ancestorsStillValid = true;
+
+        // --- Enabled chain (every ancestor, named or not) ---
+        bool isCurrentEnabled = true;
+        if (!candidate.enablementAncestors.isEmpty()) {
+            QAction *deepest = candidate.enablementAncestors.last();
+            if (!deepest) {
+                ancestorsStillValid = false;
+            } else {
+                auto it = enabledCache.find(deepest);
+                if (it != enabledCache.end()) {
+                    isCurrentEnabled = it.value();
+                } else {
+                    for (QAction *ancestor : std::as_const(candidate.enablementAncestors)) {
+                        if (!ancestor) {
+                            ancestorsStillValid = false;
+                            break;
+                        }
+                        auto it2 = enabledCache.find(ancestor);
+                        if (it2 != enabledCache.end()) {
+                            isCurrentEnabled = it2.value();
+                        } else {
+                            if (!ancestor->isEnabled()) {
+                                isCurrentEnabled = false;
+                            }
+                            enabledCache.insert(ancestor, isCurrentEnabled);
+                        }
+                    }
+                }
+            }
+        }
+
+        // --- Match/text chain (only ancestors with a non-empty title) ---
+        bool currentMatched = false;
+        if (ancestorsStillValid && !candidate.namedAncestors.isEmpty()) {
+            QAction *parent = candidate.namedAncestors.last();
+            if (!parent) {
+                ancestorsStillValid = false;
+            } else {
+                auto it = matchCache.find(parent);
+                if (it != matchCache.end()) {
+                    currentMatched = it.value().currentMatched;
+                } else {
+                    for (int i = 0; i < candidate.namedAncestors.size(); ++i) {
+                        QAction *ancestor = candidate.namedAncestors.at(i);
+                        if (!ancestor) {
+                            ancestorsStillValid = false;
+                            break;
+                        }
+                        auto it2 = matchCache.find(ancestor);
+                        if (it2 != matchCache.end()) {
+                            currentMatched = it2.value().currentMatched;
+                        } else {
+                            QString ancestorText = getActionText(ancestor);
+                            if (!currentMatched && (!ignoreTopLevel || i > 0)) {
+                                if (matcher.indexIn(ancestorText) != -1) {
+                                    currentMatched = true;
+                                }
+                            }
+                            matchCache.insert(ancestor, {currentMatched, ancestorText});
+                        }
+                    }
+                }
+            }
+        }
+
+        if (!ancestorsStillValid) {
+            continue; // A submenu in the path was rebuilt/destroyed; skip until next full rebuild.
+        }
+
+        const QString itemText = getActionText(action);
+        bool match = currentMatched;
+        if (ignoreSubMenus) {
+            match = matcher.indexIn(itemText) != -1;
+        } else if (!match && (!ignoreTopLevel || !candidate.namedAncestors.isEmpty())) {
+            if (matcher.indexIn(itemText) != -1) {
+                match = true;
+            }
+        }
+
+        if (!match) {
+            continue; // Skip building path entirely for non-matching entries!
+        }
+
+        const bool isEffectivelyEnabled = isCurrentEnabled && action->isEnabled();
+        if (!isEffectivelyEnabled && !showDisabledActions) {
+            continue;
+        }
+
+        // 2. Only perform path allocation and joins for matching results
+        QStringList currentPath;
+        currentPath.reserve(candidate.namedAncestors.size() + 1);
+        for (int i = 0; i < candidate.namedAncestors.size(); ++i) {
+            QAction *ancestor = candidate.namedAncestors.at(i);
+            currentPath.append(matchCache.value(ancestor).text);
+        }
+
+        ActionInfo info;
+        info.label = itemText;
+        info.isEffectivelyEnabled = isEffectivelyEnabled;
+        info.isChecked = action->isChecked();
+        info.isCheckable = action->isCheckable();
+
+        currentPath.append(itemText);
+        info.path = currentPath.join(QStringLiteral(" » "));
+
+        results.append({action, info});
+    }
+
+    return results;
+}
+
+QString AppMenuSearch::getActionText(QAction *action) const
+{
+    if (!action) {
+        return QString();
+    }
+    const QString rawText = action->text();
+    auto it = m_actionTextCache.find(rawText);
+    if (it != m_actionTextCache.end()) {
+        return it.value();
+    }
+    const QString cleanedText = KLocalizedString::removeAcceleratorMarker(rawText.trimmed());
+    m_actionTextCache.insert(rawText, cleanedText);
+    return cleanedText;
+}
+
+} // namespace Material

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -57,15 +57,8 @@ void AppMenuSearch::filter(const QString &text, const FilterOptions &options)
 
     m_lastSearchQuery = text;
 
-    // Clear results if search text is too short
-    if (isQueryTooShort(text)) {
-        clear();
-        resetSearchState();
-        Q_EMIT repositionRequested();
-        return;
-    }
-
-    if (!m_appMenuModel) {
+    // Clear results if search text is too short or model is unavailable
+    if (isQueryTooShort(text) || !m_appMenuModel) {
         clear();
         resetSearchState();
         Q_EMIT repositionRequested();

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -174,7 +174,11 @@ void AppMenuSearch::invalidateCandidates()
 {
     m_searchCandidatesDirty = true;
     m_searchCandidates.clear();
-    resetSearchState();
+    m_lastResults.clear();
+    m_lastProcessedMenu = nullptr;
+    m_lastShowDisabledActions = false;
+    m_lastIgnoreTopLevel = false;
+    m_lastIgnoreSubMenus = false;
 }
 
 void AppMenuSearch::clearLastResults()

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -52,7 +52,6 @@ void AppMenuSearch::filter(QMenu *searchMenu, const QString &text, const FilterO
     if (!m_searchMenu) {
         return;
     }
-    m_lastSearchQuery = text;
 
     // Clear results if search text is too short
     if (isQueryTooShort(text)) {
@@ -173,7 +172,6 @@ void AppMenuSearch::invalidateCandidates()
 void AppMenuSearch::clearLastResults()
 {
     resetSearchState();
-    m_lastSearchQuery.clear();
     m_actionTextCache.clear();
 }
 
@@ -186,17 +184,11 @@ void AppMenuSearch::resetSearchState()
     m_lastIgnoreSubMenus = false;
 }
 
-QString AppMenuSearch::lastSearchQuery() const
-{
-    return m_lastSearchQuery;
-}
-
 void AppMenuSearch::rebuildSearchCandidatesIfNeeded()
 {
     if (!m_searchCandidatesDirty) {
         return;
     }
-    m_searchCandidatesDirty = false;
     m_searchCandidates.clear();
 
     if (!m_appMenuModel) {
@@ -207,6 +199,7 @@ void AppMenuSearch::rebuildSearchCandidatesIfNeeded()
         return;
     }
 
+    m_searchCandidatesDirty = false;
     QSet<QMenu *> visited;
     QList<QPointer<QAction>> namedAncestors;
     QList<QPointer<QAction>> enablementAncestors;

--- a/src/AppMenuSearch.h
+++ b/src/AppMenuSearch.h
@@ -78,11 +78,14 @@ public:
         bool showDisabledActions = false;
     };
 
-    void filter(QMenu *searchMenu, const QString &text, const FilterOptions &options);
+    void setSearchMenu(QMenu *searchMenu);
+    void filter(const QString &text, const FilterOptions &options);
     void clear();
     
     void invalidateCandidates();
     void clearLastResults();
+    QString lastSearchQuery() const;
+    bool hasValidQuery() const;
 
 signals:
     void repositionRequested();
@@ -96,6 +99,7 @@ private:
 
     QPointer<AppMenuModel> m_appMenuModel;
     QPointer<QMenu> m_searchMenu;
+    QString m_lastSearchQuery;
     bool m_lastShowDisabledActions = false;
     bool m_lastIgnoreTopLevel = false;
     bool m_lastIgnoreSubMenus = false;

--- a/src/AppMenuSearch.h
+++ b/src/AppMenuSearch.h
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2025 Guido Iodice <guido[dot]iodice[at]gmail[dot]com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QObject>
+#include <QMenu>
+#include <QAction>
+#include <QActionGroup>
+#include <QPointer>
+#include <QList>
+#include <QSet>
+#include <QHash>
+#include <QStringList>
+#include <QStringMatcher>
+
+namespace Material
+{
+
+class AppMenuModel;
+
+class AppMenuSearch : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit AppMenuSearch(AppMenuModel *model, QObject *parent = nullptr);
+    ~AppMenuSearch() override;
+
+    static constexpr int MINIMUM_SEARCH_LENGTH = 3;
+    static constexpr const char PROPERTY_SEARCH_PROXY[] = "isAppMenuSearchProxy";
+    static bool isQueryTooShort(const QString &text);
+
+    struct ActionInfo {
+        QString path;
+        QString label;
+        bool isEffectivelyEnabled = false;
+        bool isChecked = false;
+        bool isCheckable = false;
+    };
+
+    struct SearchCandidate {
+        QPointer<QAction> action;
+        QList<QPointer<QAction>> namedAncestors;
+        QList<QPointer<QAction>> enablementAncestors;
+    };
+
+    struct SearchResult {
+        QPointer<QAction> action;
+        ActionInfo info;
+
+        bool operator==(const SearchResult &other) const {
+            return action == other.action
+            && info.isEffectivelyEnabled == other.info.isEffectivelyEnabled
+            && info.path == other.info.path
+            && info.isChecked == other.info.isChecked
+            && info.isCheckable == other.info.isCheckable;
+        }
+    };
+
+    struct FilterOptions {
+        bool ignoreTopLevel = false;
+        bool ignoreSubMenus = false;
+        bool showDisabledActions = false;
+    };
+
+    void filter(QMenu *searchMenu, const QString &text, const FilterOptions &options);
+    void clear();
+    
+    void invalidateCandidates();
+    void clearLastResults();
+    
+    QString lastSearchQuery() const;
+
+signals:
+    void repositionRequested();
+
+private:
+    void rebuildSearchCandidatesIfNeeded();
+    void collectSearchCandidates(QMenu *menu, QSet<QMenu *> &visited, QList<QPointer<QAction>> &namedAncestors, QList<QPointer<QAction>> &enablementAncestors);
+    QList<SearchResult> matchSearchCandidates(const QStringMatcher &matcher, bool ignoreTopLevel, bool ignoreSubMenus, bool showDisabledActions) const;
+    QString getActionText(QAction *action) const;
+    void resetSearchState();
+
+    QPointer<AppMenuModel> m_appMenuModel;
+    QPointer<QMenu> m_searchMenu;
+    QString m_lastSearchQuery;
+    bool m_lastShowDisabledActions = false;
+    bool m_lastIgnoreTopLevel = false;
+    bool m_lastIgnoreSubMenus = false;
+    QList<SearchResult> m_lastResults;
+    QPointer<QMenu> m_lastProcessedMenu;
+    QList<SearchCandidate> m_searchCandidates;
+    bool m_searchCandidatesDirty = true;
+    QList<QPointer<QActionGroup>> m_searchResultGroups;
+    mutable QHash<QString, QString> m_actionTextCache;
+};
+
+} // namespace Material

--- a/src/AppMenuSearch.h
+++ b/src/AppMenuSearch.h
@@ -83,8 +83,6 @@ public:
     
     void invalidateCandidates();
     void clearLastResults();
-    
-    QString lastSearchQuery() const;
 
 signals:
     void repositionRequested();
@@ -98,7 +96,6 @@ private:
 
     QPointer<AppMenuModel> m_appMenuModel;
     QPointer<QMenu> m_searchMenu;
-    QString m_lastSearchQuery;
     bool m_lastShowDisabledActions = false;
     bool m_lastIgnoreTopLevel = false;
     bool m_lastIgnoreSubMenus = false;

--- a/src/AppMenuSearch.h
+++ b/src/AppMenuSearch.h
@@ -107,6 +107,8 @@ private:
     QPointer<QMenu> m_lastProcessedMenu;
     QList<SearchCandidate> m_searchCandidates;
     bool m_searchCandidatesDirty = true;
+    bool m_menuIsRendered = false;
+    bool m_candidateTruncationLogged = false;
     QList<QPointer<QActionGroup>> m_searchResultGroups;
     mutable QHash<QString, QString> m_actionTextCache;
 };

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,6 +55,7 @@ configure_file(BuildConfig.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/BuildConfig.h)
 
 set (decoration_SRCS
     AppMenuModel.cc
+    AppMenuSearch.cc
     NavigableMenu.cc
     AppMenuButton.cc
     AppMenuButtonGroup.cc
@@ -74,6 +75,8 @@ kconfig_add_kcfg_files(decoration_SRCS
 add_library (materialdecoration MODULE
     ${decoration_SRCS}
 )
+
+set_target_properties(materialdecoration PROPERTIES AUTOMOC ON)
 
 target_include_directories(materialdecoration PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 


### PR DESCRIPTION
## Summary by Sourcery

Estrarre la logica di ricerca del menu dell'app in un helper dedicato `AppMenuSearch` e integrarlo con `AppMenuButtonGroup` per gestire il filtraggio, il rendering dei risultati e la gestione dello stato.

Miglioramenti:
- Rifattorizzare la funzionalità di ricerca del menu dell'app in una classe riutilizzabile `AppMenuSearch` che gestisca i candidati, il matching e le azioni proxy, preservando al contempo i gruppi di azioni e lo stato.
- Semplificare `AppMenuButtonGroup` delegando a `AppMenuSearch` le responsabilità relative alla ricerca, inclusa l'invalidazione dei candidati, la cancellazione dei risultati e il riutilizzo delle query tra gli aggiornamenti del menu.
- Migliorare la gestione dei risultati di ricerca contrassegnando esplicitamente le azioni proxy, riutilizzando i risultati in cache quando i parametri non cambiano e applicando limiti ai candidati con logging quando vengono troncati.
- Aggiornare la configurazione di build per compilare il nuovo componente `AppMenuSearch` con `AUTOMOC` abilitato per la libreria `materialdecoration`.

Documentazione:
- Rimuovere un badge esterno di revisione delle pull request di CodeRabbit dal README per snellire la documentazione del progetto.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extract app menu search logic into a dedicated AppMenuSearch helper and integrate it with AppMenuButtonGroup to handle filtering, result rendering, and state management.

Enhancements:
- Refactor app menu search functionality into a reusable AppMenuSearch class that manages candidates, matching, and proxy actions while preserving action groups and state.
- Simplify AppMenuButtonGroup by delegating search-related responsibilities to AppMenuSearch, including candidate invalidation, result clearing, and query reuse across menu updates.
- Improve search result handling by marking proxy actions explicitly, reusing cached results when parameters are unchanged, and enforcing limits on candidates with logging when truncated.
- Update the build configuration to compile the new AppMenuSearch component with AUTOMOC enabled for the materialdecoration library.

Documentation:
- Remove an external CodeRabbit pull-request review badge from the README to streamline project documentation.

</details>