### PR TITLE
optimize shortcut string append

### DIFF
--- a/src/libdbusmenuqt/dbusmenushortcut_p.cpp
+++ b/src/libdbusmenuqt/dbusmenushortcut_p.cpp
@@ -8,6 +8,7 @@
 
 // Qt
 #include <QKeySequence>
+#include <QStringBuilder>
 #include <QStringTokenizer>
 
 // STL
@@ -82,7 +83,7 @@ QKeySequence DBusMenuShortcut::toKeySequence() const
     QString res;
     // Heuristic: estimate size to minimize reallocations.
     // Each shortcut part is at least a few chars, plus separators.
-    res.reserve(size() * 16);
+    res.reserve(size() * 24);
 
     for (const QStringList &keyTokens : std::as_const(*this)) {
         if (keyTokens.isEmpty()) {
@@ -93,14 +94,23 @@ QKeySequence DBusMenuShortcut::toKeySequence() const
         }
         bool first = true;
         for (const QString &token : keyTokens) {
+            auto withToken = [&](auto &&callback) {
+                if (const auto t = translate(token, DM_COLUMN, QT_COLUMN); !t.isEmpty()) {
+                    callback(t);
+                } else {
+                    callback(token);
+                }
+            };
+
             if (!first) {
-                res += QLatin1Char('+');
-            }
-            first = false;
-            if (const auto t = translate(token, DM_COLUMN, QT_COLUMN); !t.isEmpty()) {
-                res += t;
+                withToken([&](const auto &str) {
+                    res += QLatin1Char('+') % str;
+                });
             } else {
-                res += token;
+                first = false;
+                withToken([&](const auto &str) {
+                    res += str;
+                });
             }
         }
     }


### PR DESCRIPTION
## Summary by Sourcery

Ottimizza la costruzione delle stringhe di sequenze di scorciatoie da tastiera per ridurre le allocazioni e migliorare le prestazioni di concatenazione.

Miglioramenti:
- Aumentare la capacità riservata per i buffer di stringhe delle scorciatoie per allinearla meglio alle lunghezze tipiche delle scorciatoie.
- Utilizzare la concatenazione basata su QStringBuilder e un helper di callback per evitare traduzioni ripetute e temporanei intermedi durante l’aggiunta dei token delle scorciatoie.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize construction of key sequence shortcut strings to reduce allocations and improve concatenation performance.

Enhancements:
- Increase reserved capacity for shortcut string buffers to better match typical shortcut lengths.
- Use QStringBuilder-based concatenation and a callback helper to avoid repeated translations and intermediate temporaries when appending shortcut tokens.

</details>