### PR TITLE
AppMenuSearch: simplify candidate ancestors and matching

### DIFF
--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -359,6 +359,7 @@ QList<AppMenuSearch::SearchResult> AppMenuSearch::matchSearchCandidates(const QS
                     text = it.value().text;
                 } else {
                     text = getActionText(ancestor);
+                    matchCache.insert(ancestor, {text, false});
                 }
                 if (!text.isEmpty()) {
                     currentPath.append(text);

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -259,13 +259,55 @@ void AppMenuSearch::collectSearchCandidates(QMenu *menu, QSet<QMenu *> &visited,
     }
 }
 
+bool AppMenuSearch::matchesAncestorsOrText(const SearchCandidate &candidate, const QStringMatcher &matcher, bool ignoreTopLevel, QHash<QAction *, MatchState> &matchCache) const
+{
+    const QString itemText = getActionText(candidate.action);
+    bool isTopLevel = true;
+    bool hasNamedAncestors = false;
+    for (QAction *ancestor : candidate.ancestors) {
+        if (!ancestor) {
+            continue;
+        }
+
+        auto it = matchCache.find(ancestor);
+        QString ancestorText;
+        bool matched = false;
+        if (it != matchCache.end()) {
+            ancestorText = it.value().text;
+            matched = it.value().matched;
+        } else {
+            ancestorText = getActionText(ancestor);
+            matched = (matcher.indexIn(ancestorText) != -1);
+            matchCache.insert(ancestor, {ancestorText, matched});
+        }
+
+        if (ancestorText.isEmpty()) {
+            continue;
+        }
+        hasNamedAncestors = true;
+        if (ignoreTopLevel && isTopLevel) {
+            isTopLevel = false;
+            continue;
+        }
+        isTopLevel = false;
+
+        if (matched) {
+            return true;
+        }
+    }
+
+    if (!ignoreTopLevel || hasNamedAncestors) {
+        if (matcher.indexIn(itemText) != -1) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 QList<AppMenuSearch::SearchResult> AppMenuSearch::matchSearchCandidates(const QStringMatcher &matcher, bool ignoreTopLevel, bool ignoreSubMenus, bool showDisabledActions) const
 {
     QList<SearchResult> results;
-    struct MatchState {
-        QString text;
-        bool matched = false;
-    };
     QHash<QAction *, MatchState> matchCache;
 
     for (const SearchCandidate &candidate : std::as_const(m_searchCandidates)) {
@@ -303,46 +345,7 @@ QList<AppMenuSearch::SearchResult> AppMenuSearch::matchSearchCandidates(const QS
         if (ignoreSubMenus) {
             match = (matcher.indexIn(itemText) != -1);
         } else {
-            bool isTopLevel = true;
-            bool hasNamedAncestors = false;
-            for (QAction *ancestor : candidate.ancestors) {
-                if (!ancestor) {
-                    continue;
-                }
-
-                auto it = matchCache.find(ancestor);
-                QString ancestorText;
-                bool matched = false;
-                if (it != matchCache.end()) {
-                    ancestorText = it.value().text;
-                    matched = it.value().matched;
-                } else {
-                    ancestorText = getActionText(ancestor);
-                    matched = (matcher.indexIn(ancestorText) != -1);
-                    matchCache.insert(ancestor, {ancestorText, matched});
-                }
-
-                if (ancestorText.isEmpty()) {
-                    continue;
-                }
-                hasNamedAncestors = true;
-                if (ignoreTopLevel && isTopLevel) {
-                    isTopLevel = false;
-                    continue;
-                }
-                isTopLevel = false;
-
-                if (matched) {
-                    match = true;
-                    break;
-                }
-            }
-
-            if (!match && (!ignoreTopLevel || hasNamedAncestors)) {
-                if (matcher.indexIn(itemText) != -1) {
-                    match = true;
-                }
-            }
+            match = matchesAncestorsOrText(candidate, matcher, ignoreTopLevel, matchCache);
         }
 
         if (!match) {

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -215,31 +215,22 @@ void AppMenuSearch::rebuildSearchCandidatesIfNeeded()
 
     m_searchCandidatesDirty = false;
     QSet<QMenu *> visited;
-    QList<QPointer<QAction>> namedAncestors;
-    QList<QPointer<QAction>> enablementAncestors;
-    collectSearchCandidates(rootMenu, visited, namedAncestors, enablementAncestors);
+    QList<QPointer<QAction>> ancestors;
+    collectSearchCandidates(rootMenu, visited, ancestors);
 }
 
-void AppMenuSearch::collectSearchCandidates(QMenu *menu, QSet<QMenu *> &visited, QList<QPointer<QAction>> &namedAncestors, QList<QPointer<QAction>> &enablementAncestors)
+void AppMenuSearch::collectSearchCandidates(QMenu *menu, QSet<QMenu *> &visited, QList<QPointer<QAction>> &ancestors)
 {
-    if (!menu || visited.contains(menu) || m_searchCandidates.size() >= MAX_SEARCH_CANDIDATES || enablementAncestors.size() >= MAX_MENU_DEPTH) {
+    if (!menu || visited.contains(menu) || m_searchCandidates.size() >= MAX_SEARCH_CANDIDATES || ancestors.size() >= MAX_MENU_DEPTH) {
         return;
     }
     visited.insert(menu);
 
     QAction *menuAction = menu->menuAction();
-    bool addedNamed = false;
-    bool addedEnablement = false;
+    bool addedAncestor = false;
     if (menuAction) {
-        // Unconditional: even an untitled submenu still gates whether its
-        // children are reachable/enabled, so its own enabled state must
-        // propagate down regardless of whether it has display text.
-        enablementAncestors.append(menuAction);
-        addedEnablement = true;
-        if (!getActionText(menuAction).isEmpty()) {
-            namedAncestors.append(menuAction);
-            addedNamed = true;
-        }
+        ancestors.append(menuAction);
+        addedAncestor = true;
     }
 
     for (QAction *action : menu->actions()) {
@@ -257,36 +248,20 @@ void AppMenuSearch::collectSearchCandidates(QMenu *menu, QSet<QMenu *> &visited,
             continue;
         }
         if (action->menu()) {
-            collectSearchCandidates(action->menu(), visited, namedAncestors, enablementAncestors);
+            collectSearchCandidates(action->menu(), visited, ancestors);
         } else {
-            m_searchCandidates.append({action, namedAncestors, enablementAncestors});
+            m_searchCandidates.append({action, ancestors});
         }
     }
 
-    if (addedNamed) {
-        namedAncestors.removeLast();
-    }
-    if (addedEnablement) {
-        enablementAncestors.removeLast();
+    if (addedAncestor) {
+        ancestors.removeLast();
     }
 }
 
 QList<AppMenuSearch::SearchResult> AppMenuSearch::matchSearchCandidates(const QStringMatcher &matcher, bool ignoreTopLevel, bool ignoreSubMenus, bool showDisabledActions) const
 {
     QList<SearchResult> results;
-
-    // Two independent memoized chains, mirroring how the original recursive
-    // algorithm kept these concerns separate: a submenu's *enabled* state
-    // always propagates to its children, even if the submenu has no title
-    // of its own; its *title* only contributes to the visible path/matching
-    // when non-empty. Folding both into a single "named ancestors" chain
-    // would silently drop the disabled state of untitled submenus.
-    QHash<QAction *, bool> enabledCache; // cumulative isEnabled up to and including this ancestor
-    struct MatchState {
-        bool currentMatched = false;
-        QString text = QString();
-    };
-    QHash<QAction *, MatchState> matchCache; // cumulative match state + this ancestor's text
 
     for (const SearchCandidate &candidate : std::as_const(m_searchCandidates)) {
         if (results.size() >= MAX_SEARCH_RESULTS) {
@@ -297,69 +272,15 @@ QList<AppMenuSearch::SearchResult> AppMenuSearch::matchSearchCandidates(const QS
             continue; // Action was destroyed since the cache was built.
         }
 
+        bool isEffectivelyEnabled = action->isEnabled();
         bool ancestorsStillValid = true;
-
-        // --- Enabled chain (every ancestor, named or not) ---
-        bool isCurrentEnabled = true;
-        if (!candidate.enablementAncestors.isEmpty()) {
-            QAction *deepest = candidate.enablementAncestors.last();
-            if (!deepest) {
+        for (const auto &ancestor : candidate.ancestors) {
+            if (!ancestor) {
                 ancestorsStillValid = false;
-            } else {
-                auto it = enabledCache.find(deepest);
-                if (it != enabledCache.end()) {
-                    isCurrentEnabled = it.value();
-                } else {
-                    for (QAction *ancestor : std::as_const(candidate.enablementAncestors)) {
-                        if (!ancestor) {
-                            ancestorsStillValid = false;
-                            break;
-                        }
-                        auto it2 = enabledCache.find(ancestor);
-                        if (it2 != enabledCache.end()) {
-                            isCurrentEnabled = it2.value();
-                        } else {
-                            if (!ancestor->isEnabled()) {
-                                isCurrentEnabled = false;
-                            }
-                            enabledCache.insert(ancestor, isCurrentEnabled);
-                        }
-                    }
-                }
+                break;
             }
-        }
-
-        // --- Match/text chain (only ancestors with a non-empty title) ---
-        bool currentMatched = false;
-        if (ancestorsStillValid && !candidate.namedAncestors.isEmpty()) {
-            QAction *parent = candidate.namedAncestors.last();
-            if (!parent) {
-                ancestorsStillValid = false;
-            } else {
-                auto it = matchCache.find(parent);
-                if (it != matchCache.end()) {
-                    currentMatched = it.value().currentMatched;
-                } else {
-                    for (int i = 0; i < candidate.namedAncestors.size(); ++i) {
-                        QAction *ancestor = candidate.namedAncestors.at(i);
-                        if (!ancestor) {
-                            ancestorsStillValid = false;
-                            break;
-                        }
-                        auto it2 = matchCache.find(ancestor);
-                        if (it2 != matchCache.end()) {
-                            currentMatched = it2.value().currentMatched;
-                        } else {
-                            QString ancestorText = getActionText(ancestor);
-                            if (!currentMatched && (!ignoreTopLevel || i > 0)) {
-                                if (matcher.indexIn(ancestorText) != -1) {
-                                    currentMatched = true;
-                                }
-                            }
-                            matchCache.insert(ancestor, {currentMatched, ancestorText});
-                        }
-                    }
-                }
+            if (!ancestor->isEnabled()) {
+                isEffectivelyEnabled = false;
             }
         }
 
@@ -367,31 +288,54 @@ QList<AppMenuSearch::SearchResult> AppMenuSearch::matchSearchCandidates(const QS
             continue; // A submenu in the path was rebuilt/destroyed; skip until next full rebuild.
         }
 
-        const QString itemText = getActionText(action);
-        bool match = currentMatched;
-        if (ignoreSubMenus) {
-            match = matcher.indexIn(itemText) != -1;
-        } else if (!match && (!ignoreTopLevel || !candidate.namedAncestors.isEmpty())) {
-            if (matcher.indexIn(itemText) != -1) {
-                match = true;
-            }
-        }
-
-        if (!match) {
-            continue; // Skip building path entirely for non-matching entries!
-        }
-
-        const bool isEffectivelyEnabled = isCurrentEnabled && action->isEnabled();
         if (!isEffectivelyEnabled && !showDisabledActions) {
             continue;
         }
 
-        // 2. Only perform path allocation and joins for matching results
+        const QString itemText = getActionText(action);
+        bool match = false;
+
+        if (ignoreSubMenus) {
+            match = (matcher.indexIn(itemText) != -1);
+        } else {
+            if (matcher.indexIn(itemText) != -1) {
+                match = true;
+            } else {
+                bool isTopLevel = true;
+                for (QAction *ancestor : candidate.ancestors) {
+                    if (!ancestor) {
+                        continue;
+                    }
+                    QString ancestorText = getActionText(ancestor);
+                    if (ancestorText.isEmpty()) {
+                        continue;
+                    }
+                    if (ignoreTopLevel && isTopLevel) {
+                        isTopLevel = false;
+                        continue;
+                    }
+                    isTopLevel = false;
+                    if (matcher.indexIn(ancestorText) != -1) {
+                        match = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (!match) {
+            continue;
+        }
+
         QStringList currentPath;
-        currentPath.reserve(candidate.namedAncestors.size() + 1);
-        for (int i = 0; i < candidate.namedAncestors.size(); ++i) {
-            QAction *ancestor = candidate.namedAncestors.at(i);
-            currentPath.append(matchCache.value(ancestor).text);
+        currentPath.reserve(candidate.ancestors.size() + 1);
+        for (QAction *ancestor : candidate.ancestors) {
+            if (ancestor) {
+                QString text = getActionText(ancestor);
+                if (!text.isEmpty()) {
+                    currentPath.append(text);
+                }
+            }
         }
 
         ActionInfo info;
@@ -403,7 +347,7 @@ QList<AppMenuSearch::SearchResult> AppMenuSearch::matchSearchCandidates(const QS
         currentPath.append(itemText);
         info.path = currentPath.join(QStringLiteral(" » "));
 
-        results.append({action, info, action ? action->icon().cacheKey() : 0});
+        results.append({action, info, action->icon().cacheKey()});
     }
 
     return results;

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -262,6 +262,7 @@ void AppMenuSearch::collectSearchCandidates(QMenu *menu, QSet<QMenu *> &visited,
 QList<AppMenuSearch::SearchResult> AppMenuSearch::matchSearchCandidates(const QStringMatcher &matcher, bool ignoreTopLevel, bool ignoreSubMenus, bool showDisabledActions) const
 {
     QList<SearchResult> results;
+    QHash<QAction *, bool> matchCache;
 
     for (const SearchCandidate &candidate : std::as_const(m_searchCandidates)) {
         if (results.size() >= MAX_SEARCH_RESULTS) {
@@ -315,7 +316,17 @@ QList<AppMenuSearch::SearchResult> AppMenuSearch::matchSearchCandidates(const QS
                         continue;
                     }
                     isTopLevel = false;
-                    if (matcher.indexIn(ancestorText) != -1) {
+
+                    auto it = matchCache.find(ancestor);
+                    bool matched = false;
+                    if (it != matchCache.end()) {
+                        matched = it.value();
+                    } else {
+                        matched = (matcher.indexIn(ancestorText) != -1);
+                        matchCache.insert(ancestor, matched);
+                    }
+
+                    if (matched) {
                         match = true;
                         break;
                     }

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -219,20 +219,22 @@ void AppMenuSearch::rebuildSearchCandidatesIfNeeded()
     collectSearchCandidates(rootMenu, visited, ancestors);
 }
 
-void AppMenuSearch::collectSearchCandidates(QMenu *menu, QSet<QMenu *> &visited, QList<QPointer<QAction>> &ancestors)
+void AppMenuSearch::collectSearchCandidates(QMenu *menu, QSet<QMenu *> &visited, QList<QPointer<QAction>> &ancestors, bool hasNamedAncestor)
 {
     if (!menu || visited.contains(menu) || m_searchCandidates.size() >= MAX_SEARCH_CANDIDATES || ancestors.size() >= MAX_MENU_DEPTH) {
         return;
     }
     visited.insert(menu);
 
-    bool isMenuRoot = m_appMenuModel && (menu == m_appMenuModel->menu());
-
     QAction *menuAction = menu->menuAction();
     bool addedAncestor = false;
+    bool childHasNamedAncestor = hasNamedAncestor;
     if (menuAction) {
         ancestors.append(menuAction);
         addedAncestor = true;
+        if (!getActionText(menuAction).isEmpty()) {
+            childHasNamedAncestor = true;
+        }
     }
 
     for (QAction *action : menu->actions()) {
@@ -250,9 +252,9 @@ void AppMenuSearch::collectSearchCandidates(QMenu *menu, QSet<QMenu *> &visited,
             continue;
         }
         if (action->menu()) {
-            collectSearchCandidates(action->menu(), visited, ancestors);
+            collectSearchCandidates(action->menu(), visited, ancestors, childHasNamedAncestor);
         } else {
-            m_searchCandidates.append({action, ancestors, isMenuRoot});
+            m_searchCandidates.append({action, ancestors, !childHasNamedAncestor});
         }
     }
 
@@ -295,7 +297,7 @@ bool AppMenuSearch::matchesAncestorsOrText(const SearchCandidate &candidate, con
         }
     }
 
-    if (!ignoreTopLevel || !candidate.isTopLevel) {
+    if (!ignoreTopLevel || !candidate.hasNoNamedAncestor) {
         if (matcher.indexIn(itemText) != -1) {
             return true;
         }
@@ -342,7 +344,7 @@ QList<AppMenuSearch::SearchResult> AppMenuSearch::matchSearchCandidates(const QS
         bool match = false;
 
         if (ignoreSubMenus) {
-            if (ignoreTopLevel && candidate.isTopLevel) {
+            if (ignoreTopLevel && candidate.hasNoNamedAncestor) {
                 match = false;
             } else {
                 match = (matcher.indexIn(itemText) != -1);

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -254,7 +254,7 @@ void AppMenuSearch::collectSearchCandidates(QMenu *menu, QSet<QMenu *> &visited,
         if (action->menu()) {
             collectSearchCandidates(action->menu(), visited, ancestors, childHasNamedAncestor);
         } else {
-            m_searchCandidates.append({action, ancestors, !childHasNamedAncestor});
+            m_searchCandidates.append({action, ancestors, childHasNamedAncestor});
         }
     }
 
@@ -297,7 +297,7 @@ bool AppMenuSearch::matchesAncestorsOrText(const SearchCandidate &candidate, con
         }
     }
 
-    if (!ignoreTopLevel || !candidate.hasNoNamedAncestor) {
+    if (!ignoreTopLevel || candidate.hasNamedAncestor) {
         if (matcher.indexIn(itemText) != -1) {
             return true;
         }
@@ -344,7 +344,7 @@ QList<AppMenuSearch::SearchResult> AppMenuSearch::matchSearchCandidates(const QS
         bool match = false;
 
         if (ignoreSubMenus) {
-            if (ignoreTopLevel && candidate.hasNoNamedAncestor) {
+            if (ignoreTopLevel && !candidate.hasNamedAncestor) {
                 match = false;
             } else {
                 match = (matcher.indexIn(itemText) != -1);

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -343,7 +343,18 @@ QList<AppMenuSearch::SearchResult> AppMenuSearch::matchSearchCandidates(const QS
         bool match = false;
 
         if (ignoreSubMenus) {
-            match = (matcher.indexIn(itemText) != -1);
+            bool hasNamedAncestors = false;
+            for (QAction *ancestor : candidate.ancestors) {
+                if (ancestor && !getActionText(ancestor).isEmpty()) {
+                    hasNamedAncestors = true;
+                    break;
+                }
+            }
+            if (ignoreTopLevel && !hasNamedAncestors) {
+                match = false;
+            } else {
+                match = (matcher.indexIn(itemText) != -1);
+            }
         } else {
             match = matchesAncestorsOrText(candidate, matcher, ignoreTopLevel, matchCache);
         }

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -226,6 +226,8 @@ void AppMenuSearch::collectSearchCandidates(QMenu *menu, QSet<QMenu *> &visited,
     }
     visited.insert(menu);
 
+    bool isMenuRoot = m_appMenuModel && (menu == m_appMenuModel->menu());
+
     QAction *menuAction = menu->menuAction();
     bool addedAncestor = false;
     if (menuAction) {
@@ -250,7 +252,7 @@ void AppMenuSearch::collectSearchCandidates(QMenu *menu, QSet<QMenu *> &visited,
         if (action->menu()) {
             collectSearchCandidates(action->menu(), visited, ancestors);
         } else {
-            m_searchCandidates.append({action, ancestors});
+            m_searchCandidates.append({action, ancestors, isMenuRoot});
         }
     }
 
@@ -259,11 +261,9 @@ void AppMenuSearch::collectSearchCandidates(QMenu *menu, QSet<QMenu *> &visited,
     }
 }
 
-bool AppMenuSearch::matchesAncestorsOrText(const SearchCandidate &candidate, const QStringMatcher &matcher, bool ignoreTopLevel, QHash<QAction *, MatchState> &matchCache) const
+bool AppMenuSearch::matchesAncestorsOrText(const SearchCandidate &candidate, const QString &itemText, const QStringMatcher &matcher, bool ignoreTopLevel, QHash<QAction *, MatchState> &matchCache) const
 {
-    const QString itemText = getActionText(candidate.action);
-    bool isTopLevel = true;
-    bool hasNamedAncestors = false;
+    bool isTopLevelAncestor = true;
     for (QAction *ancestor : candidate.ancestors) {
         if (!ancestor) {
             continue;
@@ -284,19 +284,18 @@ bool AppMenuSearch::matchesAncestorsOrText(const SearchCandidate &candidate, con
         if (ancestorText.isEmpty()) {
             continue;
         }
-        hasNamedAncestors = true;
-        if (ignoreTopLevel && isTopLevel) {
-            isTopLevel = false;
+        if (ignoreTopLevel && isTopLevelAncestor) {
+            isTopLevelAncestor = false;
             continue;
         }
-        isTopLevel = false;
+        isTopLevelAncestor = false;
 
         if (matched) {
             return true;
         }
     }
 
-    if (!ignoreTopLevel || hasNamedAncestors) {
+    if (!ignoreTopLevel || !candidate.isTopLevel) {
         if (matcher.indexIn(itemText) != -1) {
             return true;
         }
@@ -343,20 +342,13 @@ QList<AppMenuSearch::SearchResult> AppMenuSearch::matchSearchCandidates(const QS
         bool match = false;
 
         if (ignoreSubMenus) {
-            bool hasNamedAncestors = false;
-            for (QAction *ancestor : candidate.ancestors) {
-                if (ancestor && !getActionText(ancestor).isEmpty()) {
-                    hasNamedAncestors = true;
-                    break;
-                }
-            }
-            if (ignoreTopLevel && !hasNamedAncestors) {
+            if (ignoreTopLevel && candidate.isTopLevel) {
                 match = false;
             } else {
                 match = (matcher.indexIn(itemText) != -1);
             }
         } else {
-            match = matchesAncestorsOrText(candidate, matcher, ignoreTopLevel, matchCache);
+            match = matchesAncestorsOrText(candidate, itemText, matcher, ignoreTopLevel, matchCache);
         }
 
         if (!match) {

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -299,37 +299,41 @@ QList<AppMenuSearch::SearchResult> AppMenuSearch::matchSearchCandidates(const QS
         if (ignoreSubMenus) {
             match = (matcher.indexIn(itemText) != -1);
         } else {
-            if (matcher.indexIn(itemText) != -1) {
-                match = true;
-            } else {
-                bool isTopLevel = true;
-                for (QAction *ancestor : candidate.ancestors) {
-                    if (!ancestor) {
-                        continue;
-                    }
-                    QString ancestorText = getActionText(ancestor);
-                    if (ancestorText.isEmpty()) {
-                        continue;
-                    }
-                    if (ignoreTopLevel && isTopLevel) {
-                        isTopLevel = false;
-                        continue;
-                    }
+            bool isTopLevel = true;
+            bool hasNamedAncestors = false;
+            for (QAction *ancestor : candidate.ancestors) {
+                if (!ancestor) {
+                    continue;
+                }
+                QString ancestorText = getActionText(ancestor);
+                if (ancestorText.isEmpty()) {
+                    continue;
+                }
+                hasNamedAncestors = true;
+                if (ignoreTopLevel && isTopLevel) {
                     isTopLevel = false;
+                    continue;
+                }
+                isTopLevel = false;
 
-                    auto it = matchCache.find(ancestor);
-                    bool matched = false;
-                    if (it != matchCache.end()) {
-                        matched = it.value();
-                    } else {
-                        matched = (matcher.indexIn(ancestorText) != -1);
-                        matchCache.insert(ancestor, matched);
-                    }
+                auto it = matchCache.find(ancestor);
+                bool matched = false;
+                if (it != matchCache.end()) {
+                    matched = it.value();
+                } else {
+                    matched = (matcher.indexIn(ancestorText) != -1);
+                    matchCache.insert(ancestor, matched);
+                }
 
-                    if (matched) {
-                        match = true;
-                        break;
-                    }
+                if (matched) {
+                    match = true;
+                    break;
+                }
+            }
+
+            if (!match && (!ignoreTopLevel || hasNamedAncestors)) {
+                if (matcher.indexIn(itemText) != -1) {
+                    match = true;
                 }
             }
         }

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -362,7 +362,7 @@ QList<AppMenuSearch::SearchResult> AppMenuSearch::matchSearchCandidates(const QS
                     text = it.value().text;
                 } else {
                     text = getActionText(ancestor);
-                    matchCache.insert(ancestor, {text, false});
+                    matchCache.insert(ancestor, {text, matcher.indexIn(text) != -1});
                 }
                 if (!text.isEmpty()) {
                     currentPath.append(text);

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -262,7 +262,11 @@ void AppMenuSearch::collectSearchCandidates(QMenu *menu, QSet<QMenu *> &visited,
 QList<AppMenuSearch::SearchResult> AppMenuSearch::matchSearchCandidates(const QStringMatcher &matcher, bool ignoreTopLevel, bool ignoreSubMenus, bool showDisabledActions) const
 {
     QList<SearchResult> results;
-    QHash<QAction *, bool> matchCache;
+    struct MatchState {
+        QString text;
+        bool matched = false;
+    };
+    QHash<QAction *, MatchState> matchCache;
 
     for (const SearchCandidate &candidate : std::as_const(m_searchCandidates)) {
         if (results.size() >= MAX_SEARCH_RESULTS) {
@@ -305,7 +309,19 @@ QList<AppMenuSearch::SearchResult> AppMenuSearch::matchSearchCandidates(const QS
                 if (!ancestor) {
                     continue;
                 }
-                QString ancestorText = getActionText(ancestor);
+
+                auto it = matchCache.find(ancestor);
+                QString ancestorText;
+                bool matched = false;
+                if (it != matchCache.end()) {
+                    ancestorText = it.value().text;
+                    matched = it.value().matched;
+                } else {
+                    ancestorText = getActionText(ancestor);
+                    matched = (matcher.indexIn(ancestorText) != -1);
+                    matchCache.insert(ancestor, {ancestorText, matched});
+                }
+
                 if (ancestorText.isEmpty()) {
                     continue;
                 }
@@ -315,15 +331,6 @@ QList<AppMenuSearch::SearchResult> AppMenuSearch::matchSearchCandidates(const QS
                     continue;
                 }
                 isTopLevel = false;
-
-                auto it = matchCache.find(ancestor);
-                bool matched = false;
-                if (it != matchCache.end()) {
-                    matched = it.value();
-                } else {
-                    matched = (matcher.indexIn(ancestorText) != -1);
-                    matchCache.insert(ancestor, matched);
-                }
 
                 if (matched) {
                     match = true;
@@ -346,7 +353,13 @@ QList<AppMenuSearch::SearchResult> AppMenuSearch::matchSearchCandidates(const QS
         currentPath.reserve(candidate.ancestors.size() + 1);
         for (QAction *ancestor : candidate.ancestors) {
             if (ancestor) {
-                QString text = getActionText(ancestor);
+                QString text;
+                auto it = matchCache.find(ancestor);
+                if (it != matchCache.end()) {
+                    text = it.value().text;
+                } else {
+                    text = getActionText(ancestor);
+                }
                 if (!text.isEmpty()) {
                     currentPath.append(text);
                 }

--- a/src/AppMenuSearch.h
+++ b/src/AppMenuSearch.h
@@ -101,6 +101,13 @@ signals:
 private:
     void rebuildSearchCandidatesIfNeeded();
     void collectSearchCandidates(QMenu *menu, QSet<QMenu *> &visited, QList<QPointer<QAction>> &ancestors);
+    
+    struct MatchState {
+        QString text;
+        bool matched = false;
+    };
+    bool matchesAncestorsOrText(const SearchCandidate &candidate, const QStringMatcher &matcher, bool ignoreTopLevel, QHash<QAction *, MatchState> &matchCache) const;
+    
     QList<SearchResult> matchSearchCandidates(const QStringMatcher &matcher, bool ignoreTopLevel, bool ignoreSubMenus, bool showDisabledActions) const;
     QString getActionText(QAction *action) const;
     void resetSearchState();

--- a/src/AppMenuSearch.h
+++ b/src/AppMenuSearch.h
@@ -55,6 +55,9 @@ public:
 
     struct SearchCandidate {
         QPointer<QAction> action;
+        // Contains all parent menu actions, including those without a title/label.
+        // This is a strict invariant: even an untitled submenu gates whether its children
+        // are reachable, so its enabled state must propagate down to all descendants.
         QList<QPointer<QAction>> ancestors;
     };
 

--- a/src/AppMenuSearch.h
+++ b/src/AppMenuSearch.h
@@ -59,7 +59,7 @@ public:
         // This is a strict invariant: even an untitled submenu gates whether its children
         // are reachable, so its enabled state must propagate down to all descendants.
         QList<QPointer<QAction>> ancestors;
-        bool isTopLevel = false;
+        bool hasNoNamedAncestor = false;
     };
 
     struct SearchResult {
@@ -101,7 +101,7 @@ signals:
 
 private:
     void rebuildSearchCandidatesIfNeeded();
-    void collectSearchCandidates(QMenu *menu, QSet<QMenu *> &visited, QList<QPointer<QAction>> &ancestors);
+    void collectSearchCandidates(QMenu *menu, QSet<QMenu *> &visited, QList<QPointer<QAction>> &ancestors, bool hasNamedAncestor = false);
     
     struct MatchState {
         QString text;

--- a/src/AppMenuSearch.h
+++ b/src/AppMenuSearch.h
@@ -59,6 +59,7 @@ public:
         // This is a strict invariant: even an untitled submenu gates whether its children
         // are reachable, so its enabled state must propagate down to all descendants.
         QList<QPointer<QAction>> ancestors;
+        bool isTopLevel = false;
     };
 
     struct SearchResult {
@@ -106,7 +107,7 @@ private:
         QString text;
         bool matched = false;
     };
-    bool matchesAncestorsOrText(const SearchCandidate &candidate, const QStringMatcher &matcher, bool ignoreTopLevel, QHash<QAction *, MatchState> &matchCache) const;
+    bool matchesAncestorsOrText(const SearchCandidate &candidate, const QString &itemText, const QStringMatcher &matcher, bool ignoreTopLevel, QHash<QAction *, MatchState> &matchCache) const;
     
     QList<SearchResult> matchSearchCandidates(const QStringMatcher &matcher, bool ignoreTopLevel, bool ignoreSubMenus, bool showDisabledActions) const;
     QString getActionText(QAction *action) const;

--- a/src/AppMenuSearch.h
+++ b/src/AppMenuSearch.h
@@ -55,8 +55,7 @@ public:
 
     struct SearchCandidate {
         QPointer<QAction> action;
-        QList<QPointer<QAction>> namedAncestors;
-        QList<QPointer<QAction>> enablementAncestors;
+        QList<QPointer<QAction>> ancestors;
     };
 
     struct SearchResult {
@@ -98,7 +97,7 @@ signals:
 
 private:
     void rebuildSearchCandidatesIfNeeded();
-    void collectSearchCandidates(QMenu *menu, QSet<QMenu *> &visited, QList<QPointer<QAction>> &namedAncestors, QList<QPointer<QAction>> &enablementAncestors);
+    void collectSearchCandidates(QMenu *menu, QSet<QMenu *> &visited, QList<QPointer<QAction>> &ancestors);
     QList<SearchResult> matchSearchCandidates(const QStringMatcher &matcher, bool ignoreTopLevel, bool ignoreSubMenus, bool showDisabledActions) const;
     QString getActionText(QAction *action) const;
     void resetSearchState();

--- a/src/AppMenuSearch.h
+++ b/src/AppMenuSearch.h
@@ -59,7 +59,9 @@ public:
         // This is a strict invariant: even an untitled submenu gates whether its children
         // are reachable, so its enabled state must propagate down to all descendants.
         QList<QPointer<QAction>> ancestors;
-        bool hasNoNamedAncestor = false;
+        // True if at least one ancestor in the whole parent chain (not just the immediate parent)
+        // has a non-empty title/label. Used to correctly identify top-level leaf actions.
+        bool hasNamedAncestor = false;
     };
 
     struct SearchResult {


### PR DESCRIPTION
## Summary by Sourcery

Unificare il tracciamento degli antenati per la ricerca nel menu dell’app e semplificare la logica di corrispondenza.

Miglioramenti:
- Sostituire le catene di antenati separate per nome e abilitazione con un’unica lista `ancestors` e un flag `hasNamedAncestor` nei candidati di ricerca.
- Rifattorizzare la corrispondenza dei candidati di ricerca per calcolare direttamente lo stato effettivo di abilitazione e la corrispondenza del testo a partire dall’elenco unificato degli antenati, senza cache separate.
- Semplificare la costruzione del percorso riutilizzando i testi degli antenati memorizzati in cache, ignorando i titoli vuoti e usando sempre la chiave di cache dell’icona dell’azione nei risultati di ricerca.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify ancestor tracking for app menu search and simplify matching logic.

Enhancements:
- Replace separate named and enablement ancestor chains with a single ancestors list and a hasNamedAncestor flag in search candidates.
- Refactor search candidate matching to compute effective enabled state and text matching directly from the unified ancestor list without separate caches.
- Simplify path construction by reusing cached ancestor texts, skipping empty titles, and always using the action icon cache key in search results.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unificare il tracciamento degli antenati per la ricerca nel menu dell’app e semplificare la logica di corrispondenza.

Miglioramenti:
- Sostituire le catene di antenati separate per nome e abilitazione con un’unica lista `ancestors` e un flag `hasNamedAncestor` nei candidati di ricerca.
- Rifattorizzare la corrispondenza dei candidati di ricerca per calcolare direttamente lo stato effettivo di abilitazione e la corrispondenza del testo a partire dall’elenco unificato degli antenati, senza cache separate.
- Semplificare la costruzione del percorso riutilizzando i testi degli antenati memorizzati in cache, ignorando i titoli vuoti e usando sempre la chiave di cache dell’icona dell’azione nei risultati di ricerca.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify ancestor tracking for app menu search and simplify matching logic.

Enhancements:
- Replace separate named and enablement ancestor chains with a single ancestors list and a hasNamedAncestor flag in search candidates.
- Refactor search candidate matching to compute effective enabled state and text matching directly from the unified ancestor list without separate caches.
- Simplify path construction by reusing cached ancestor texts, skipping empty titles, and always using the action icon cache key in search results.

</details>

</details>

Miglioramenti:
- Comprimi le separate catene di antenati nominati e di abilitazione in un unico elenco di antenati per i candidati di ricerca.
- Rifattorizza `matchSearchCandidates` per calcolare direttamente lo stato effettivo di abilitazione e la corrispondenza del testo a partire dall’elenco di antenati, senza cache memorizzate.
- Semplifica la costruzione del percorso utilizzando i titoli non vuoti degli antenati dalla catena unificata e usando sempre la chiave di cache dell’icona dell’azione.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unificare il tracciamento degli antenati per la ricerca nel menu dell’app e semplificare la logica di corrispondenza.

Miglioramenti:
- Sostituire le catene di antenati separate per nome e abilitazione con un’unica lista `ancestors` e un flag `hasNamedAncestor` nei candidati di ricerca.
- Rifattorizzare la corrispondenza dei candidati di ricerca per calcolare direttamente lo stato effettivo di abilitazione e la corrispondenza del testo a partire dall’elenco unificato degli antenati, senza cache separate.
- Semplificare la costruzione del percorso riutilizzando i testi degli antenati memorizzati in cache, ignorando i titoli vuoti e usando sempre la chiave di cache dell’icona dell’azione nei risultati di ricerca.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify ancestor tracking for app menu search and simplify matching logic.

Enhancements:
- Replace separate named and enablement ancestor chains with a single ancestors list and a hasNamedAncestor flag in search candidates.
- Refactor search candidate matching to compute effective enabled state and text matching directly from the unified ancestor list without separate caches.
- Simplify path construction by reusing cached ancestor texts, skipping empty titles, and always using the action icon cache key in search results.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unificare il tracciamento degli antenati per la ricerca nel menu dell’app e semplificare la logica di corrispondenza.

Miglioramenti:
- Sostituire le catene di antenati separate per nome e abilitazione con un’unica lista `ancestors` e un flag `hasNamedAncestor` nei candidati di ricerca.
- Rifattorizzare la corrispondenza dei candidati di ricerca per calcolare direttamente lo stato effettivo di abilitazione e la corrispondenza del testo a partire dall’elenco unificato degli antenati, senza cache separate.
- Semplificare la costruzione del percorso riutilizzando i testi degli antenati memorizzati in cache, ignorando i titoli vuoti e usando sempre la chiave di cache dell’icona dell’azione nei risultati di ricerca.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify ancestor tracking for app menu search and simplify matching logic.

Enhancements:
- Replace separate named and enablement ancestor chains with a single ancestors list and a hasNamedAncestor flag in search candidates.
- Refactor search candidate matching to compute effective enabled state and text matching directly from the unified ancestor list without separate caches.
- Simplify path construction by reusing cached ancestor texts, skipping empty titles, and always using the action icon cache key in search results.

</details>

</details>

</details>