### PR TITLE
AppMenuSearch: fix search state handling for short queries

### DIFF
--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -56,15 +56,17 @@ void AppMenuSearch::filter(const QString &text, const FilterOptions &options)
         return;
     }
 
+    m_lastSearchQuery = text;
+
     // Clear results if search text is too short or model is unavailable
     if (isQueryTooShort(text) || !m_appMenuModel) {
         clear();
-        resetSearchState();
+        m_lastResults.clear();
+        m_lastProcessedMenu = nullptr;
+        m_lastOptions = FilterOptions();
         Q_EMIT repositionRequested();
         return;
     }
-
-    m_lastSearchQuery = text;
 
     {
         // Find results
@@ -161,12 +163,6 @@ void AppMenuSearch::clear()
     m_searchResultGroups.clear();
 }
 
-void AppMenuSearch::reset()
-{
-    clear();
-    clearLastResults();
-}
-
 void AppMenuSearch::invalidateCandidates()
 {
     m_searchCandidatesDirty = true;
@@ -189,6 +185,12 @@ void AppMenuSearch::clearLastResults()
 bool AppMenuSearch::hasValidQuery() const
 {
     return !m_lastSearchQuery.isEmpty() && !isQueryTooShort(m_lastSearchQuery);
+}
+
+void AppMenuSearch::reset()
+{
+    clear();
+    clearLastResults();
 }
 
 void AppMenuSearch::resetSearchState()

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -56,17 +56,15 @@ void AppMenuSearch::filter(const QString &text, const FilterOptions &options)
         return;
     }
 
-    m_lastSearchQuery = text;
-
     // Clear results if search text is too short or model is unavailable
     if (isQueryTooShort(text) || !m_appMenuModel) {
         clear();
-        m_lastResults.clear();
-        m_lastProcessedMenu = nullptr;
-        m_lastOptions = FilterOptions();
+        resetSearchState();
         Q_EMIT repositionRequested();
         return;
     }
+
+    m_lastSearchQuery = text;
 
     {
         // Find results
@@ -176,12 +174,6 @@ void AppMenuSearch::invalidateCandidates()
     m_lastOptions = FilterOptions();
 }
 
-void AppMenuSearch::clearLastResults()
-{
-    resetSearchState();
-    m_actionTextCache.clear();
-}
-
 bool AppMenuSearch::hasValidQuery() const
 {
     return !m_lastSearchQuery.isEmpty() && !isQueryTooShort(m_lastSearchQuery);
@@ -190,7 +182,8 @@ bool AppMenuSearch::hasValidQuery() const
 void AppMenuSearch::reset()
 {
     clear();
-    clearLastResults();
+    resetSearchState();
+    m_actionTextCache.clear();
 }
 
 void AppMenuSearch::resetSearchState()

--- a/src/AppMenuSearch.h
+++ b/src/AppMenuSearch.h
@@ -89,7 +89,6 @@ public:
     void reset();
     
     void invalidateCandidates();
-    void clearLastResults();
     bool hasValidQuery() const;
 
 signals:

--- a/src/AppMenuSearch.h
+++ b/src/AppMenuSearch.h
@@ -87,7 +87,7 @@ public:
     // Clears both the rendered result actions and the cached search state
     // (query, results, options). Used whenever the search UI is dismissed.
     void reset();
-
+    
     void invalidateCandidates();
     void clearLastResults();
     bool hasValidQuery() const;


### PR DESCRIPTION
## Riepilogo di Sourcery

Regola la gestione dello stato di ricerca del menu dell'app quando le query sono troppo corte e riorganizza la logica di reset.

Correzioni di bug:
- Garantisce che lo stato di ricerca venga correttamente ripulito senza reimpostare completamente l’ultima query quando il testo di ricerca è troppo corto o il modello non è disponibile.

Miglioramenti:
- Riordina e chiarisce i metodi relativi al reset in `AppMenuSearch` per separare meglio la pulizia dei risultati renderizzati dal reset dello stato di ricerca memorizzato nella cache.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust app menu search state handling when queries are too short and reorganize reset logic.

Bug Fixes:
- Ensure search state is correctly cleared without fully resetting the last query when the search text is too short or the model is unavailable.

Enhancements:
- Reorder and clarify reset-related methods in AppMenuSearch to better separate clearing rendered results from resetting cached search state.

</details>