### PR TITLE
Optimize appmenusearch

### DIFF
--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -266,8 +266,8 @@ void AppMenuSearch::collectSearchCandidates(QMenu *menu, QSet<QMenu *> &visited,
 bool AppMenuSearch::matchesAncestorsOrText(const SearchCandidate &candidate, const QString &itemText, const QStringMatcher &matcher, bool ignoreTopLevel, QHash<QAction *, MatchState> &matchCache, QHash<QAction *, bool> &pathMatchCache) const
 {
     // 1. O(1) Fast-Path: check if the direct parent menu's path evaluation is already cached.
-    // Safe because each submenu action occurs in one unique root-to-leaf path (since Qt's QObject/QMenu
-    // hierarchy forms a strict, tree-structured parent-child relationship with unique parentage).
+    // Safe within this search pass: collectSearchCandidates() visits every QMenu
+    // at most once, so each submenu action has a unique root-to-parent path.
     QAction *lastAncestor = candidate.ancestors.isEmpty() ? nullptr : candidate.ancestors.last();
     if (lastAncestor) {
         auto it = pathMatchCache.find(lastAncestor);
@@ -322,7 +322,7 @@ bool AppMenuSearch::matchesAncestorsOrText(const SearchCandidate &candidate, con
         }
     }
 
-    // Cache the cumulative root-to-leaf path match result for this parent
+    // Cache the cumulative root-to-parent match result for this submenu action.
     if (lastAncestor) {
         Q_ASSERT(!pathMatchCache.contains(lastAncestor));
         pathMatchCache.insert(lastAncestor, anyAncestorMatched);

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -263,30 +263,30 @@ void AppMenuSearch::collectSearchCandidates(QMenu *menu, QSet<QMenu *> &visited,
     }
 }
 
-bool AppMenuSearch::matchesAncestorsOrText(const SearchCandidate &candidate, const QString &itemText, const QStringMatcher &matcher, bool ignoreTopLevel, QHash<QAction *, MatchState> &matchCache) const
+bool AppMenuSearch::matchesAncestorsOrText(const SearchCandidate &candidate, const QString &itemText, const QStringMatcher &matcher, bool ignoreTopLevel, QHash<QAction *, MatchState> &matchCache, QHash<QAction *, bool> &pathMatchCache) const
 {
-    // 1. O(1) Fast-Path: check if the last ancestor is already cached and valid
-    if (!candidate.ancestors.isEmpty()) {
-        QAction *lastAncestor = candidate.ancestors.last();
-        if (lastAncestor) {
-            auto it = matchCache.find(lastAncestor);
-            if (it != matchCache.end() && it.value().pathMatchedValid) {
-                if (it.value().pathMatched) {
+    // 1. O(1) Fast-Path: check if the direct parent menu's path evaluation is already cached.
+    // Safe because each submenu action occurs in one unique root-to-leaf path (since Qt's QObject/QMenu
+    // hierarchy forms a strict, tree-structured parent-child relationship with unique parentage).
+    QAction *lastAncestor = candidate.ancestors.isEmpty() ? nullptr : candidate.ancestors.last();
+    if (lastAncestor) {
+        auto it = pathMatchCache.find(lastAncestor);
+        if (it != pathMatchCache.end()) {
+            if (it.value()) {
+                return true;
+            }
+            if (!ignoreTopLevel || candidate.hasNamedAncestor) {
+                if (matcher.indexIn(itemText) != -1) {
                     return true;
                 }
-                if (!ignoreTopLevel || candidate.hasNamedAncestor) {
-                    if (matcher.indexIn(itemText) != -1) {
-                        return true;
-                    }
-                }
-                return false;
             }
+            return false;
         }
     }
 
-    // 2. Slow path/Fallback path: Evaluate sequentially and cache
+    // 2. Fallback path: Evaluate sequentially and cache individual elements
     bool isTopLevelAncestor = true;
-    bool runningPathMatched = false;
+    bool anyAncestorMatched = false;
 
     for (QAction *ancestor : candidate.ancestors) {
         if (!ancestor) {
@@ -296,47 +296,40 @@ bool AppMenuSearch::matchesAncestorsOrText(const SearchCandidate &candidate, con
         auto it = matchCache.find(ancestor);
         QString ancestorText;
         bool matched = false;
-        bool pathMatched = false;
 
         if (it != matchCache.end()) {
             ancestorText = it.value().text;
             matched = it.value().matched;
-            if (it.value().pathMatchedValid) {
-                pathMatched = it.value().pathMatched;
-            } else {
-                if (ignoreTopLevel && isTopLevelAncestor) {
-                    pathMatched = false;
-                } else {
-                    pathMatched = runningPathMatched || matched;
-                }
-                matchCache.insert(ancestor, {ancestorText, matched, pathMatched, true});
-            }
         } else {
             ancestorText = getActionText(ancestor);
-            if (!ancestorText.isEmpty()) {
-                matched = (matcher.indexIn(ancestorText) != -1);
-                if (ignoreTopLevel && isTopLevelAncestor) {
-                    pathMatched = false;
-                } else {
-                    pathMatched = runningPathMatched || matched;
-                }
-                matchCache.insert(ancestor, {ancestorText, matched, pathMatched, true});
-            } else {
-                pathMatched = runningPathMatched;
-                matchCache.insert(ancestor, {ancestorText, false, pathMatched, true});
-            }
+            matched = (matcher.indexIn(ancestorText) != -1);
+            matchCache.insert(ancestor, {ancestorText, matched});
         }
 
         if (ancestorText.isEmpty()) {
             continue;
         }
 
-        isTopLevelAncestor = false;
-        runningPathMatched = pathMatched;
-
-        if (runningPathMatched) {
-            return true;
+        if (ignoreTopLevel && isTopLevelAncestor) {
+            isTopLevelAncestor = false;
+            continue;
         }
+        isTopLevelAncestor = false;
+
+        if (matched) {
+            anyAncestorMatched = true;
+            break; // Stop evaluating further ancestors since we found a match
+        }
+    }
+
+    // Cache the cumulative root-to-leaf path match result for this parent
+    if (lastAncestor) {
+        Q_ASSERT(!pathMatchCache.contains(lastAncestor));
+        pathMatchCache.insert(lastAncestor, anyAncestorMatched);
+    }
+
+    if (anyAncestorMatched) {
+        return true;
     }
 
     if (!ignoreTopLevel || candidate.hasNamedAncestor) {
@@ -352,6 +345,7 @@ QList<AppMenuSearch::SearchResult> AppMenuSearch::matchSearchCandidates(const QS
 {
     QList<SearchResult> results;
     QHash<QAction *, MatchState> matchCache;
+    QHash<QAction *, bool> pathMatchCache;
 
     for (const SearchCandidate &candidate : std::as_const(m_searchCandidates)) {
         if (results.size() >= MAX_SEARCH_RESULTS) {
@@ -392,7 +386,7 @@ QList<AppMenuSearch::SearchResult> AppMenuSearch::matchSearchCandidates(const QS
                 match = (matcher.indexIn(itemText) != -1);
             }
         } else {
-            match = matchesAncestorsOrText(candidate, itemText, matcher, ignoreTopLevel, matchCache);
+            match = matchesAncestorsOrText(candidate, itemText, matcher, ignoreTopLevel, matchCache, pathMatchCache);
         }
 
         if (!match) {
@@ -409,7 +403,7 @@ QList<AppMenuSearch::SearchResult> AppMenuSearch::matchSearchCandidates(const QS
                     text = it.value().text;
                 } else {
                     text = getActionText(ancestor);
-                    matchCache.insert(ancestor, {text, matcher.indexIn(text) != -1, false, false});
+                    matchCache.insert(ancestor, {text, matcher.indexIn(text) != -1});
                 }
                 if (!text.isEmpty()) {
                     currentPath.append(text);

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -263,15 +263,15 @@ void AppMenuSearch::collectSearchCandidates(QMenu *menu, QSet<QMenu *> &visited,
     }
 }
 
-bool AppMenuSearch::matchesAncestorsOrText(const SearchCandidate &candidate, const QString &itemText, const QStringMatcher &matcher, bool ignoreTopLevel, QHash<QAction *, MatchState> &matchCache, QHash<QAction *, bool> &pathMatchCache) const
+bool AppMenuSearch::matchesAncestorsOrText(const SearchCandidate &candidate, const QString &itemText, const QStringMatcher &matcher, bool ignoreTopLevel, MatchContext &context) const
 {
     // 1. O(1) Fast-Path: check if the direct parent menu's path evaluation is already cached.
     // Safe within this search pass: collectSearchCandidates() visits every QMenu
     // at most once, so each submenu action has a unique root-to-parent path.
     QAction *lastAncestor = candidate.ancestors.isEmpty() ? nullptr : candidate.ancestors.last();
     if (lastAncestor) {
-        auto it = pathMatchCache.find(lastAncestor);
-        if (it != pathMatchCache.end()) {
+        auto it = context.pathMatchCache.find(lastAncestor);
+        if (it != context.pathMatchCache.end()) {
             if (it.value()) {
                 return true;
             }
@@ -293,23 +293,26 @@ bool AppMenuSearch::matchesAncestorsOrText(const SearchCandidate &candidate, con
             continue;
         }
 
-        auto it = matchCache.find(ancestor);
+        auto it = context.matchCache.find(ancestor);
         QString ancestorText;
         bool matched = false;
 
-        if (it != matchCache.end()) {
+        if (it != context.matchCache.end()) {
             ancestorText = it.value().text;
             matched = it.value().matched;
         } else {
             ancestorText = getActionText(ancestor);
             matched = (matcher.indexIn(ancestorText) != -1);
-            matchCache.insert(ancestor, {ancestorText, matched});
+            context.matchCache.insert(ancestor, {ancestorText, matched});
         }
 
         if (ancestorText.isEmpty()) {
             continue;
         }
 
+        // If ignoreTopLevel is true, the first non-empty ancestor is skipped from evaluation.
+        // This ensures anyAncestorMatched remains false for the top-level menu match,
+        // correctly preventing children of the top-level menu from matching solely due to their parent.
         if (ignoreTopLevel && isTopLevelAncestor) {
             isTopLevelAncestor = false;
             continue;
@@ -324,8 +327,8 @@ bool AppMenuSearch::matchesAncestorsOrText(const SearchCandidate &candidate, con
 
     // Cache the cumulative root-to-parent match result for this submenu action.
     if (lastAncestor) {
-        Q_ASSERT(!pathMatchCache.contains(lastAncestor));
-        pathMatchCache.insert(lastAncestor, anyAncestorMatched);
+        Q_ASSERT(!context.pathMatchCache.contains(lastAncestor));
+        context.pathMatchCache.insert(lastAncestor, anyAncestorMatched);
     }
 
     if (anyAncestorMatched) {
@@ -346,6 +349,7 @@ QList<AppMenuSearch::SearchResult> AppMenuSearch::matchSearchCandidates(const QS
     QList<SearchResult> results;
     QHash<QAction *, MatchState> matchCache;
     QHash<QAction *, bool> pathMatchCache;
+    MatchContext context{matchCache, pathMatchCache};
 
     for (const SearchCandidate &candidate : std::as_const(m_searchCandidates)) {
         if (results.size() >= MAX_SEARCH_RESULTS) {
@@ -386,7 +390,7 @@ QList<AppMenuSearch::SearchResult> AppMenuSearch::matchSearchCandidates(const QS
                 match = (matcher.indexIn(itemText) != -1);
             }
         } else {
-            match = matchesAncestorsOrText(candidate, itemText, matcher, ignoreTopLevel, matchCache, pathMatchCache);
+            match = matchesAncestorsOrText(candidate, itemText, matcher, ignoreTopLevel, context);
         }
 
         if (!match) {

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -265,7 +265,29 @@ void AppMenuSearch::collectSearchCandidates(QMenu *menu, QSet<QMenu *> &visited,
 
 bool AppMenuSearch::matchesAncestorsOrText(const SearchCandidate &candidate, const QString &itemText, const QStringMatcher &matcher, bool ignoreTopLevel, QHash<QAction *, MatchState> &matchCache) const
 {
+    // 1. O(1) Fast-Path: check if the last ancestor is already cached and valid
+    if (!candidate.ancestors.isEmpty()) {
+        QAction *lastAncestor = candidate.ancestors.last();
+        if (lastAncestor) {
+            auto it = matchCache.find(lastAncestor);
+            if (it != matchCache.end() && it.value().pathMatchedValid) {
+                if (it.value().pathMatched) {
+                    return true;
+                }
+                if (!ignoreTopLevel || candidate.hasNamedAncestor) {
+                    if (matcher.indexIn(itemText) != -1) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+        }
+    }
+
+    // 2. Slow path/Fallback path: Evaluate sequentially and cache
     bool isTopLevelAncestor = true;
+    bool runningPathMatched = false;
+
     for (QAction *ancestor : candidate.ancestors) {
         if (!ancestor) {
             continue;
@@ -274,25 +296,45 @@ bool AppMenuSearch::matchesAncestorsOrText(const SearchCandidate &candidate, con
         auto it = matchCache.find(ancestor);
         QString ancestorText;
         bool matched = false;
+        bool pathMatched = false;
+
         if (it != matchCache.end()) {
             ancestorText = it.value().text;
             matched = it.value().matched;
+            if (it.value().pathMatchedValid) {
+                pathMatched = it.value().pathMatched;
+            } else {
+                if (ignoreTopLevel && isTopLevelAncestor) {
+                    pathMatched = false;
+                } else {
+                    pathMatched = runningPathMatched || matched;
+                }
+                matchCache.insert(ancestor, {ancestorText, matched, pathMatched, true});
+            }
         } else {
             ancestorText = getActionText(ancestor);
-            matched = (matcher.indexIn(ancestorText) != -1);
-            matchCache.insert(ancestor, {ancestorText, matched});
+            if (!ancestorText.isEmpty()) {
+                matched = (matcher.indexIn(ancestorText) != -1);
+                if (ignoreTopLevel && isTopLevelAncestor) {
+                    pathMatched = false;
+                } else {
+                    pathMatched = runningPathMatched || matched;
+                }
+                matchCache.insert(ancestor, {ancestorText, matched, pathMatched, true});
+            } else {
+                pathMatched = runningPathMatched;
+                matchCache.insert(ancestor, {ancestorText, false, pathMatched, true});
+            }
         }
 
         if (ancestorText.isEmpty()) {
             continue;
         }
-        if (ignoreTopLevel && isTopLevelAncestor) {
-            isTopLevelAncestor = false;
-            continue;
-        }
-        isTopLevelAncestor = false;
 
-        if (matched) {
+        isTopLevelAncestor = false;
+        runningPathMatched = pathMatched;
+
+        if (runningPathMatched) {
             return true;
         }
     }
@@ -367,7 +409,7 @@ QList<AppMenuSearch::SearchResult> AppMenuSearch::matchSearchCandidates(const QS
                     text = it.value().text;
                 } else {
                     text = getActionText(ancestor);
-                    matchCache.insert(ancestor, {text, matcher.indexIn(text) != -1});
+                    matchCache.insert(ancestor, {text, matcher.indexIn(text) != -1, false, false});
                 }
                 if (!text.isEmpty()) {
                     currentPath.append(text);

--- a/src/AppMenuSearch.h
+++ b/src/AppMenuSearch.h
@@ -108,10 +108,8 @@ private:
     struct MatchState {
         QString text;
         bool matched = false;
-        bool pathMatched = false;
-        bool pathMatchedValid = false;
     };
-    bool matchesAncestorsOrText(const SearchCandidate &candidate, const QString &itemText, const QStringMatcher &matcher, bool ignoreTopLevel, QHash<QAction *, MatchState> &matchCache) const;
+    bool matchesAncestorsOrText(const SearchCandidate &candidate, const QString &itemText, const QStringMatcher &matcher, bool ignoreTopLevel, QHash<QAction *, MatchState> &matchCache, QHash<QAction *, bool> &pathMatchCache) const;
     
     QList<SearchResult> matchSearchCandidates(const QStringMatcher &matcher, bool ignoreTopLevel, bool ignoreSubMenus, bool showDisabledActions) const;
     QString getActionText(QAction *action) const;

--- a/src/AppMenuSearch.h
+++ b/src/AppMenuSearch.h
@@ -108,6 +108,8 @@ private:
     struct MatchState {
         QString text;
         bool matched = false;
+        bool pathMatched = false;
+        bool pathMatchedValid = false;
     };
     bool matchesAncestorsOrText(const SearchCandidate &candidate, const QString &itemText, const QStringMatcher &matcher, bool ignoreTopLevel, QHash<QAction *, MatchState> &matchCache) const;
     

--- a/src/AppMenuSearch.h
+++ b/src/AppMenuSearch.h
@@ -109,7 +109,13 @@ private:
         QString text;
         bool matched = false;
     };
-    bool matchesAncestorsOrText(const SearchCandidate &candidate, const QString &itemText, const QStringMatcher &matcher, bool ignoreTopLevel, QHash<QAction *, MatchState> &matchCache, QHash<QAction *, bool> &pathMatchCache) const;
+
+    struct MatchContext {
+        QHash<QAction *, MatchState> &matchCache;
+        QHash<QAction *, bool> &pathMatchCache;
+    };
+
+    bool matchesAncestorsOrText(const SearchCandidate &candidate, const QString &itemText, const QStringMatcher &matcher, bool ignoreTopLevel, MatchContext &context) const;
     
     QList<SearchResult> matchSearchCandidates(const QStringMatcher &matcher, bool ignoreTopLevel, bool ignoreSubMenus, bool showDisabledActions) const;
     QString getActionText(QAction *action) const;


### PR DESCRIPTION
Menu structures are trees, ergo each menu node has a unique sequence of ancestors. In the original implementation, the code performed redundant linear scans of identical ancestors for every single candidate. By caching the cumulative match status on each ancestor node, we completely eliminate redundant linear scans and reduce the matching logic of shared paths to O(1) complexity.

Enhancements:
- Add fast-path ancestor cache check in AppMenuSearch::matchesAncestorsOrText to avoid recomputing path matches.
- Extend MatchState with path-level matching flags and propagate incremental pathMatched state during ancestor traversal.
- Ensure newly cached ancestors in matchSearchCandidates include initialized path matching fields for later reuse.