### PR TITLE
Button icons: perfect pixel snapping using devicePixelRatioF()

### DIFF
--- a/src/AppIconButton.h
+++ b/src/AppIconButton.h
@@ -47,8 +47,8 @@ public:
         );
     }
     
-    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal dpr) {
-        Q_UNUSED(dpr)
+    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const PixelSnapper &snapper) {
+        Q_UNUSED(snapper)
         //const QRectF contentRect = button->contentArea();
         const QSizeF appIconSize(
             iconRect.width() * 0.7,

--- a/src/AppIconButton.h
+++ b/src/AppIconButton.h
@@ -47,7 +47,8 @@ public:
         );
     }
     
-    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal) {
+    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal dpr) {
+        Q_UNUSED(dpr)
         //const QRectF contentRect = button->contentArea();
         const QSizeF appIconSize(
             iconRect.width() * 0.7,

--- a/src/ApplicationMenuButton.h
+++ b/src/ApplicationMenuButton.h
@@ -41,19 +41,11 @@ public:
         Q_UNUSED(iconRect)
         button->setPenWidth(painter, 1.5);
 
-        const qreal scaleX = qAbs(painter->transform().m11());
-        const qreal localToPhysical = scaleX * dpr;
-
         const qreal spacing = 4.0;
         for (int i = -1; i <= 1; ++i) {
-            qreal y = i * spacing;
-            qreal xLeft = -5.5;
-            qreal xRight = 5.5;
-            if (localToPhysical > 0.0) {
-                y = qRound(y * localToPhysical) / localToPhysical;
-                xLeft = qRound(xLeft * localToPhysical) / localToPhysical;
-                xRight = qRound(xRight * localToPhysical) / localToPhysical;
-            }
+            const qreal y = button->snapValue(painter, i * spacing, dpr);
+            const qreal xLeft = button->snapValue(painter, -5.5, dpr);
+            const qreal xRight = button->snapValue(painter, 5.5, dpr);
             const QPointF left { xLeft, y };
             const QPointF right { xRight, y };
 

--- a/src/ApplicationMenuButton.h
+++ b/src/ApplicationMenuButton.h
@@ -41,11 +41,12 @@ public:
         Q_UNUSED(iconRect)
         button->setPenWidth(painter, 1.5);
         
+        PixelSnapper snapper(painter, dpr);
         const qreal spacing = painter->pen().widthF() * 2.5;
         for (int i = -1; i <= 1; ++i) {
             const qreal y = i * spacing;
-            const QPointF left = button->snapPoint(painter, QPointF { -5.5, y }, dpr);
-            const QPointF right = button->snapPoint(painter, QPointF { 5.5, y }, dpr);
+            const QPointF left = snapper.snap(QPointF { -5.5, y });
+            const QPointF right = snapper.snap(QPointF { 5.5, y });
 
             painter->drawLine(left, right);
         }

--- a/src/ApplicationMenuButton.h
+++ b/src/ApplicationMenuButton.h
@@ -40,14 +40,12 @@ public:
     static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal dpr) {
         Q_UNUSED(iconRect)
         button->setPenWidth(painter, 1.5);
-
-        const qreal spacing = 4.0;
+        
+        const qreal spacing = painter->pen().widthF() * 2.5;
         for (int i = -1; i <= 1; ++i) {
-            const qreal y = button->snapValue(painter, i * spacing, dpr);
-            const qreal xLeft = button->snapValue(painter, -5.5, dpr);
-            const qreal xRight = button->snapValue(painter, 5.5, dpr);
-            const QPointF left { xLeft, y };
-            const QPointF right { xRight, y };
+            const qreal y = i * spacing;
+            const QPointF left = button->snapPoint(painter, QPointF { -5.5, y }, dpr);
+            const QPointF right = button->snapPoint(painter, QPointF { 5.5, y }, dpr);
 
             painter->drawLine(left, right);
         }

--- a/src/ApplicationMenuButton.h
+++ b/src/ApplicationMenuButton.h
@@ -37,11 +37,10 @@ public:
     static void init(Button *button, KDecoration3::DecoratedWindow *decoratedClient) {
         button->setVisible(decoratedClient->hasApplicationMenu());
     }
-    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal) {
+    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal dpr) {
         Q_UNUSED(iconRect)
         button->setPenWidth(painter, 1.5);
 
-        const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : 1.0;
         const qreal scaleX = qAbs(painter->transform().m11());
         const qreal localToPhysical = scaleX * dpr;
 

--- a/src/ApplicationMenuButton.h
+++ b/src/ApplicationMenuButton.h
@@ -37,11 +37,10 @@ public:
     static void init(Button *button, KDecoration3::DecoratedWindow *decoratedClient) {
         button->setVisible(decoratedClient->hasApplicationMenu());
     }
-    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal dpr) {
+    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const PixelSnapper &snapper) {
         Q_UNUSED(iconRect)
         button->setPenWidth(painter, 1.5);
         
-        PixelSnapper snapper(painter, dpr);
         const qreal spacing = painter->pen().widthF() * 2.5;
         for (int i = -1; i <= 1; ++i) {
             const qreal y = i * spacing;

--- a/src/ApplicationMenuButton.h
+++ b/src/ApplicationMenuButton.h
@@ -41,11 +41,22 @@ public:
         Q_UNUSED(iconRect)
         button->setPenWidth(painter, 1.5);
 
+        const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : 1.0;
+        const qreal scaleX = qAbs(painter->transform().m11());
+        const qreal localToPhysical = scaleX * dpr;
+
         const qreal spacing = 4.0;
         for (int i = -1; i <= 1; ++i) {
-            const qreal y = i * spacing;
-            const QPointF left { -5.5, y };
-            const QPointF right { 5.5, y };
+            qreal y = i * spacing;
+            qreal xLeft = -5.5;
+            qreal xRight = 5.5;
+            if (localToPhysical > 0.0) {
+                y = qRound(y * localToPhysical) / localToPhysical;
+                xLeft = qRound(xLeft * localToPhysical) / localToPhysical;
+                xRight = qRound(xRight * localToPhysical) / localToPhysical;
+            }
+            const QPointF left { xLeft, y };
+            const QPointF right { xRight, y };
 
             painter->drawLine(left, right);
         }

--- a/src/Button.cc
+++ b/src/Button.cc
@@ -353,14 +353,14 @@ void Button::paint(QPainter *painter, const QRectF &repaintRegion)
         }
 
         // For a sharper image, we use physical-pixel-aligned positioning and scaling
-        const QTransform transform = painter->transform();
-        const qreal localToPhysicalScale = std::hypot(transform.m11(), transform.m12()) * dpr;
+        PixelSnapper snapper(painter, dpr);
+        const qreal localToPhysicalScale = snapper.localToPhysicalScale();
         const qreal physicalIconSize = (localToPhysicalScale > 0.0) ? qRound(size * localToPhysicalScale) : qRound(size * dpr);
         const qreal iconLogicalSize = (localToPhysicalScale > 0.0) ? (physicalIconSize / localToPhysicalScale) : (physicalIconSize / dpr);
 
         // Translate to a center aligned with physical pixel grid
         const QPointF center = contentRect.center();
-        const QPointF centerSnapped = snapPoint(painter, center, dpr);
+        const QPointF centerSnapped = snapper.snap(center);
         painter->translate(centerSnapped);
 
         // Scale by physical-aligned factor
@@ -451,8 +451,8 @@ void Button::setPenWidth(QPainter *painter, const qreal scale)
     pen.setJoinStyle(Qt::MiterJoin);
 
     const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : 1.0;
-    const QTransform transform = painter->transform();
-    const qreal localToPhysicalScale = std::hypot(transform.m11(), transform.m12()) * dpr;
+    PixelSnapper snapper(painter, dpr);
+    const qreal localToPhysicalScale = snapper.localToPhysicalScale();
 
     if (localToPhysicalScale > 0.0) {
         const qreal nominalPhysicalWidth = PenWidth::Symbol * scale * localToPhysicalScale;
@@ -504,6 +504,11 @@ qreal PixelSnapper::snapY(const qreal v) const
 qreal PixelSnapper::snap(const qreal v) const
 {
     return snapX(v);
+}
+
+qreal PixelSnapper::localToPhysicalScale() const
+{
+    return std::hypot(m_trans.m11(), m_trans.m12()) * m_dpr;
 }
 
 QPointF Button::snapPoint(QPainter *painter, const QPointF &p, const qreal dpr) const

--- a/src/Button.cc
+++ b/src/Button.cc
@@ -465,29 +465,44 @@ void Button::setPenWidth(QPainter *painter, const qreal scale)
     painter->setPen(pen);
 }
 
-QPointF Button::snapPoint(QPainter *painter, const QPointF &p, const qreal dpr) const
+PixelSnapper::PixelSnapper(QPainter *painter, const qreal dpr)
+    : m_trans(painter->transform())
+    , m_dpr(dpr)
+    , m_invertible(false)
 {
-    if (dpr > 0.0) {
-        const QTransform trans = painter->transform();
-        bool invertible = false;
-        const QTransform inv = trans.inverted(&invertible);
-        if (invertible) {
-            const QPointF devInd = trans.map(p);
-            const QPointF phys(devInd.x() * dpr, devInd.y() * dpr);
-            const QPointF physSnapped(qRound(phys.x()), qRound(phys.y()));
-            const QPointF devIndSnapped(physSnapped.x() / dpr, physSnapped.y() / dpr);
-            return inv.map(devIndSnapped);
-        }
+    m_inv = m_trans.inverted(&m_invertible);
+}
+
+QPointF PixelSnapper::snap(const QPointF &p) const
+{
+    if (m_dpr > 0.0 && m_invertible) {
+        const QPointF devInd = m_trans.map(p);
+        const QPointF phys(devInd.x() * m_dpr, devInd.y() * m_dpr);
+        const QPointF physSnapped(qRound(phys.x()), qRound(phys.y()));
+        const QPointF devIndSnapped(physSnapped.x() / m_dpr, physSnapped.y() / m_dpr);
+        return m_inv.map(devIndSnapped);
     }
     return p;
 }
 
-qreal Button::snapValue(QPainter *painter, const qreal v, const qreal dpr) const
+qreal PixelSnapper::snap(const qreal v) const
 {
-    const QPointF p0 = snapPoint(painter, QPointF(0.0, 0.0), dpr);
-    const QPointF pV = snapPoint(painter, QPointF(v, 0.0), dpr);
+    const QPointF p0 = snap(QPointF(0.0, 0.0));
+    const QPointF pV = snap(QPointF(v, 0.0));
     const qreal len = std::hypot(pV.x() - p0.x(), pV.y() - p0.y());
     return (v < 0.0) ? -len : len;
+}
+
+QPointF Button::snapPoint(QPainter *painter, const QPointF &p, const qreal dpr) const
+{
+    PixelSnapper snapper(painter, dpr);
+    return snapper.snap(p);
+}
+
+qreal Button::snapValue(QPainter *painter, const qreal v, const qreal dpr) const
+{
+    PixelSnapper snapper(painter, dpr);
+    return snapper.snap(v);
 }
 
 QColor Button::backgroundColor() const

--- a/src/Button.cc
+++ b/src/Button.cc
@@ -465,52 +465,6 @@ void Button::setPenWidth(QPainter *painter, const qreal scale)
     painter->setPen(pen);
 }
 
-PixelSnapper::PixelSnapper(QPainter *painter, const qreal dpr)
-    : m_trans(painter->transform())
-    , m_dpr(dpr)
-    , m_invertible(false)
-{
-    m_inv = m_trans.inverted(&m_invertible);
-}
-
-QPointF PixelSnapper::snap(const QPointF &p) const
-{
-    if (m_dpr > 0.0 && m_invertible) {
-        const QPointF devInd = m_trans.map(p);
-        const QPointF phys(devInd.x() * m_dpr, devInd.y() * m_dpr);
-        const QPointF physSnapped(qRound(phys.x()), qRound(phys.y()));
-        const QPointF devIndSnapped(physSnapped.x() / m_dpr, physSnapped.y() / m_dpr);
-        return m_inv.map(devIndSnapped);
-    }
-    return p;
-}
-
-qreal PixelSnapper::snapX(const qreal v) const
-{
-    const QPointF p0 = snap(QPointF(0.0, 0.0));
-    const QPointF pV = snap(QPointF(v, 0.0));
-    const qreal len = std::hypot(pV.x() - p0.x(), pV.y() - p0.y());
-    return (v < 0.0) ? -len : len;
-}
-
-qreal PixelSnapper::snapY(const qreal v) const
-{
-    const QPointF p0 = snap(QPointF(0.0, 0.0));
-    const QPointF pV = snap(QPointF(0.0, v));
-    const qreal len = std::hypot(pV.x() - p0.x(), pV.y() - p0.y());
-    return (v < 0.0) ? -len : len;
-}
-
-qreal PixelSnapper::snap(const qreal v) const
-{
-    return snapX(v);
-}
-
-qreal PixelSnapper::localToPhysicalScale() const
-{
-    return std::hypot(m_trans.m11(), m_trans.m12()) * m_dpr;
-}
-
 QPointF Button::snapPoint(QPainter *painter, const QPointF &p, const qreal dpr) const
 {
     PixelSnapper snapper(painter, dpr);

--- a/src/Button.cc
+++ b/src/Button.cc
@@ -320,13 +320,15 @@ void Button::paint(QPainter *painter, const QRectF &repaintRegion)
     painter->setRenderHint(QPainter::Antialiasing, true);
     painter->setBrush(Qt::NoBrush);
 
+    const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : 1.0;
+
     const QRectF contentRect = contentArea();
 
     // TextButton and AppIconButton are special, so we don't scale the painter
     if (auto textButton = qobject_cast<TextButton*>(this)) {
-        textButton->paintIcon(painter, contentRect, 0);
+        textButton->paintIcon(painter, contentRect, dpr);
     } else if (type() == KDecoration3::DecorationButtonType::Menu) {
-        AppIconButton::paintIcon(this, painter, contentRect, 0);
+        AppIconButton::paintIcon(this, painter, contentRect, dpr);
     } else {
         // All further rendering is performed inside a 18x18 square
         const qreal width = contentRect.width();
@@ -349,8 +351,6 @@ void Button::paint(QPainter *painter, const QRectF &repaintRegion)
             size = qMin(width, height) * 0.6; // 60% of the Kwin Deco
         }
 
-        const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : 1.0;
-
         // For a sharper image, we use physical-pixel-aligned positioning and scaling
         const qreal physicalIconSize = qRound(size * dpr);
         const qreal iconLogicalSize = physicalIconSize / dpr;
@@ -371,47 +371,47 @@ void Button::paint(QPainter *painter, const QRectF &repaintRegion)
         switch (type()) {
         // NOTE: Menu and ApplicationMenu are handled above
         case KDecoration3::DecorationButtonType::OnAllDesktops:
-            OnAllDesktopsButton::paintIcon(this, painter, iconRect, 0);
+            OnAllDesktopsButton::paintIcon(this, painter, iconRect, dpr);
             break;
 
         case KDecoration3::DecorationButtonType::ContextHelp:
-            ContextHelpButton::paintIcon(this, painter, iconRect, 0);
+            ContextHelpButton::paintIcon(this, painter, iconRect, dpr);
             break;
 
         case KDecoration3::DecorationButtonType::Shade:
-            ShadeButton::paintIcon(this, painter, iconRect, 0);
+            ShadeButton::paintIcon(this, painter, iconRect, dpr);
             break;
 
         case KDecoration3::DecorationButtonType::KeepAbove:
-            KeepAboveButton::paintIcon(this, painter, iconRect, 0);
+            KeepAboveButton::paintIcon(this, painter, iconRect, dpr);
             break;
 
         case KDecoration3::DecorationButtonType::KeepBelow:
-            KeepBelowButton::paintIcon(this, painter, iconRect, 0);
+            KeepBelowButton::paintIcon(this, painter, iconRect, dpr);
             break;
 
         case KDecoration3::DecorationButtonType::Close:
-            CloseButton::paintIcon(this, painter, iconRect, 0);
+            CloseButton::paintIcon(this, painter, iconRect, dpr);
             break;
 
         case KDecoration3::DecorationButtonType::Maximize:
-            MaximizeButton::paintIcon(this, painter, iconRect, 0);
+            MaximizeButton::paintIcon(this, painter, iconRect, dpr);
             break;
 
         case KDecoration3::DecorationButtonType::Minimize:
-            MinimizeButton::paintIcon(this, painter, iconRect, 0);
+            MinimizeButton::paintIcon(this, painter, iconRect, dpr);
             break;
         case KDecoration3::DecorationButtonType::Spacer:  
             break;            
 
 #if HAVE_EXCLUDE_FROM_CAPTURE
         case KDecoration3::DecorationButtonType::ExcludeFromCapture:
-            ExcludeFromCaptureButton::paintIcon(this, painter, iconRect, 0);
+            ExcludeFromCaptureButton::paintIcon(this, painter, iconRect, dpr);
             break;
 #endif
 
         default:
-            paintIcon(painter, iconRect, 0);
+            paintIcon(painter, iconRect, dpr);
             break;
         }
     }
@@ -419,10 +419,11 @@ void Button::paint(QPainter *painter, const QRectF &repaintRegion)
     painter->restore();
 }
 
-void Button::paintIcon(QPainter *painter, const QRectF &iconRect, const qreal)
+void Button::paintIcon(QPainter *painter, const QRectF &iconRect, const qreal dpr)
 {
     Q_UNUSED(painter)
     Q_UNUSED(iconRect)
+    Q_UNUSED(dpr)
 }
 
 void Button::updateSize(qreal contentWidth, qreal contentHeight)

--- a/src/Button.cc
+++ b/src/Button.cc
@@ -353,8 +353,10 @@ void Button::paint(QPainter *painter, const QRectF &repaintRegion)
         }
 
         // For a sharper image, we use physical-pixel-aligned positioning and scaling
-        const qreal physicalIconSize = qRound(size * dpr);
-        const qreal iconLogicalSize = physicalIconSize / dpr;
+        const QTransform transform = painter->transform();
+        const qreal localToPhysicalScale = std::hypot(transform.m11(), transform.m12()) * dpr;
+        const qreal physicalIconSize = (localToPhysicalScale > 0.0) ? qRound(size * localToPhysicalScale) : qRound(size * dpr);
+        const qreal iconLogicalSize = (localToPhysicalScale > 0.0) ? (physicalIconSize / localToPhysicalScale) : (physicalIconSize / dpr);
 
         // Translate to a center aligned with physical pixel grid
         const QPointF center = contentRect.center();
@@ -483,12 +485,25 @@ QPointF PixelSnapper::snap(const QPointF &p) const
     return p;
 }
 
-qreal PixelSnapper::snap(const qreal v) const
+qreal PixelSnapper::snapX(const qreal v) const
 {
     const QPointF p0 = snap(QPointF(0.0, 0.0));
     const QPointF pV = snap(QPointF(v, 0.0));
     const qreal len = std::hypot(pV.x() - p0.x(), pV.y() - p0.y());
     return (v < 0.0) ? -len : len;
+}
+
+qreal PixelSnapper::snapY(const qreal v) const
+{
+    const QPointF p0 = snap(QPointF(0.0, 0.0));
+    const QPointF pV = snap(QPointF(0.0, v));
+    const qreal len = std::hypot(pV.x() - p0.x(), pV.y() - p0.y());
+    return (v < 0.0) ? -len : len;
+}
+
+qreal PixelSnapper::snap(const qreal v) const
+{
+    return snapX(v);
 }
 
 QPointF Button::snapPoint(QPainter *painter, const QPointF &p, const qreal dpr) const
@@ -500,7 +515,7 @@ QPointF Button::snapPoint(QPainter *painter, const QPointF &p, const qreal dpr) 
 qreal Button::snapValue(QPainter *painter, const qreal v, const qreal dpr) const
 {
     PixelSnapper snapper(painter, dpr);
-    return snapper.snap(v);
+    return snapper.snapX(v);
 }
 
 QColor Button::backgroundColor() const

--- a/src/Button.cc
+++ b/src/Button.cc
@@ -325,11 +325,13 @@ void Button::paint(QPainter *painter, const QRectF &repaintRegion)
 
     const QRectF contentRect = contentArea();
 
+    PixelSnapper snapper(painter, dpr);
+
     // TextButton and AppIconButton are special, so we don't scale the painter
     if (auto textButton = qobject_cast<TextButton*>(this)) {
-        textButton->paintIcon(painter, contentRect, dpr);
+        textButton->paintIcon(painter, contentRect, snapper);
     } else if (type() == KDecoration3::DecorationButtonType::Menu) {
-        AppIconButton::paintIcon(this, painter, contentRect, dpr);
+        AppIconButton::paintIcon(this, painter, contentRect, snapper);
     } else {
         // All further rendering is performed inside a 18x18 square
         const qreal width = contentRect.width();
@@ -353,7 +355,6 @@ void Button::paint(QPainter *painter, const QRectF &repaintRegion)
         }
 
         // For a sharper image, we use physical-pixel-aligned positioning and scaling
-        PixelSnapper snapper(painter, dpr);
         const qreal localToPhysicalScale = snapper.localToPhysicalScale();
         const qreal physicalIconSize = (localToPhysicalScale > 0.0) ? qRound(size * localToPhysicalScale) : qRound(size * dpr);
         const qreal iconLogicalSize = (localToPhysicalScale > 0.0) ? (physicalIconSize / localToPhysicalScale) : (physicalIconSize / dpr);
@@ -368,52 +369,54 @@ void Button::paint(QPainter *painter, const QRectF &repaintRegion)
         
         setPenWidth(painter, KDecoration3::pixelSize(deco->window()->scale()));
 
+        PixelSnapper iconSnapper(painter, dpr);
+
         // Icons
         const QRectF iconRect(-9, -9, 18, 18);
         switch (type()) {
         // NOTE: Menu and ApplicationMenu are handled above
         case KDecoration3::DecorationButtonType::OnAllDesktops:
-            OnAllDesktopsButton::paintIcon(this, painter, iconRect, dpr);
+            OnAllDesktopsButton::paintIcon(this, painter, iconRect, iconSnapper);
             break;
 
         case KDecoration3::DecorationButtonType::ContextHelp:
-            ContextHelpButton::paintIcon(this, painter, iconRect, dpr);
+            ContextHelpButton::paintIcon(this, painter, iconRect, iconSnapper);
             break;
 
         case KDecoration3::DecorationButtonType::Shade:
-            ShadeButton::paintIcon(this, painter, iconRect, dpr);
+            ShadeButton::paintIcon(this, painter, iconRect, iconSnapper);
             break;
 
         case KDecoration3::DecorationButtonType::KeepAbove:
-            KeepAboveButton::paintIcon(this, painter, iconRect, dpr);
+            KeepAboveButton::paintIcon(this, painter, iconRect, iconSnapper);
             break;
 
         case KDecoration3::DecorationButtonType::KeepBelow:
-            KeepBelowButton::paintIcon(this, painter, iconRect, dpr);
+            KeepBelowButton::paintIcon(this, painter, iconRect, iconSnapper);
             break;
 
         case KDecoration3::DecorationButtonType::Close:
-            CloseButton::paintIcon(this, painter, iconRect, dpr);
+            CloseButton::paintIcon(this, painter, iconRect, iconSnapper);
             break;
 
         case KDecoration3::DecorationButtonType::Maximize:
-            MaximizeButton::paintIcon(this, painter, iconRect, dpr);
+            MaximizeButton::paintIcon(this, painter, iconRect, iconSnapper);
             break;
 
         case KDecoration3::DecorationButtonType::Minimize:
-            MinimizeButton::paintIcon(this, painter, iconRect, dpr);
+            MinimizeButton::paintIcon(this, painter, iconRect, iconSnapper);
             break;
         case KDecoration3::DecorationButtonType::Spacer:  
             break;            
 
 #if HAVE_EXCLUDE_FROM_CAPTURE
         case KDecoration3::DecorationButtonType::ExcludeFromCapture:
-            ExcludeFromCaptureButton::paintIcon(this, painter, iconRect, dpr);
+            ExcludeFromCaptureButton::paintIcon(this, painter, iconRect, iconSnapper);
             break;
 #endif
 
         default:
-            paintIcon(painter, iconRect, dpr);
+            paintIcon(painter, iconRect, iconSnapper);
             break;
         }
     }
@@ -421,11 +424,11 @@ void Button::paint(QPainter *painter, const QRectF &repaintRegion)
     painter->restore();
 }
 
-void Button::paintIcon(QPainter *painter, const QRectF &iconRect, const qreal dpr)
+void Button::paintIcon(QPainter *painter, const QRectF &iconRect, const PixelSnapper &snapper)
 {
     Q_UNUSED(painter)
     Q_UNUSED(iconRect)
-    Q_UNUSED(dpr)
+    Q_UNUSED(snapper)
 }
 
 void Button::updateSize(qreal contentWidth, qreal contentHeight)
@@ -465,17 +468,6 @@ void Button::setPenWidth(QPainter *painter, const qreal scale)
     painter->setPen(pen);
 }
 
-QPointF Button::snapPoint(QPainter *painter, const QPointF &p, const qreal dpr) const
-{
-    PixelSnapper snapper(painter, dpr);
-    return snapper.snap(p);
-}
-
-qreal Button::snapValue(QPainter *painter, const qreal v, const qreal dpr) const
-{
-    PixelSnapper snapper(painter, dpr);
-    return snapper.snapX(v);
-}
 
 QColor Button::backgroundColor() const
 {

--- a/src/Button.cc
+++ b/src/Button.cc
@@ -349,15 +349,20 @@ void Button::paint(QPainter *painter, const QRectF &repaintRegion)
             size = qMin(width, height) * 0.6; // 60% of the Kwin Deco
         }
 
-        // For a sharper image, we use integer-based positioning
-        const int iconSize = qRound(size);
+        const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : 1.0;
 
-        // Translate to a rounded center
+        // For a sharper image, we use physical-pixel-aligned positioning and scaling
+        const qreal physicalIconSize = qRound(size * dpr);
+        const qreal iconLogicalSize = physicalIconSize / dpr;
+
+        // Translate to a center aligned with physical pixel grid
         const QPointF center = contentRect.center();
-        painter->translate(qRound(center.x()), qRound(center.y()));
+        const qreal centerX = qRound(center.x() * dpr) / dpr;
+        const qreal centerY = qRound(center.y() * dpr) / dpr;
+        painter->translate(centerX, centerY);
 
-        // Scale by an integer-based factor
-        painter->scale(static_cast<qreal>(iconSize) / 18.0, static_cast<qreal>(iconSize) / 18.0);
+        // Scale by physical-aligned factor
+        painter->scale(iconLogicalSize / 18.0, iconLogicalSize / 18.0);
         
         setPenWidth(painter, KDecoration3::pixelSize(deco->window()->scale()));
 
@@ -441,10 +446,20 @@ void Button::setPenWidth(QPainter *painter, const qreal scale)
     QPen pen(foregroundColor());
     pen.setCapStyle(Qt::RoundCap);
     pen.setJoinStyle(Qt::MiterJoin);
-    // Set the base pen width. This will be correctly scaled by the painter's
-    // transformation in the paint() method, preserving the behavior of
-    // lines getting thicker as the icon scales up.
-    pen.setWidthF(PenWidth::Symbol * scale);
+
+    const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : 1.0;
+    const QTransform transform = painter->transform();
+    const qreal scaleX = qAbs(transform.m11());
+    const qreal localToPhysicalScale = scaleX * dpr;
+
+    if (localToPhysicalScale > 0.0) {
+        const qreal nominalPhysicalWidth = PenWidth::Symbol * scale * localToPhysicalScale;
+        const qreal snappedPhysicalWidth = qMax(1.0, qRound(nominalPhysicalWidth * 2.0) / 2.0);
+        pen.setWidthF(snappedPhysicalWidth / localToPhysicalScale);
+    } else {
+        pen.setWidthF(PenWidth::Symbol * scale);
+    }
+
     painter->setPen(pen);
 }
 

--- a/src/Button.cc
+++ b/src/Button.cc
@@ -59,6 +59,7 @@
 #include <QTimer>
 #include <QDBusConnection>
 #include <QDBusMessage>
+#include <cmath>
 
 #define UPDATE_GEOM() update(geometry().adjusted(-1, -1, 1, 1))
 
@@ -466,25 +467,27 @@ void Button::setPenWidth(QPainter *painter, const qreal scale)
 
 QPointF Button::snapPoint(QPainter *painter, const QPointF &p, const qreal dpr) const
 {
-    const qreal scaleX = qAbs(painter->transform().m11());
-    const qreal localToPhysical = scaleX * dpr;
-    if (localToPhysical > 0.0) {
-        return QPointF(
-            qRound(p.x() * localToPhysical) / localToPhysical,
-            qRound(p.y() * localToPhysical) / localToPhysical
-        );
+    if (dpr > 0.0) {
+        const QTransform trans = painter->transform();
+        bool invertible = false;
+        const QTransform inv = trans.inverted(&invertible);
+        if (invertible) {
+            const QPointF devInd = trans.map(p);
+            const QPointF phys(devInd.x() * dpr, devInd.y() * dpr);
+            const QPointF physSnapped(qRound(phys.x()), qRound(phys.y()));
+            const QPointF devIndSnapped(physSnapped.x() / dpr, physSnapped.y() / dpr);
+            return inv.map(devIndSnapped);
+        }
     }
     return p;
 }
 
 qreal Button::snapValue(QPainter *painter, const qreal v, const qreal dpr) const
 {
-    const qreal scaleX = qAbs(painter->transform().m11());
-    const qreal localToPhysical = scaleX * dpr;
-    if (localToPhysical > 0.0) {
-        return qRound(v * localToPhysical) / localToPhysical;
-    }
-    return v;
+    const QPointF p0 = snapPoint(painter, QPointF(0.0, 0.0), dpr);
+    const QPointF pV = snapPoint(painter, QPointF(v, 0.0), dpr);
+    const qreal len = std::hypot(pV.x() - p0.x(), pV.y() - p0.y());
+    return (v < 0.0) ? -len : len;
 }
 
 QColor Button::backgroundColor() const

--- a/src/Button.cc
+++ b/src/Button.cc
@@ -464,6 +464,29 @@ void Button::setPenWidth(QPainter *painter, const qreal scale)
     painter->setPen(pen);
 }
 
+QPointF Button::snapPoint(QPainter *painter, const QPointF &p, const qreal dpr) const
+{
+    const qreal scaleX = qAbs(painter->transform().m11());
+    const qreal localToPhysical = scaleX * dpr;
+    if (localToPhysical > 0.0) {
+        return QPointF(
+            qRound(p.x() * localToPhysical) / localToPhysical,
+            qRound(p.y() * localToPhysical) / localToPhysical
+        );
+    }
+    return p;
+}
+
+qreal Button::snapValue(QPainter *painter, const qreal v, const qreal dpr) const
+{
+    const qreal scaleX = qAbs(painter->transform().m11());
+    const qreal localToPhysical = scaleX * dpr;
+    if (localToPhysical > 0.0) {
+        return qRound(v * localToPhysical) / localToPhysical;
+    }
+    return v;
+}
+
 QColor Button::backgroundColor() const
 {
     const auto *deco = qobject_cast<Decoration *>(this->decoration());

--- a/src/Button.cc
+++ b/src/Button.cc
@@ -358,9 +358,8 @@ void Button::paint(QPainter *painter, const QRectF &repaintRegion)
 
         // Translate to a center aligned with physical pixel grid
         const QPointF center = contentRect.center();
-        const qreal centerX = qRound(center.x() * dpr) / dpr;
-        const qreal centerY = qRound(center.y() * dpr) / dpr;
-        painter->translate(centerX, centerY);
+        const QPointF centerSnapped = snapPoint(painter, center, dpr);
+        painter->translate(centerSnapped);
 
         // Scale by physical-aligned factor
         painter->scale(iconLogicalSize / 18.0, iconLogicalSize / 18.0);
@@ -451,8 +450,7 @@ void Button::setPenWidth(QPainter *painter, const qreal scale)
 
     const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : 1.0;
     const QTransform transform = painter->transform();
-    const qreal scaleX = qAbs(transform.m11());
-    const qreal localToPhysicalScale = scaleX * dpr;
+    const qreal localToPhysicalScale = std::hypot(transform.m11(), transform.m12()) * dpr;
 
     if (localToPhysicalScale > 0.0) {
         const qreal nominalPhysicalWidth = PenWidth::Symbol * scale * localToPhysicalScale;

--- a/src/Button.h
+++ b/src/Button.h
@@ -32,28 +32,12 @@
 class QTimer;
 class QPainter;
 
+#include "PixelSnapper.h"
+
 namespace Material
 {
 
 class Decoration;
-
-class PixelSnapper
-{
-public:
-    PixelSnapper(QPainter *painter, const qreal dpr);
-
-    QPointF snap(const QPointF &p) const;
-    qreal snap(const qreal v) const;
-    qreal snapX(const qreal v) const;
-    qreal snapY(const qreal v) const;
-    qreal localToPhysicalScale() const;
-
-private:
-    QTransform m_trans;
-    QTransform m_inv;
-    qreal m_dpr;
-    bool m_invertible;
-};
 
 class Button : public KDecoration3::DecorationButton
 {

--- a/src/Button.h
+++ b/src/Button.h
@@ -93,7 +93,7 @@ signals:
     void paddingChanged();
 
 protected:
-    virtual void paintIcon(QPainter *painter, const QRectF &iconRect, const qreal);
+    virtual void paintIcon(QPainter *painter, const QRectF &iconRect, const qreal dpr);
     virtual void updateSize(qreal contentWidth, qreal contentHeight);
     virtual void setHeight(qreal buttonHeight);
 

--- a/src/Button.h
+++ b/src/Button.h
@@ -46,6 +46,7 @@ public:
     qreal snap(const qreal v) const;
     qreal snapX(const qreal v) const;
     qreal snapY(const qreal v) const;
+    qreal localToPhysicalScale() const;
 
 private:
     QTransform m_trans;

--- a/src/Button.h
+++ b/src/Button.h
@@ -69,8 +69,6 @@ public:
 
     //virtual qreal iconLineWidth(const qreal size) const;
     void setPenWidth(QPainter *painter, const qreal scale);
-    QPointF snapPoint(QPainter *painter, const QPointF &p, const qreal dpr) const;
-    qreal snapValue(QPainter *painter, const qreal v, const qreal dpr) const;
 
     bool animationEnabled() const;
     void setAnimationEnabled(bool value);
@@ -99,7 +97,7 @@ signals:
     void paddingChanged();
 
 protected:
-    virtual void paintIcon(QPainter *painter, const QRectF &iconRect, const qreal dpr);
+    virtual void paintIcon(QPainter *painter, const QRectF &iconRect, const PixelSnapper &snapper);
     virtual void updateSize(qreal contentWidth, qreal contentHeight);
     virtual void setHeight(qreal buttonHeight);
 

--- a/src/Button.h
+++ b/src/Button.h
@@ -44,6 +44,8 @@ public:
 
     QPointF snap(const QPointF &p) const;
     qreal snap(const qreal v) const;
+    qreal snapX(const qreal v) const;
+    qreal snapY(const qreal v) const;
 
 private:
     QTransform m_trans;

--- a/src/Button.h
+++ b/src/Button.h
@@ -27,13 +27,30 @@
 #include <QMouseEvent>
 #include <QRectF>
 #include <QVariantAnimation>
+#include <QTransform>
 
 class QTimer;
+class QPainter;
 
 namespace Material
 {
 
 class Decoration;
+
+class PixelSnapper
+{
+public:
+    PixelSnapper(QPainter *painter, const qreal dpr);
+
+    QPointF snap(const QPointF &p) const;
+    qreal snap(const qreal v) const;
+
+private:
+    QTransform m_trans;
+    QTransform m_inv;
+    qreal m_dpr;
+    bool m_invertible;
+};
 
 class Button : public KDecoration3::DecorationButton
 {

--- a/src/Button.h
+++ b/src/Button.h
@@ -65,6 +65,8 @@ public:
 
     //virtual qreal iconLineWidth(const qreal size) const;
     void setPenWidth(QPainter *painter, const qreal scale);
+    QPointF snapPoint(QPainter *painter, const QPointF &p, const qreal dpr) const;
+    qreal snapValue(QPainter *painter, const qreal v, const qreal dpr) const;
 
     bool animationEnabled() const;
     void setAnimationEnabled(bool value);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,6 +63,7 @@ set (decoration_SRCS
     Button.cc
     Decoration.cc
     MenuOverflowButton.cc
+    PixelSnapper.cc
     SearchButton.cc
     TextButton.cc
     plugin.cc

--- a/src/CloseButton.h
+++ b/src/CloseButton.h
@@ -45,7 +45,7 @@ public:
         button->setPenWidth(painter, 1.5);
 
         PixelSnapper snapper(painter, dpr);
-        const qreal s = snapper.snap(5.0);
+        const qreal s = snapper.snapX(5.0);
 
         painter->drawLine(QPointF(-s, -s), QPointF(s, s));
         painter->drawLine(QPointF(s, -s), QPointF(-s, s));

--- a/src/CloseButton.h
+++ b/src/CloseButton.h
@@ -46,13 +46,7 @@ public:
 
         button->setPenWidth(painter, 1.5);
 
-        const qreal scaleX = qAbs(painter->transform().m11());
-        const qreal localToPhysical = scaleX * dpr;
-
-        qreal s = 5.0;
-        if (localToPhysical > 0.0) {
-            s = qRound(s * localToPhysical) / localToPhysical;
-        }
+        const qreal s = button->snapValue(painter, 5.0, dpr);
 
         painter->drawLine(QPointF(-s, -s), QPointF(s, s));
         painter->drawLine(QPointF(s, -s), QPointF(-s, s));

--- a/src/CloseButton.h
+++ b/src/CloseButton.h
@@ -42,11 +42,10 @@ public:
     static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal dpr) {
         Q_UNUSED(iconRect)
 
-        //painter->setRenderHints(QPainter::Antialiasing, true);
-
         button->setPenWidth(painter, 1.5);
 
-        const qreal s = button->snapValue(painter, 5.0, dpr);
+        PixelSnapper snapper(painter, dpr);
+        const qreal s = snapper.snap(5.0);
 
         painter->drawLine(QPointF(-s, -s), QPointF(s, s));
         painter->drawLine(QPointF(s, -s), QPointF(-s, s));

--- a/src/CloseButton.h
+++ b/src/CloseButton.h
@@ -40,14 +40,21 @@ public:
         button->setVisible(decoratedClient->isCloseable());
     }
     static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal) {
-        Q_UNUSED(button)
         Q_UNUSED(iconRect)
 
         //painter->setRenderHints(QPainter::Antialiasing, true);
 
         button->setPenWidth(painter, 1.5);
 
-        const qreal s = 5;
+        const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : 1.0;
+        const qreal scaleX = qAbs(painter->transform().m11());
+        const qreal localToPhysical = scaleX * dpr;
+
+        qreal s = 5.0;
+        if (localToPhysical > 0.0) {
+            s = qRound(s * localToPhysical) / localToPhysical;
+        }
+
         painter->drawLine(QPointF(-s, -s), QPointF(s, s));
         painter->drawLine(QPointF(s, -s), QPointF(-s, s));
     }

--- a/src/CloseButton.h
+++ b/src/CloseButton.h
@@ -39,16 +39,18 @@ public:
 
         button->setVisible(decoratedClient->isCloseable());
     }
-    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal dpr) {
+    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const PixelSnapper &snapper) {
         Q_UNUSED(iconRect)
 
         button->setPenWidth(painter, 1.5);
 
-        PixelSnapper snapper(painter, dpr);
-        const qreal s = snapper.snapX(5.0);
+        const QPointF p1 = snapper.snap(QPointF(-5.0, -5.0));
+        const QPointF p2 = snapper.snap(QPointF(5.0, 5.0));
+        const QPointF p3 = snapper.snap(QPointF(5.0, -5.0));
+        const QPointF p4 = snapper.snap(QPointF(-5.0, 5.0));
 
-        painter->drawLine(QPointF(-s, -s), QPointF(s, s));
-        painter->drawLine(QPointF(s, -s), QPointF(-s, s));
+        painter->drawLine(p1, p2);
+        painter->drawLine(p3, p4);
     }
 };
 

--- a/src/CloseButton.h
+++ b/src/CloseButton.h
@@ -39,14 +39,13 @@ public:
 
         button->setVisible(decoratedClient->isCloseable());
     }
-    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal) {
+    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal dpr) {
         Q_UNUSED(iconRect)
 
         //painter->setRenderHints(QPainter::Antialiasing, true);
 
         button->setPenWidth(painter, 1.5);
 
-        const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : 1.0;
         const qreal scaleX = qAbs(painter->transform().m11());
         const qreal localToPhysical = scaleX * dpr;
 

--- a/src/ContextHelpButton.h
+++ b/src/ContextHelpButton.h
@@ -48,17 +48,16 @@ public:
         Q_UNUSED(iconRect)
         button->setPenWidth(painter, 1.25);
 
-        //painter->setRenderHints(QPainter::Antialiasing, true);
-
-        auto snapPoint = [button, painter, dpr](const QPointF &p) -> QPointF {
-            return button->snapPoint(painter, p, dpr);
+        PixelSnapper snapper(painter, dpr);
+        auto snapPoint = [&snapper](const QPointF &p) -> QPointF {
+            return snapper.snap(p);
         };
 
         const QPointF offset(-5.5, -5.5);
 
         const QPointF p1 = snapPoint(QPointF( 1.5, 0.5 ) + offset);
-        const qreal topCurveW = button->snapValue(painter, 8.0, dpr);
-        const qreal topCurveH = button->snapValue(painter, 6.0, dpr);
+        const qreal topCurveW = snapper.snap(8.0);
+        const qreal topCurveH = snapper.snap(6.0);
         const QRectF topCurveRect(p1, QSizeF(topCurveW, topCurveH));
 
         QPainterPath path;
@@ -77,8 +76,8 @@ public:
 
         // Dot
         const QPointF dotPos = snapPoint(QPointF( 5.0, 10.0 ) + offset);
-        const qreal dotW = button->snapValue(painter, 0.5, dpr);
-        const qreal dotH = button->snapValue(painter, 0.5, dpr);
+        const qreal dotW = snapper.snap(0.5);
+        const qreal dotH = snapper.snap(0.5);
         painter->drawRect(QRectF(dotPos, QSizeF(dotW, dotH)));
     }
 };

--- a/src/ContextHelpButton.h
+++ b/src/ContextHelpButton.h
@@ -56,8 +56,8 @@ public:
         const QPointF offset(-5.5, -5.5);
 
         const QPointF p1 = snapPoint(QPointF( 1.5, 0.5 ) + offset);
-        const qreal topCurveW = snapper.snap(8.0);
-        const qreal topCurveH = snapper.snap(6.0);
+        const qreal topCurveW = snapper.snapX(8.0);
+        const qreal topCurveH = snapper.snapY(6.0);
         const QRectF topCurveRect(p1, QSizeF(topCurveW, topCurveH));
 
         QPainterPath path;
@@ -76,8 +76,8 @@ public:
 
         // Dot
         const QPointF dotPos = snapPoint(QPointF( 5.0, 10.0 ) + offset);
-        const qreal dotW = snapper.snap(0.5);
-        const qreal dotH = snapper.snap(0.5);
+        const qreal dotW = snapper.snapX(0.5);
+        const qreal dotH = snapper.snapY(0.5);
         painter->drawRect(QRectF(dotPos, QSizeF(dotW, dotH)));
     }
 };

--- a/src/ContextHelpButton.h
+++ b/src/ContextHelpButton.h
@@ -44,13 +44,12 @@ public:
 
         button->setVisible(decoratedClient->providesContextHelp());
     }
-    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal) {
+    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal dpr) {
         Q_UNUSED(iconRect)
         button->setPenWidth(painter, 1.25);
 
         //painter->setRenderHints(QPainter::Antialiasing, true);
         
-        const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : 1.0;
         const qreal scaleX = qAbs(painter->transform().m11());
         const qreal localToPhysical = scaleX * dpr;
 

--- a/src/ContextHelpButton.h
+++ b/src/ContextHelpButton.h
@@ -49,33 +49,30 @@ public:
         button->setPenWidth(painter, 1.25);
 
         PixelSnapper snapper(painter, dpr);
-        auto snapPoint = [&snapper](const QPointF &p) -> QPointF {
-            return snapper.snap(p);
-        };
 
         const QPointF offset(-5.5, -5.5);
 
-        const QPointF p1 = snapPoint(QPointF( 1.5, 0.5 ) + offset);
+        const QPointF p1 = snapper.snap(QPointF( 1.5, 0.5 ) + offset);
         const qreal topCurveW = snapper.snapX(8.0);
         const qreal topCurveH = snapper.snapY(6.0);
         const QRectF topCurveRect(p1, QSizeF(topCurveW, topCurveH));
 
         QPainterPath path;
-        path.moveTo(snapPoint(topCurveRect.center() - QPointF(topCurveRect.width() / 2.0, 0.0)));
+        path.moveTo(snapper.snap(topCurveRect.center() - QPointF(topCurveRect.width() / 2.0, 0.0)));
         path.arcTo(
             topCurveRect,
             180,
             -180
         );
         path.cubicTo(
-            snapPoint(QPointF( 7.8125, 5.9375 ) + offset),
-            snapPoint(QPointF( 5.625, 4.6875 ) + offset),
-            snapPoint(QPointF( 5.0, 8.0 ) + offset)
+            snapper.snap(QPointF( 7.8125, 5.9375 ) + offset),
+            snapper.snap(QPointF( 5.625, 4.6875 ) + offset),
+            snapper.snap(QPointF( 5.0, 8.0 ) + offset)
         );
         painter->drawPath(path);
 
         // Dot
-        const QPointF dotPos = snapPoint(QPointF( 5.0, 10.0 ) + offset);
+        const QPointF dotPos = snapper.snap(QPointF( 5.0, 10.0 ) + offset);
         const qreal dotW = snapper.snapX(0.5);
         const qreal dotH = snapper.snapY(0.5);
         painter->drawRect(QRectF(dotPos, QSizeF(dotW, dotH)));

--- a/src/ContextHelpButton.h
+++ b/src/ContextHelpButton.h
@@ -44,11 +44,9 @@ public:
 
         button->setVisible(decoratedClient->providesContextHelp());
     }
-    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal dpr) {
+    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const PixelSnapper &snapper) {
         Q_UNUSED(iconRect)
         button->setPenWidth(painter, 1.25);
-
-        PixelSnapper snapper(painter, dpr);
 
         const QPointF offset(-5.5, -5.5);
 

--- a/src/ContextHelpButton.h
+++ b/src/ContextHelpButton.h
@@ -50,13 +50,12 @@ public:
 
         const QPointF offset(-5.5, -5.5);
 
-        const QPointF p1 = snapper.snap(QPointF( 1.5, 0.5 ) + offset);
-        const qreal topCurveW = snapper.snapX(8.0);
-        const qreal topCurveH = snapper.snapY(6.0);
-        const QRectF topCurveRect(p1, QSizeF(topCurveW, topCurveH));
+        const QPointF topCurveTopLeft = snapper.snap(QPointF(1.5, 0.5) + offset);
+        const QPointF topCurveBottomRight = snapper.snap(QPointF(9.5, 6.5) + offset);
+        const QRectF topCurveRect(topCurveTopLeft, topCurveBottomRight);
 
         QPainterPath path;
-        path.moveTo(snapper.snap(topCurveRect.center() - QPointF(topCurveRect.width() / 2.0, 0.0)));
+        path.moveTo(snapper.snap(QPointF(1.5, 3.5) + offset));
         path.arcTo(
             topCurveRect,
             180,
@@ -70,10 +69,9 @@ public:
         painter->drawPath(path);
 
         // Dot
-        const QPointF dotPos = snapper.snap(QPointF( 5.0, 10.0 ) + offset);
-        const qreal dotW = snapper.snapX(0.5);
-        const qreal dotH = snapper.snapY(0.5);
-        painter->drawRect(QRectF(dotPos, QSizeF(dotW, dotH)));
+        const QPointF dotTopLeft = snapper.snap(QPointF(5.0, 10.0) + offset);
+        const QPointF dotBottomRight = snapper.snap(QPointF(5.5, 10.5) + offset);
+        painter->drawRect(QRectF(dotTopLeft, dotBottomRight));
     }
 };
 

--- a/src/ContextHelpButton.h
+++ b/src/ContextHelpButton.h
@@ -49,29 +49,16 @@ public:
         button->setPenWidth(painter, 1.25);
 
         //painter->setRenderHints(QPainter::Antialiasing, true);
-        
-        const qreal scaleX = qAbs(painter->transform().m11());
-        const qreal localToPhysical = scaleX * dpr;
 
-        auto snapPoint = [localToPhysical](const QPointF &p) -> QPointF {
-            if (localToPhysical > 0.0) {
-                return QPointF(
-                    qRound(p.x() * localToPhysical) / localToPhysical,
-                    qRound(p.y() * localToPhysical) / localToPhysical
-                );
-            }
-            return p;
+        auto snapPoint = [button, painter, dpr](const QPointF &p) -> QPointF {
+            return button->snapPoint(painter, p, dpr);
         };
 
         const QPointF offset(-5.5, -5.5);
 
         const QPointF p1 = snapPoint(QPointF( 1.5, 0.5 ) + offset);
-        qreal topCurveW = 8.0;
-        qreal topCurveH = 6.0;
-        if (localToPhysical > 0.0) {
-            topCurveW = qRound(topCurveW * localToPhysical) / localToPhysical;
-            topCurveH = qRound(topCurveH * localToPhysical) / localToPhysical;
-        }
+        const qreal topCurveW = button->snapValue(painter, 8.0, dpr);
+        const qreal topCurveH = button->snapValue(painter, 6.0, dpr);
         const QRectF topCurveRect(p1, QSizeF(topCurveW, topCurveH));
 
         QPainterPath path;
@@ -90,12 +77,8 @@ public:
 
         // Dot
         const QPointF dotPos = snapPoint(QPointF( 5.0, 10.0 ) + offset);
-        qreal dotW = 0.5;
-        qreal dotH = 0.5;
-        if (localToPhysical > 0.0) {
-            dotW = qRound(dotW * localToPhysical) / localToPhysical;
-            dotH = qRound(dotH * localToPhysical) / localToPhysical;
-        }
+        const qreal dotW = button->snapValue(painter, 0.5, dpr);
+        const qreal dotH = button->snapValue(painter, 0.5, dpr);
         painter->drawRect(QRectF(dotPos, QSizeF(dotW, dotH)));
     }
 };

--- a/src/ContextHelpButton.h
+++ b/src/ContextHelpButton.h
@@ -50,31 +50,54 @@ public:
 
         //painter->setRenderHints(QPainter::Antialiasing, true);
         
+        const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : 1.0;
+        const qreal scaleX = qAbs(painter->transform().m11());
+        const qreal localToPhysical = scaleX * dpr;
+
+        auto snapPoint = [localToPhysical](const QPointF &p) -> QPointF {
+            if (localToPhysical > 0.0) {
+                return QPointF(
+                    qRound(p.x() * localToPhysical) / localToPhysical,
+                    qRound(p.y() * localToPhysical) / localToPhysical
+                );
+            }
+            return p;
+        };
+
         const QPointF offset(-5.5, -5.5);
 
-        const QRectF topCurveRect = QRectF(
-            QPointF( 1.5, 0.5 ) + offset,
-            QSizeF( 8, 6 )
-        );
+        const QPointF p1 = snapPoint(QPointF( 1.5, 0.5 ) + offset);
+        qreal topCurveW = 8.0;
+        qreal topCurveH = 6.0;
+        if (localToPhysical > 0.0) {
+            topCurveW = qRound(topCurveW * localToPhysical) / localToPhysical;
+            topCurveH = qRound(topCurveH * localToPhysical) / localToPhysical;
+        }
+        const QRectF topCurveRect(p1, QSizeF(topCurveW, topCurveH));
+
         QPainterPath path;
-        path.moveTo( topCurveRect.center() - QPointF(topCurveRect.width()/2, 0) );
+        path.moveTo(snapPoint(topCurveRect.center() - QPointF(topCurveRect.width() / 2.0, 0.0)));
         path.arcTo(
             topCurveRect,
             180,
             -180
         );
         path.cubicTo(
-            QPointF( 7.8125, 5.9375 ) + offset,
-            QPointF( 5.625, 4.6875 ) + offset,
-            QPointF( 5, 8 ) + offset
+            snapPoint(QPointF( 7.8125, 5.9375 ) + offset),
+            snapPoint(QPointF( 5.625, 4.6875 ) + offset),
+            snapPoint(QPointF( 5.0, 8.0 ) + offset)
         );
         painter->drawPath(path);
 
         // Dot
-        painter->drawRect( QRectF(
-            QPointF( 5, 10 ) + offset,
-            QSizeF( 0.5, 0.5 )
-        ));
+        const QPointF dotPos = snapPoint(QPointF( 5.0, 10.0 ) + offset);
+        qreal dotW = 0.5;
+        qreal dotH = 0.5;
+        if (localToPhysical > 0.0) {
+            dotW = qRound(dotW * localToPhysical) / localToPhysical;
+            dotH = qRound(dotH * localToPhysical) / localToPhysical;
+        }
+        painter->drawRect(QRectF(dotPos, QSizeF(dotW, dotH)));
     }
 };
 

--- a/src/ExcludeFromCaptureButton.h
+++ b/src/ExcludeFromCaptureButton.h
@@ -55,8 +55,9 @@ public:
         }
         button->setPenWidth(painter, 1.25 * KDecoration3::pixelSize(deco->window()->scale()));
 
-        auto snapPoint = [button, painter, dpr](const QPointF &p) -> QPointF {
-            return button->snapPoint(painter, p, dpr);
+        PixelSnapper snapper(painter, dpr);
+        auto snapPoint = [&snapper](const QPointF &p) -> QPointF {
+            return snapper.snap(p);
         };
 
         // A spy hat (like view-private.svg icon)
@@ -76,8 +77,8 @@ public:
         painter->drawLine(snapPoint(QPointF(-6.2, -0.5)), snapPoint(QPointF(6.2, -0.5)));
 
         // Glasses' lenses
-        const qreal rx = button->snapValue(painter, 2.3, dpr);
-        const qreal ry = button->snapValue(painter, 2.3, dpr);
+        const qreal rx = snapper.snap(2.3);
+        const qreal ry = snapper.snap(2.3);
         painter->drawEllipse(snapPoint(QPointF(-4.0, 3.8)), rx, ry);
         painter->drawEllipse(snapPoint(QPointF(4.0, 3.8)), rx, ry);
 

--- a/src/ExcludeFromCaptureButton.h
+++ b/src/ExcludeFromCaptureButton.h
@@ -77,8 +77,8 @@ public:
         painter->drawLine(snapPoint(QPointF(-6.2, -0.5)), snapPoint(QPointF(6.2, -0.5)));
 
         // Glasses' lenses
-        const qreal rx = snapper.snap(2.3);
-        const qreal ry = snapper.snap(2.3);
+        const qreal rx = snapper.snapX(2.3);
+        const qreal ry = snapper.snapY(2.3);
         painter->drawEllipse(snapPoint(QPointF(-4.0, 3.8)), rx, ry);
         painter->drawEllipse(snapPoint(QPointF(4.0, 3.8)), rx, ry);
 

--- a/src/ExcludeFromCaptureButton.h
+++ b/src/ExcludeFromCaptureButton.h
@@ -47,15 +47,13 @@ public:
     }
     
     //--- copied from Breeze for now. Copyright goes to KDE Developers
-    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal dpr) {
+    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const PixelSnapper &snapper) {
         Q_UNUSED(iconRect)
         const auto *deco = qobject_cast<Decoration *>(button->decoration());
         if (!deco) {
             return;
         }
         button->setPenWidth(painter, 1.25 * KDecoration3::pixelSize(deco->window()->scale()));
-
-        PixelSnapper snapper(painter, dpr);
 
         // A spy hat (like view-private.svg icon)
         // Hat crown with dip/crease at top (filled)

--- a/src/ExcludeFromCaptureButton.h
+++ b/src/ExcludeFromCaptureButton.h
@@ -47,7 +47,7 @@ public:
     }
     
     //--- copied from Breeze for now. Copyright goes to KDE Developers
-    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal) {
+    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal dpr) {
         Q_UNUSED(iconRect)
         const auto *deco = qobject_cast<Decoration *>(button->decoration());
         if (!deco) {
@@ -55,7 +55,6 @@ public:
         }
         button->setPenWidth(painter, 1.25 * KDecoration3::pixelSize(deco->window()->scale()));
 
-        const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : 1.0;
         const qreal scaleX = qAbs(painter->transform().m11());
         const qreal localToPhysical = scaleX * dpr;
 

--- a/src/ExcludeFromCaptureButton.h
+++ b/src/ExcludeFromCaptureButton.h
@@ -55,17 +55,8 @@ public:
         }
         button->setPenWidth(painter, 1.25 * KDecoration3::pixelSize(deco->window()->scale()));
 
-        const qreal scaleX = qAbs(painter->transform().m11());
-        const qreal localToPhysical = scaleX * dpr;
-
-        auto snapPoint = [localToPhysical](const QPointF &p) -> QPointF {
-            if (localToPhysical > 0.0) {
-                return QPointF(
-                    qRound(p.x() * localToPhysical) / localToPhysical,
-                    qRound(p.y() * localToPhysical) / localToPhysical
-                );
-            }
-            return p;
+        auto snapPoint = [button, painter, dpr](const QPointF &p) -> QPointF {
+            return button->snapPoint(painter, p, dpr);
         };
 
         // A spy hat (like view-private.svg icon)
@@ -85,12 +76,8 @@ public:
         painter->drawLine(snapPoint(QPointF(-6.2, -0.5)), snapPoint(QPointF(6.2, -0.5)));
 
         // Glasses' lenses
-        qreal rx = 2.3;
-        qreal ry = 2.3;
-        if (localToPhysical > 0.0) {
-            rx = qRound(rx * localToPhysical) / localToPhysical;
-            ry = qRound(ry * localToPhysical) / localToPhysical;
-        }
+        const qreal rx = button->snapValue(painter, 2.3, dpr);
+        const qreal ry = button->snapValue(painter, 2.3, dpr);
         painter->drawEllipse(snapPoint(QPointF(-4.0, 3.8)), rx, ry);
         painter->drawEllipse(snapPoint(QPointF(4.0, 3.8)), rx, ry);
 

--- a/src/ExcludeFromCaptureButton.h
+++ b/src/ExcludeFromCaptureButton.h
@@ -55,28 +55,48 @@ public:
         }
         button->setPenWidth(painter, 1.25 * KDecoration3::pixelSize(deco->window()->scale()));
 
+        const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : 1.0;
+        const qreal scaleX = qAbs(painter->transform().m11());
+        const qreal localToPhysical = scaleX * dpr;
+
+        auto snapPoint = [localToPhysical](const QPointF &p) -> QPointF {
+            if (localToPhysical > 0.0) {
+                return QPointF(
+                    qRound(p.x() * localToPhysical) / localToPhysical,
+                    qRound(p.y() * localToPhysical) / localToPhysical
+                );
+            }
+            return p;
+        };
+
         // A spy hat (like view-private.svg icon)
         // Hat crown with dip/crease at top (filled)
         const QVector<QPointF> crownPoints {
-            QPointF(-4.1, -2.5),
-            QPointF(-3.2, -6.1),
-            QPointF(0, -5),
-            QPointF(3.2, -6.1),
-            QPointF(4.1, -2.5)
+            snapPoint(QPointF(-4.1, -2.5)),
+            snapPoint(QPointF(-3.2, -6.1)),
+            snapPoint(QPointF(0, -5)),
+            snapPoint(QPointF(3.2, -6.1)),
+            snapPoint(QPointF(4.1, -2.5))
         };
         painter->setBrush(painter->pen().color());
         painter->drawPolygon(crownPoints);
         painter->setBrush(Qt::NoBrush);
 
         // Hat brim
-        painter->drawLine(QPointF(-6.2, -0.5), QPointF(6.2, -0.5));
+        painter->drawLine(snapPoint(QPointF(-6.2, -0.5)), snapPoint(QPointF(6.2, -0.5)));
 
         // Glasses' lenses
-        painter->drawEllipse(QPointF(-4, 3.8), 2.3, 2.3);
-        painter->drawEllipse(QPointF(4, 3.8), 2.3, 2.3);
+        qreal rx = 2.3;
+        qreal ry = 2.3;
+        if (localToPhysical > 0.0) {
+            rx = qRound(rx * localToPhysical) / localToPhysical;
+            ry = qRound(ry * localToPhysical) / localToPhysical;
+        }
+        painter->drawEllipse(snapPoint(QPointF(-4.0, 3.8)), rx, ry);
+        painter->drawEllipse(snapPoint(QPointF(4.0, 3.8)), rx, ry);
 
         // Bridge between lenses
-        painter->drawLine(QPointF(-1.5, 3.8), QPointF(1.5, 3.8));
+        painter->drawLine(snapPoint(QPointF(-1.5, 3.8)), snapPoint(QPointF(1.5, 3.8)));
     }
 };
 #endif

--- a/src/ExcludeFromCaptureButton.h
+++ b/src/ExcludeFromCaptureButton.h
@@ -56,34 +56,31 @@ public:
         button->setPenWidth(painter, 1.25 * KDecoration3::pixelSize(deco->window()->scale()));
 
         PixelSnapper snapper(painter, dpr);
-        auto snapPoint = [&snapper](const QPointF &p) -> QPointF {
-            return snapper.snap(p);
-        };
 
         // A spy hat (like view-private.svg icon)
         // Hat crown with dip/crease at top (filled)
         const QVector<QPointF> crownPoints {
-            snapPoint(QPointF(-4.1, -2.5)),
-            snapPoint(QPointF(-3.2, -6.1)),
-            snapPoint(QPointF(0, -5)),
-            snapPoint(QPointF(3.2, -6.1)),
-            snapPoint(QPointF(4.1, -2.5))
+            snapper.snap(QPointF(-4.1, -2.5)),
+            snapper.snap(QPointF(-3.2, -6.1)),
+            snapper.snap(QPointF(0, -5)),
+            snapper.snap(QPointF(3.2, -6.1)),
+            snapper.snap(QPointF(4.1, -2.5))
         };
         painter->setBrush(painter->pen().color());
         painter->drawPolygon(crownPoints);
         painter->setBrush(Qt::NoBrush);
 
         // Hat brim
-        painter->drawLine(snapPoint(QPointF(-6.2, -0.5)), snapPoint(QPointF(6.2, -0.5)));
+        painter->drawLine(snapper.snap(QPointF(-6.2, -0.5)), snapper.snap(QPointF(6.2, -0.5)));
 
         // Glasses' lenses
         const qreal rx = snapper.snapX(2.3);
         const qreal ry = snapper.snapY(2.3);
-        painter->drawEllipse(snapPoint(QPointF(-4.0, 3.8)), rx, ry);
-        painter->drawEllipse(snapPoint(QPointF(4.0, 3.8)), rx, ry);
+        painter->drawEllipse(snapper.snap(QPointF(-4.0, 3.8)), rx, ry);
+        painter->drawEllipse(snapper.snap(QPointF(4.0, 3.8)), rx, ry);
 
         // Bridge between lenses
-        painter->drawLine(snapPoint(QPointF(-1.5, 3.8)), snapPoint(QPointF(1.5, 3.8)));
+        painter->drawLine(snapper.snap(QPointF(-1.5, 3.8)), snapper.snap(QPointF(1.5, 3.8)));
     }
 };
 #endif

--- a/src/ExcludeFromCaptureButton.h
+++ b/src/ExcludeFromCaptureButton.h
@@ -72,10 +72,13 @@ public:
         painter->drawLine(snapper.snap(QPointF(-6.2, -0.5)), snapper.snap(QPointF(6.2, -0.5)));
 
         // Glasses' lenses
-        const qreal rx = snapper.snapX(2.3);
-        const qreal ry = snapper.snapY(2.3);
-        painter->drawEllipse(snapper.snap(QPointF(-4.0, 3.8)), rx, ry);
-        painter->drawEllipse(snapper.snap(QPointF(4.0, 3.8)), rx, ry);
+        const QPointF lensLeftTopLeft = snapper.snap(QPointF(-6.3, 1.5));
+        const QPointF lensLeftBottomRight = snapper.snap(QPointF(-1.7, 6.1));
+        painter->drawEllipse(QRectF(lensLeftTopLeft, lensLeftBottomRight));
+
+        const QPointF lensRightTopLeft = snapper.snap(QPointF(1.7, 1.5));
+        const QPointF lensRightBottomRight = snapper.snap(QPointF(6.3, 6.1));
+        painter->drawEllipse(QRectF(lensRightTopLeft, lensRightBottomRight));
 
         // Bridge between lenses
         painter->drawLine(snapper.snap(QPointF(-1.5, 3.8)), snapper.snap(QPointF(1.5, 3.8)));

--- a/src/KeepAboveButton.h
+++ b/src/KeepAboveButton.h
@@ -39,11 +39,9 @@ public:
 
         button->setVisible(true);
     }
-    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal dpr) {
+    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const PixelSnapper &snapper) {
         Q_UNUSED(iconRect)
         button->setPenWidth(painter, 1.25);
-
-        PixelSnapper snapper(painter, dpr);
 
         const QPointF offset(-5.0, -5.0);
         painter->drawPolyline(  QVector<QPointF> {

--- a/src/KeepAboveButton.h
+++ b/src/KeepAboveButton.h
@@ -44,21 +44,18 @@ public:
         button->setPenWidth(painter, 1.25);
 
         PixelSnapper snapper(painter, dpr);
-        auto snapPoint = [&snapper](const QPointF &p) -> QPointF {
-            return snapper.snap(p);
-        };
 
         const QPointF offset(-5.0, -5.0);
         painter->drawPolyline(  QVector<QPointF> {
-            snapPoint(QPointF( 0.0, 5.0 ) + offset),
-            snapPoint(QPointF( 5.0, 0.0 ) + offset),
-            snapPoint(QPointF( 10.0, 5.0 ) + offset)
+            snapper.snap(QPointF( 0.0, 5.0 ) + offset),
+            snapper.snap(QPointF( 5.0, 0.0 ) + offset),
+            snapper.snap(QPointF( 10.0, 5.0 ) + offset)
         });
 
         painter->drawPolyline(  QVector<QPointF> {
-            snapPoint(QPointF( 0.0, 10.0 ) + offset),
-            snapPoint(QPointF( 5.0, 5.0 ) + offset),
-            snapPoint(QPointF( 10.0, 10.0 ) + offset)
+            snapper.snap(QPointF( 0.0, 10.0 ) + offset),
+            snapper.snap(QPointF( 5.0, 5.0 ) + offset),
+            snapper.snap(QPointF( 10.0, 10.0 ) + offset)
         });
     }
 };

--- a/src/KeepAboveButton.h
+++ b/src/KeepAboveButton.h
@@ -43,17 +43,8 @@ public:
         Q_UNUSED(iconRect)
         button->setPenWidth(painter, 1.25);
 
-        const qreal scaleX = qAbs(painter->transform().m11());
-        const qreal localToPhysical = scaleX * dpr;
-
-        auto snapPoint = [localToPhysical](const QPointF &p) -> QPointF {
-            if (localToPhysical > 0.0) {
-                return QPointF(
-                    qRound(p.x() * localToPhysical) / localToPhysical,
-                    qRound(p.y() * localToPhysical) / localToPhysical
-                );
-            }
-            return p;
+        auto snapPoint = [button, painter, dpr](const QPointF &p) -> QPointF {
+            return button->snapPoint(painter, p, dpr);
         };
 
         const QPointF offset(-5.0, -5.0);

--- a/src/KeepAboveButton.h
+++ b/src/KeepAboveButton.h
@@ -39,11 +39,10 @@ public:
 
         button->setVisible(true);
     }
-    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal) {
+    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal dpr) {
         Q_UNUSED(iconRect)
         button->setPenWidth(painter, 1.25);
 
-        const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : 1.0;
         const qreal scaleX = qAbs(painter->transform().m11());
         const qreal localToPhysical = scaleX * dpr;
 
@@ -59,15 +58,15 @@ public:
 
         const QPointF offset(-5.0, -5.0);
         painter->drawPolyline(  QVector<QPointF> {
-            snapPoint(QPointF( 0.5, 4.75 ) + offset),
-            snapPoint(QPointF( 5.0, 0.25 ) + offset),
-            snapPoint(QPointF( 9.5, 4.75 ) + offset)
+            snapPoint(QPointF( 0.0, 5.0 ) + offset),
+            snapPoint(QPointF( 5.0, 0.0 ) + offset),
+            snapPoint(QPointF( 10.0, 5.0 ) + offset)
         });
 
         painter->drawPolyline(  QVector<QPointF> {
-            snapPoint(QPointF( 0.5, 9.75 ) + offset),
-            snapPoint(QPointF( 5.0, 5.25 ) + offset),
-            snapPoint(QPointF( 9.5, 9.75 ) + offset)
+            snapPoint(QPointF( 0.0, 10.0 ) + offset),
+            snapPoint(QPointF( 5.0, 5.0 ) + offset),
+            snapPoint(QPointF( 10.0, 10.0 ) + offset)
         });
     }
 };

--- a/src/KeepAboveButton.h
+++ b/src/KeepAboveButton.h
@@ -43,8 +43,9 @@ public:
         Q_UNUSED(iconRect)
         button->setPenWidth(painter, 1.25);
 
-        auto snapPoint = [button, painter, dpr](const QPointF &p) -> QPointF {
-            return button->snapPoint(painter, p, dpr);
+        PixelSnapper snapper(painter, dpr);
+        auto snapPoint = [&snapper](const QPointF &p) -> QPointF {
+            return snapper.snap(p);
         };
 
         const QPointF offset(-5.0, -5.0);

--- a/src/KeepAboveButton.h
+++ b/src/KeepAboveButton.h
@@ -43,17 +43,31 @@ public:
         Q_UNUSED(iconRect)
         button->setPenWidth(painter, 1.25);
 
-        const QPointF offset(-5, -5);
+        const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : 1.0;
+        const qreal scaleX = qAbs(painter->transform().m11());
+        const qreal localToPhysical = scaleX * dpr;
+
+        auto snapPoint = [localToPhysical](const QPointF &p) -> QPointF {
+            if (localToPhysical > 0.0) {
+                return QPointF(
+                    qRound(p.x() * localToPhysical) / localToPhysical,
+                    qRound(p.y() * localToPhysical) / localToPhysical
+                );
+            }
+            return p;
+        };
+
+        const QPointF offset(-5.0, -5.0);
         painter->drawPolyline(  QVector<QPointF> {
-            QPointF( 0.5, 4.75 ) + offset,
-            QPointF( 5.0, 0.25 ) + offset,
-            QPointF( 9.5, 4.75 ) + offset
+            snapPoint(QPointF( 0.5, 4.75 ) + offset),
+            snapPoint(QPointF( 5.0, 0.25 ) + offset),
+            snapPoint(QPointF( 9.5, 4.75 ) + offset)
         });
 
         painter->drawPolyline(  QVector<QPointF> {
-            QPointF( 0.5, 9.75 ) + offset,
-            QPointF( 5.0, 5.25 ) + offset,
-            QPointF( 9.5, 9.75 ) + offset
+            snapPoint(QPointF( 0.5, 9.75 ) + offset),
+            snapPoint(QPointF( 5.0, 5.25 ) + offset),
+            snapPoint(QPointF( 9.5, 9.75 ) + offset)
         });
     }
 };

--- a/src/KeepBelowButton.h
+++ b/src/KeepBelowButton.h
@@ -39,11 +39,9 @@ public:
 
         button->setVisible(true);
     }
-    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal dpr) {
+    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const PixelSnapper &snapper) {
         Q_UNUSED(iconRect)
         button->setPenWidth(painter, 1.25);
-
-        PixelSnapper snapper(painter, dpr);
 
         const QPointF offset(-5.0, -5.0);
         painter->drawPolyline(  QVector<QPointF> {

--- a/src/KeepBelowButton.h
+++ b/src/KeepBelowButton.h
@@ -43,17 +43,31 @@ public:
         Q_UNUSED(iconRect)
         button->setPenWidth(painter, 1.25);
 
-        const QPointF offset(-5, -5);
+        const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : 1.0;
+        const qreal scaleX = qAbs(painter->transform().m11());
+        const qreal localToPhysical = scaleX * dpr;
+
+        auto snapPoint = [localToPhysical](const QPointF &p) -> QPointF {
+            if (localToPhysical > 0.0) {
+                return QPointF(
+                    qRound(p.x() * localToPhysical) / localToPhysical,
+                    qRound(p.y() * localToPhysical) / localToPhysical
+                );
+            }
+            return p;
+        };
+
+        const QPointF offset(-5.0, -5.0);
         painter->drawPolyline(  QVector<QPointF> {
-            QPointF( 0.5, 0.25 ) + offset,
-            QPointF( 5.0, 4.75 ) + offset,
-            QPointF( 9.5, 0.25 ) + offset
+            snapPoint(QPointF( 0.5, 0.25 ) + offset),
+            snapPoint(QPointF( 5.0, 4.75 ) + offset),
+            snapPoint(QPointF( 9.5, 0.25 ) + offset)
         });
 
         painter->drawPolyline(  QVector<QPointF> {
-            QPointF( 0.5, 5.25 ) + offset,
-            QPointF( 5.0, 9.75 ) + offset,
-            QPointF( 9.5, 5.25 ) + offset
+            snapPoint(QPointF( 0.5, 5.25 ) + offset),
+            snapPoint(QPointF( 5.0, 9.75 ) + offset),
+            snapPoint(QPointF( 9.5, 5.25 ) + offset)
         });
     }
 };

--- a/src/KeepBelowButton.h
+++ b/src/KeepBelowButton.h
@@ -44,21 +44,18 @@ public:
         button->setPenWidth(painter, 1.25);
 
         PixelSnapper snapper(painter, dpr);
-        auto snapPoint = [&snapper](const QPointF &p) -> QPointF {
-            return snapper.snap(p);
-        };
 
         const QPointF offset(-5.0, -5.0);
         painter->drawPolyline(  QVector<QPointF> {
-            snapPoint(QPointF( 0.0, 0.0 ) + offset),
-            snapPoint(QPointF( 5.0, 5.0 ) + offset),
-            snapPoint(QPointF( 10.0, 0.0 ) + offset)
+            snapper.snap(QPointF( 0.0, 0.0 ) + offset),
+            snapper.snap(QPointF( 5.0, 5.0 ) + offset),
+            snapper.snap(QPointF( 10.0, 0.0 ) + offset)
         });
 
         painter->drawPolyline(  QVector<QPointF> {
-            snapPoint(QPointF( 0.0, 5.0 ) + offset),
-            snapPoint(QPointF( 5.0, 10.0 ) + offset),
-            snapPoint(QPointF( 10.0, 5.0 ) + offset)
+            snapper.snap(QPointF( 0.0, 5.0 ) + offset),
+            snapper.snap(QPointF( 5.0, 10.0 ) + offset),
+            snapper.snap(QPointF( 10.0, 5.0 ) + offset)
         });
     }
 };

--- a/src/KeepBelowButton.h
+++ b/src/KeepBelowButton.h
@@ -43,17 +43,8 @@ public:
         Q_UNUSED(iconRect)
         button->setPenWidth(painter, 1.25);
 
-        const qreal scaleX = qAbs(painter->transform().m11());
-        const qreal localToPhysical = scaleX * dpr;
-
-        auto snapPoint = [localToPhysical](const QPointF &p) -> QPointF {
-            if (localToPhysical > 0.0) {
-                return QPointF(
-                    qRound(p.x() * localToPhysical) / localToPhysical,
-                    qRound(p.y() * localToPhysical) / localToPhysical
-                );
-            }
-            return p;
+        auto snapPoint = [button, painter, dpr](const QPointF &p) -> QPointF {
+            return button->snapPoint(painter, p, dpr);
         };
 
         const QPointF offset(-5.0, -5.0);

--- a/src/KeepBelowButton.h
+++ b/src/KeepBelowButton.h
@@ -43,8 +43,9 @@ public:
         Q_UNUSED(iconRect)
         button->setPenWidth(painter, 1.25);
 
-        auto snapPoint = [button, painter, dpr](const QPointF &p) -> QPointF {
-            return button->snapPoint(painter, p, dpr);
+        PixelSnapper snapper(painter, dpr);
+        auto snapPoint = [&snapper](const QPointF &p) -> QPointF {
+            return snapper.snap(p);
         };
 
         const QPointF offset(-5.0, -5.0);

--- a/src/KeepBelowButton.h
+++ b/src/KeepBelowButton.h
@@ -39,11 +39,10 @@ public:
 
         button->setVisible(true);
     }
-    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal) {
+    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal dpr) {
         Q_UNUSED(iconRect)
         button->setPenWidth(painter, 1.25);
 
-        const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : 1.0;
         const qreal scaleX = qAbs(painter->transform().m11());
         const qreal localToPhysical = scaleX * dpr;
 
@@ -59,15 +58,15 @@ public:
 
         const QPointF offset(-5.0, -5.0);
         painter->drawPolyline(  QVector<QPointF> {
-            snapPoint(QPointF( 0.5, 0.25 ) + offset),
-            snapPoint(QPointF( 5.0, 4.75 ) + offset),
-            snapPoint(QPointF( 9.5, 0.25 ) + offset)
+            snapPoint(QPointF( 0.0, 0.0 ) + offset),
+            snapPoint(QPointF( 5.0, 5.0 ) + offset),
+            snapPoint(QPointF( 10.0, 0.0 ) + offset)
         });
 
         painter->drawPolyline(  QVector<QPointF> {
-            snapPoint(QPointF( 0.5, 5.25 ) + offset),
-            snapPoint(QPointF( 5.0, 9.75 ) + offset),
-            snapPoint(QPointF( 9.5, 5.25 ) + offset)
+            snapPoint(QPointF( 0.0, 5.0 ) + offset),
+            snapPoint(QPointF( 5.0, 10.0 ) + offset),
+            snapPoint(QPointF( 10.0, 5.0 ) + offset)
         });
     }
 };

--- a/src/MaximizeButton.h
+++ b/src/MaximizeButton.h
@@ -41,10 +41,29 @@ public:
     }
     static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal) {
         Q_UNUSED(iconRect)
-        const QRectF innerRect(-5, -5, 10, 10);
         button->setPenWidth(painter, 1.5);
+
+        const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : 1.0;
+        const qreal scaleX = qAbs(painter->transform().m11());
+        const qreal localToPhysical = scaleX * dpr;
+
+        qreal x = -5.0;
+        qreal y = -5.0;
+        qreal w = 10.0;
+        qreal h = 10.0;
+        if (localToPhysical > 0.0) {
+            x = qRound(x * localToPhysical) / localToPhysical;
+            y = qRound(y * localToPhysical) / localToPhysical;
+            w = qRound(w * localToPhysical) / localToPhysical;
+            h = qRound(h * localToPhysical) / localToPhysical;
+        }
+        const QRectF innerRect(x, y, w, h);
+
         if (button->isChecked()) {
-            const int offset = 2;
+            qreal offset = 2.0;
+            if (localToPhysical > 0.0) {
+                offset = qRound(offset * localToPhysical) / localToPhysical;
+            }
             // Outline of first square, "on top", aligned bottom left.
             painter->drawPolygon(QVector<QPointF> {
                 innerRect.bottomLeft(),

--- a/src/MaximizeButton.h
+++ b/src/MaximizeButton.h
@@ -44,10 +44,10 @@ public:
         button->setPenWidth(painter, 1.5);
 
         PixelSnapper snapper(painter, dpr);
-        const qreal x = snapper.snap(-5.0);
-        const qreal y = snapper.snap(-5.0);
-        const qreal w = snapper.snap(10.0);
-        const qreal h = snapper.snap(10.0);
+        const qreal x = snapper.snapX(-5.0);
+        const qreal y = snapper.snapY(-5.0);
+        const qreal w = snapper.snapX(10.0);
+        const qreal h = snapper.snapY(10.0);
         const QRectF innerRect(x, y, w, h);
 
         if (button->isChecked()) {

--- a/src/MaximizeButton.h
+++ b/src/MaximizeButton.h
@@ -43,31 +43,28 @@ public:
         Q_UNUSED(iconRect)
         button->setPenWidth(painter, 1.5);
 
-        const qreal x = snapper.snapX(-5.0);
-        const qreal y = snapper.snapY(-5.0);
-        const qreal w = snapper.snapX(10.0);
-        const qreal h = snapper.snapY(10.0);
-        const QRectF innerRect(x, y, w, h);
-
         if (button->isChecked()) {
             const qreal offset = painter->pen().widthF() * 1.5;
             // Outline of first square, "on top", aligned bottom left.
             painter->drawPolygon(QVector<QPointF> {
-                innerRect.bottomLeft(),
-                innerRect.topLeft() + QPointF(0, offset),
-                innerRect.topRight() + QPointF(-offset, offset),
-                innerRect.bottomRight() + QPointF(-offset, 0)
+                snapper.snap(QPointF(-5.0, 5.0)),
+                snapper.snap(QPointF(-5.0, -5.0 + offset)),
+                snapper.snap(QPointF(5.0 - offset, -5.0 + offset)),
+                snapper.snap(QPointF(5.0 - offset, 5.0))
             });
 
             // Partially occluded square, "below" first square, aligned top right.
             painter->drawPolyline(QVector<QPointF> {
-                innerRect.topLeft() + QPointF(offset, offset),
-                innerRect.topLeft() + QPointF(offset, 0),
-                innerRect.topRight(),
-                innerRect.bottomRight() + QPointF(0, -offset),
-                innerRect.bottomRight() + QPointF(-offset, -offset)
+                snapper.snap(QPointF(-5.0 + offset, -5.0 + offset)),
+                snapper.snap(QPointF(-5.0 + offset, -5.0)),
+                snapper.snap(QPointF(5.0, -5.0)),
+                snapper.snap(QPointF(5.0, 5.0 - offset)),
+                snapper.snap(QPointF(5.0 - offset, 5.0 - offset))
             });
         } else {
+            const QPointF topLeft = snapper.snap(QPointF(-5.0, -5.0));
+            const QPointF bottomRight = snapper.snap(QPointF(5.0, 5.0));
+            const QRectF innerRect(topLeft, bottomRight);
             painter->drawRect(innerRect);
         }
     }

--- a/src/MaximizeButton.h
+++ b/src/MaximizeButton.h
@@ -43,26 +43,14 @@ public:
         Q_UNUSED(iconRect)
         button->setPenWidth(painter, 1.5);
 
-        const qreal scaleX = qAbs(painter->transform().m11());
-        const qreal localToPhysical = scaleX * dpr;
-
-        qreal x = -5.0;
-        qreal y = -5.0;
-        qreal w = 10.0;
-        qreal h = 10.0;
-        if (localToPhysical > 0.0) {
-            x = qRound(x * localToPhysical) / localToPhysical;
-            y = qRound(y * localToPhysical) / localToPhysical;
-            w = qRound(w * localToPhysical) / localToPhysical;
-            h = qRound(h * localToPhysical) / localToPhysical;
-        }
+        const qreal x = button->snapValue(painter, -5.0, dpr);
+        const qreal y = button->snapValue(painter, -5.0, dpr);
+        const qreal w = button->snapValue(painter, 10.0, dpr);
+        const qreal h = button->snapValue(painter, 10.0, dpr);
         const QRectF innerRect(x, y, w, h);
 
         if (button->isChecked()) {
-            qreal offset = 2.0;
-            if (localToPhysical > 0.0) {
-                offset = qRound(offset * localToPhysical) / localToPhysical;
-            }
+            const qreal offset = button->snapValue(painter, 2.0, dpr);
             // Outline of first square, "on top", aligned bottom left.
             painter->drawPolygon(QVector<QPointF> {
                 innerRect.bottomLeft(),

--- a/src/MaximizeButton.h
+++ b/src/MaximizeButton.h
@@ -39,11 +39,10 @@ public:
 
         button->setVisible(decoratedClient->isMaximizeable());
     }
-    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal) {
+    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal dpr) {
         Q_UNUSED(iconRect)
         button->setPenWidth(painter, 1.5);
 
-        const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : 1.0;
         const qreal scaleX = qAbs(painter->transform().m11());
         const qreal localToPhysical = scaleX * dpr;
 

--- a/src/MaximizeButton.h
+++ b/src/MaximizeButton.h
@@ -50,7 +50,7 @@ public:
         const QRectF innerRect(x, y, w, h);
 
         if (button->isChecked()) {
-            const qreal offset = button->snapValue(painter, 2.0, dpr);
+            const qreal offset = painter->pen().widthF() * 1.5;
             // Outline of first square, "on top", aligned bottom left.
             painter->drawPolygon(QVector<QPointF> {
                 innerRect.bottomLeft(),

--- a/src/MaximizeButton.h
+++ b/src/MaximizeButton.h
@@ -39,11 +39,10 @@ public:
 
         button->setVisible(decoratedClient->isMaximizeable());
     }
-    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal dpr) {
+    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const PixelSnapper &snapper) {
         Q_UNUSED(iconRect)
         button->setPenWidth(painter, 1.5);
 
-        PixelSnapper snapper(painter, dpr);
         const qreal x = snapper.snapX(-5.0);
         const qreal y = snapper.snapY(-5.0);
         const qreal w = snapper.snapX(10.0);

--- a/src/MaximizeButton.h
+++ b/src/MaximizeButton.h
@@ -43,10 +43,11 @@ public:
         Q_UNUSED(iconRect)
         button->setPenWidth(painter, 1.5);
 
-        const qreal x = button->snapValue(painter, -5.0, dpr);
-        const qreal y = button->snapValue(painter, -5.0, dpr);
-        const qreal w = button->snapValue(painter, 10.0, dpr);
-        const qreal h = button->snapValue(painter, 10.0, dpr);
+        PixelSnapper snapper(painter, dpr);
+        const qreal x = snapper.snap(-5.0);
+        const qreal y = snapper.snap(-5.0);
+        const qreal w = snapper.snap(10.0);
+        const qreal h = snapper.snap(10.0);
         const QRectF innerRect(x, y, w, h);
 
         if (button->isChecked()) {

--- a/src/MenuOverflowButton.cc
+++ b/src/MenuOverflowButton.cc
@@ -41,9 +41,9 @@ MenuOverflowButton::~MenuOverflowButton()
 {
 }
 
-void MenuOverflowButton::paintIcon(QPainter *painter, const QRectF &iconRect, const qreal)
+void MenuOverflowButton::paintIcon(QPainter *painter, const QRectF &iconRect, const PixelSnapper &snapper)
 {
-    ApplicationMenuButton::paintIcon(this, painter, iconRect, 0);
+    ApplicationMenuButton::paintIcon(this, painter, iconRect, snapper);
 }
 
 } // namespace Material

--- a/src/MenuOverflowButton.h
+++ b/src/MenuOverflowButton.h
@@ -34,7 +34,7 @@ public:
     MenuOverflowButton(Decoration *decoration, const int buttonIndex, QObject *parent = nullptr);
     ~MenuOverflowButton() override;
 
-    void paintIcon(QPainter *painter, const QRectF &iconRect, const qreal) override;
+    void paintIcon(QPainter *painter, const QRectF &iconRect, const PixelSnapper &snapper) override;
 };
 
 } // namespace Material

--- a/src/MinimizeButton.h
+++ b/src/MinimizeButton.h
@@ -39,12 +39,11 @@ public:
 
         button->setVisible(decoratedClient->isMinimizeable());
     }
-    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal) {
+    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal dpr) {
         Q_UNUSED(iconRect)
         
         button->setPenWidth(painter, 1.75);
 
-        const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : 1.0;
         const qreal scaleX = qAbs(painter->transform().m11());
         const qreal localToPhysical = scaleX * dpr;
 

--- a/src/MinimizeButton.h
+++ b/src/MinimizeButton.h
@@ -44,7 +44,8 @@ public:
         
         button->setPenWidth(painter, 1.75);
 
-        const qreal s = button->snapValue(painter, 5.0, dpr);
+        PixelSnapper snapper(painter, dpr);
+        const qreal s = snapper.snap(5.0);
 
         painter->drawLine(QPointF(-s, 0), QPointF(s, 0));
     }

--- a/src/MinimizeButton.h
+++ b/src/MinimizeButton.h
@@ -39,15 +39,15 @@ public:
 
         button->setVisible(decoratedClient->isMinimizeable());
     }
-    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal dpr) {
+    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const PixelSnapper &snapper) {
         Q_UNUSED(iconRect)
         
         button->setPenWidth(painter, 1.75);
 
-        PixelSnapper snapper(painter, dpr);
-        const qreal s = snapper.snapX(5.0);
+        const QPointF p1 = snapper.snap(QPointF(-5.0, 0.0));
+        const QPointF p2 = snapper.snap(QPointF(5.0, 0.0));
 
-        painter->drawLine(QPointF(-s, 0), QPointF(s, 0));
+        painter->drawLine(p1, p2);
     }
 };
 

--- a/src/MinimizeButton.h
+++ b/src/MinimizeButton.h
@@ -44,13 +44,7 @@ public:
         
         button->setPenWidth(painter, 1.75);
 
-        const qreal scaleX = qAbs(painter->transform().m11());
-        const qreal localToPhysical = scaleX * dpr;
-
-        qreal s = 5.0;
-        if (localToPhysical > 0.0) {
-            s = qRound(s * localToPhysical) / localToPhysical;
-        }
+        const qreal s = button->snapValue(painter, 5.0, dpr);
 
         painter->drawLine(QPointF(-s, 0), QPointF(s, 0));
     }

--- a/src/MinimizeButton.h
+++ b/src/MinimizeButton.h
@@ -45,7 +45,7 @@ public:
         button->setPenWidth(painter, 1.75);
 
         PixelSnapper snapper(painter, dpr);
-        const qreal s = snapper.snap(5.0);
+        const qreal s = snapper.snapX(5.0);
 
         painter->drawLine(QPointF(-s, 0), QPointF(s, 0));
     }

--- a/src/MinimizeButton.h
+++ b/src/MinimizeButton.h
@@ -40,11 +40,20 @@ public:
         button->setVisible(decoratedClient->isMinimizeable());
     }
     static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal) {
-        //Q_UNUSED(button)
         Q_UNUSED(iconRect)
         
         button->setPenWidth(painter, 1.75);
-        painter->drawLine(QPointF(-5, 0), QPointF(5, 0));
+
+        const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : 1.0;
+        const qreal scaleX = qAbs(painter->transform().m11());
+        const qreal localToPhysical = scaleX * dpr;
+
+        qreal s = 5.0;
+        if (localToPhysical > 0.0) {
+            s = qRound(s * localToPhysical) / localToPhysical;
+        }
+
+        painter->drawLine(QPointF(-s, 0), QPointF(s, 0));
     }
 };
 

--- a/src/OnAllDesktopsButton.h
+++ b/src/OnAllDesktopsButton.h
@@ -44,13 +44,7 @@ public:
         //painter->setRenderHints(QPainter::Antialiasing, true);
         button->setPenWidth(painter, 1.25);
 
-        const qreal scaleX = qAbs(painter->transform().m11());
-        const qreal localToPhysical = scaleX * dpr;
-
-        qreal radius = 6.0;
-        if (localToPhysical > 0.0) {
-            radius = qRound(radius * localToPhysical) / localToPhysical;
-        }
+        const qreal radius = button->snapValue(painter, 6.0, dpr);
 
         painter->drawPolygon( QVector<QPointF> {
             QPointF(-radius, 0),

--- a/src/OnAllDesktopsButton.h
+++ b/src/OnAllDesktopsButton.h
@@ -39,12 +39,11 @@ public:
 
         button->setVisible(true);
     }
-    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal) {
+    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal dpr) {
         Q_UNUSED(iconRect)
         //painter->setRenderHints(QPainter::Antialiasing, true);
         button->setPenWidth(painter, 1.25);
 
-        const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : 1.0;
         const qreal scaleX = qAbs(painter->transform().m11());
         const qreal localToPhysical = scaleX * dpr;
 

--- a/src/OnAllDesktopsButton.h
+++ b/src/OnAllDesktopsButton.h
@@ -44,7 +44,7 @@ public:
         button->setPenWidth(painter, 1.25);
 
         PixelSnapper snapper(painter, dpr);
-        const qreal radius = snapper.snap(6.0);
+        const qreal radius = snapper.snapX(6.0);
 
         painter->drawPolygon( QVector<QPointF> {
             QPointF(-radius, 0),

--- a/src/OnAllDesktopsButton.h
+++ b/src/OnAllDesktopsButton.h
@@ -39,18 +39,15 @@ public:
 
         button->setVisible(true);
     }
-    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal dpr) {
+    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const PixelSnapper &snapper) {
         Q_UNUSED(iconRect)
         button->setPenWidth(painter, 1.25);
 
-        PixelSnapper snapper(painter, dpr);
-        const qreal radius = snapper.snapX(6.0);
-
         painter->drawPolygon( QVector<QPointF> {
-            QPointF(-radius, 0),
-            QPointF(0, -radius),
-            QPointF(radius, 0),
-            QPointF(0, radius)
+            snapper.snap(QPointF(-6.0, 0.0)),
+            snapper.snap(QPointF(0.0, -6.0)),
+            snapper.snap(QPointF(6.0, 0.0)),
+            snapper.snap(QPointF(0.0, 6.0))
         });
     }
 };

--- a/src/OnAllDesktopsButton.h
+++ b/src/OnAllDesktopsButton.h
@@ -41,10 +41,10 @@ public:
     }
     static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal dpr) {
         Q_UNUSED(iconRect)
-        //painter->setRenderHints(QPainter::Antialiasing, true);
         button->setPenWidth(painter, 1.25);
 
-        const qreal radius = button->snapValue(painter, 6.0, dpr);
+        PixelSnapper snapper(painter, dpr);
+        const qreal radius = snapper.snap(6.0);
 
         painter->drawPolygon( QVector<QPointF> {
             QPointF(-radius, 0),

--- a/src/OnAllDesktopsButton.h
+++ b/src/OnAllDesktopsButton.h
@@ -44,7 +44,15 @@ public:
         //painter->setRenderHints(QPainter::Antialiasing, true);
         button->setPenWidth(painter, 1.25);
 
-        const int radius = 6;
+        const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : 1.0;
+        const qreal scaleX = qAbs(painter->transform().m11());
+        const qreal localToPhysical = scaleX * dpr;
+
+        qreal radius = 6.0;
+        if (localToPhysical > 0.0) {
+            radius = qRound(radius * localToPhysical) / localToPhysical;
+        }
+
         painter->drawPolygon( QVector<QPointF> {
             QPointF(-radius, 0),
             QPointF(0, -radius),

--- a/src/PixelSnapper.cc
+++ b/src/PixelSnapper.cc
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2025 Guido Iodice <guido[dot]iodice[at]gmail[dot]com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "PixelSnapper.h"
+#include <QPainter>
+#include <cmath>
+
+namespace Material
+{
+
+PixelSnapper::PixelSnapper(QPainter *painter, const qreal dpr)
+    : m_trans(painter->transform())
+    , m_dpr(dpr)
+    , m_invertible(false)
+{
+    m_inv = m_trans.inverted(&m_invertible);
+}
+
+QPointF PixelSnapper::snap(const QPointF &p) const
+{
+    if (m_dpr > 0.0 && m_invertible) {
+        const QPointF devInd = m_trans.map(p);
+        const QPointF phys(devInd.x() * m_dpr, devInd.y() * m_dpr);
+        const QPointF physSnapped(qRound(phys.x()), qRound(phys.y()));
+        const QPointF devIndSnapped(physSnapped.x() / m_dpr, physSnapped.y() / m_dpr);
+        return m_inv.map(devIndSnapped);
+    }
+    return p;
+}
+
+qreal PixelSnapper::snapX(const qreal v) const
+{
+    const QPointF p0 = snap(QPointF(0.0, 0.0));
+    const QPointF pV = snap(QPointF(v, 0.0));
+    const qreal len = std::hypot(pV.x() - p0.x(), pV.y() - p0.y());
+    return (v < 0.0) ? -len : len;
+}
+
+qreal PixelSnapper::snapY(const qreal v) const
+{
+    const QPointF p0 = snap(QPointF(0.0, 0.0));
+    const QPointF pV = snap(QPointF(0.0, v));
+    const qreal len = std::hypot(pV.x() - p0.x(), pV.y() - p0.y());
+    return (v < 0.0) ? -len : len;
+}
+
+qreal PixelSnapper::snap(const qreal v) const
+{
+    return snapX(v);
+}
+
+qreal PixelSnapper::localToPhysicalScale() const
+{
+    return std::hypot(m_trans.m11(), m_trans.m12()) * m_dpr;
+}
+
+} // namespace Material

--- a/src/PixelSnapper.cc
+++ b/src/PixelSnapper.cc
@@ -42,25 +42,12 @@ QPointF PixelSnapper::snap(const QPointF &p) const
     return p;
 }
 
-qreal PixelSnapper::snapX(const qreal v) const
-{
-    const QPointF p0 = snap(QPointF(0.0, 0.0));
-    const QPointF pV = snap(QPointF(v, 0.0));
-    const qreal len = std::hypot(pV.x() - p0.x(), pV.y() - p0.y());
-    return (v < 0.0) ? -len : len;
-}
-
-qreal PixelSnapper::snapY(const qreal v) const
-{
-    const QPointF p0 = snap(QPointF(0.0, 0.0));
-    const QPointF pV = snap(QPointF(0.0, v));
-    const qreal len = std::hypot(pV.x() - p0.x(), pV.y() - p0.y());
-    return (v < 0.0) ? -len : len;
-}
-
 qreal PixelSnapper::snap(const qreal v) const
 {
-    return snapX(v);
+    if (m_dpr > 0.0) {
+        return qRound(v * m_dpr) / m_dpr;
+    }
+    return v;
 }
 
 qreal PixelSnapper::localToPhysicalScale() const

--- a/src/PixelSnapper.h
+++ b/src/PixelSnapper.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2025 Guido Iodice <guido[dot]iodice[at]gmail[dot]com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QTransform>
+#include <QPointF>
+
+class QPainter;
+
+namespace Material
+{
+
+class PixelSnapper
+{
+public:
+    PixelSnapper(QPainter *painter, const qreal dpr);
+
+    QPointF snap(const QPointF &p) const;
+    qreal snap(const qreal v) const;
+    qreal snapX(const qreal v) const;
+    qreal snapY(const qreal v) const;
+    qreal localToPhysicalScale() const;
+
+private:
+    QTransform m_trans;
+    QTransform m_inv;
+    qreal m_dpr;
+    bool m_invertible;
+};
+
+} // namespace Material

--- a/src/PixelSnapper.h
+++ b/src/PixelSnapper.h
@@ -35,6 +35,7 @@ public:
     qreal snapX(const qreal v) const;
     qreal snapY(const qreal v) const;
     qreal localToPhysicalScale() const;
+    qreal dpr() const { return m_dpr; }
 
 private:
     QTransform m_trans;

--- a/src/PixelSnapper.h
+++ b/src/PixelSnapper.h
@@ -32,8 +32,6 @@ public:
 
     QPointF snap(const QPointF &p) const;
     qreal snap(const qreal v) const;
-    qreal snapX(const qreal v) const;
-    qreal snapY(const qreal v) const;
     qreal localToPhysicalScale() const;
     qreal dpr() const { return m_dpr; }
 

--- a/src/SearchButton.cc
+++ b/src/SearchButton.cc
@@ -32,13 +32,12 @@ SearchButton::SearchButton(Decoration *decoration, const int buttonIndex, QObjec
 
 SearchButton::~SearchButton() = default;
 
-void SearchButton::paintIcon(QPainter *painter, const QRectF &iconRect, const qreal)
+void SearchButton::paintIcon(QPainter *painter, const QRectF &iconRect, const qreal dpr)
 {
     Q_UNUSED(iconRect)
     //painter->setRenderHint(QPainter::Antialiasing, true);
     setPenWidth(painter, 1.25);
 
-    const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : 1.0;
     const qreal scaleX = qAbs(painter->transform().m11());
     const qreal localToPhysical = scaleX * dpr;
 

--- a/src/SearchButton.cc
+++ b/src/SearchButton.cc
@@ -38,16 +38,21 @@ void SearchButton::paintIcon(QPainter *painter, const QRectF &iconRect, const Pi
     //painter->setRenderHint(QPainter::Antialiasing, true);
     setPenWidth(painter, 1.25);
 
-    const qreal circleRadius = snapper.snapX(4.0);
-    const QPointF circleCenter = snapper.snap(QPointF(-2.0, -2.0));
-    painter->drawEllipse(circleCenter, circleRadius, circleRadius);
+    const QPointF circleTopLeft = snapper.snap(QPointF(-6.0, -6.0));
+    const QPointF circleBottomRight = snapper.snap(QPointF(2.0, 2.0));
+    const QRectF circleRect(circleTopLeft, circleBottomRight);
+    painter->drawEllipse(circleRect);
 
+    const qreal sqrt2 = std::sqrt(2.0);
+    const qreal radius = 4.0;
     const qreal handleLength = 5.0;
-    const qreal sqrt2 = qSqrt(2.0);
-    const qreal handleAttachOffset = circleRadius / sqrt2;
-    const QPointF handleStart = snapper.snap(circleCenter + QPointF(handleAttachOffset, handleAttachOffset));
-    const qreal handleEndOffset = (circleRadius + handleLength) / sqrt2;
-    const QPointF handleEnd = snapper.snap(circleCenter + QPointF(handleEndOffset, handleEndOffset));
+
+    const QPointF center(-2.0, -2.0);
+    const QPointF startLogical = center + QPointF(radius / sqrt2, radius / sqrt2);
+    const QPointF endLogical = center + QPointF((radius + handleLength) / sqrt2, (radius + handleLength) / sqrt2);
+
+    const QPointF handleStart = snapper.snap(startLogical);
+    const QPointF handleEnd = snapper.snap(endLogical);
     painter->drawLine(handleStart, handleEnd);
 }
 

--- a/src/SearchButton.cc
+++ b/src/SearchButton.cc
@@ -38,11 +38,12 @@ void SearchButton::paintIcon(QPainter *painter, const QRectF &iconRect, const qr
     //painter->setRenderHint(QPainter::Antialiasing, true);
     setPenWidth(painter, 1.25);
 
-    auto snapPoint = [this, painter, dpr](const QPointF &p) -> QPointF {
-        return this->snapPoint(painter, p, dpr);
+    PixelSnapper snapper(painter, dpr);
+    auto snapPoint = [&snapper](const QPointF &p) -> QPointF {
+        return snapper.snap(p);
     };
 
-    const qreal circleRadius = snapValue(painter, 4.0, dpr);
+    const qreal circleRadius = snapper.snap(4.0);
     const QPointF circleCenter = snapPoint(QPointF(-2.0, -2.0));
     painter->drawEllipse(circleCenter, circleRadius, circleRadius);
 

--- a/src/SearchButton.cc
+++ b/src/SearchButton.cc
@@ -43,7 +43,7 @@ void SearchButton::paintIcon(QPainter *painter, const QRectF &iconRect, const qr
         return snapper.snap(p);
     };
 
-    const qreal circleRadius = snapper.snap(4.0);
+    const qreal circleRadius = snapper.snapX(4.0);
     const QPointF circleCenter = snapPoint(QPointF(-2.0, -2.0));
     painter->drawEllipse(circleCenter, circleRadius, circleRadius);
 

--- a/src/SearchButton.cc
+++ b/src/SearchButton.cc
@@ -38,23 +38,11 @@ void SearchButton::paintIcon(QPainter *painter, const QRectF &iconRect, const qr
     //painter->setRenderHint(QPainter::Antialiasing, true);
     setPenWidth(painter, 1.25);
 
-    const qreal scaleX = qAbs(painter->transform().m11());
-    const qreal localToPhysical = scaleX * dpr;
-
-    auto snapPoint = [localToPhysical](const QPointF &p) -> QPointF {
-        if (localToPhysical > 0.0) {
-            return QPointF(
-                qRound(p.x() * localToPhysical) / localToPhysical,
-                qRound(p.y() * localToPhysical) / localToPhysical
-            );
-        }
-        return p;
+    auto snapPoint = [this, painter, dpr](const QPointF &p) -> QPointF {
+        return this->snapPoint(painter, p, dpr);
     };
 
-    qreal circleRadius = 4.0;
-    if (localToPhysical > 0.0) {
-        circleRadius = qRound(circleRadius * localToPhysical) / localToPhysical;
-    }
+    const qreal circleRadius = snapValue(painter, 4.0, dpr);
     const QPointF circleCenter = snapPoint(QPointF(-2.0, -2.0));
     painter->drawEllipse(circleCenter, circleRadius, circleRadius);
 

--- a/src/SearchButton.cc
+++ b/src/SearchButton.cc
@@ -32,13 +32,11 @@ SearchButton::SearchButton(Decoration *decoration, const int buttonIndex, QObjec
 
 SearchButton::~SearchButton() = default;
 
-void SearchButton::paintIcon(QPainter *painter, const QRectF &iconRect, const qreal dpr)
+void SearchButton::paintIcon(QPainter *painter, const QRectF &iconRect, const PixelSnapper &snapper)
 {
     Q_UNUSED(iconRect)
     //painter->setRenderHint(QPainter::Antialiasing, true);
     setPenWidth(painter, 1.25);
-
-    PixelSnapper snapper(painter, dpr);
 
     const qreal circleRadius = snapper.snapX(4.0);
     const QPointF circleCenter = snapper.snap(QPointF(-2.0, -2.0));

--- a/src/SearchButton.cc
+++ b/src/SearchButton.cc
@@ -38,16 +38,33 @@ void SearchButton::paintIcon(QPainter *painter, const QRectF &iconRect, const qr
     //painter->setRenderHint(QPainter::Antialiasing, true);
     setPenWidth(painter, 1.25);
 
-    const qreal circleRadius = 4.0;
-    const QPointF circleCenter(-2, -2);
+    const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : 1.0;
+    const qreal scaleX = qAbs(painter->transform().m11());
+    const qreal localToPhysical = scaleX * dpr;
+
+    auto snapPoint = [localToPhysical](const QPointF &p) -> QPointF {
+        if (localToPhysical > 0.0) {
+            return QPointF(
+                qRound(p.x() * localToPhysical) / localToPhysical,
+                qRound(p.y() * localToPhysical) / localToPhysical
+            );
+        }
+        return p;
+    };
+
+    qreal circleRadius = 4.0;
+    if (localToPhysical > 0.0) {
+        circleRadius = qRound(circleRadius * localToPhysical) / localToPhysical;
+    }
+    const QPointF circleCenter = snapPoint(QPointF(-2.0, -2.0));
     painter->drawEllipse(circleCenter, circleRadius, circleRadius);
 
     const qreal handleLength = 5.0;
-    const qreal sqrt2 = qSqrt(2);
+    const qreal sqrt2 = qSqrt(2.0);
     const qreal handleAttachOffset = circleRadius / sqrt2;
-    const QPointF handleStart = circleCenter + QPointF(handleAttachOffset, handleAttachOffset);
+    const QPointF handleStart = snapPoint(circleCenter + QPointF(handleAttachOffset, handleAttachOffset));
     const qreal handleEndOffset = (circleRadius + handleLength) / sqrt2;
-    const QPointF handleEnd = circleCenter + QPointF(handleEndOffset, handleEndOffset);
+    const QPointF handleEnd = snapPoint(circleCenter + QPointF(handleEndOffset, handleEndOffset));
     painter->drawLine(handleStart, handleEnd);
 }
 

--- a/src/SearchButton.cc
+++ b/src/SearchButton.cc
@@ -39,20 +39,17 @@ void SearchButton::paintIcon(QPainter *painter, const QRectF &iconRect, const qr
     setPenWidth(painter, 1.25);
 
     PixelSnapper snapper(painter, dpr);
-    auto snapPoint = [&snapper](const QPointF &p) -> QPointF {
-        return snapper.snap(p);
-    };
 
     const qreal circleRadius = snapper.snapX(4.0);
-    const QPointF circleCenter = snapPoint(QPointF(-2.0, -2.0));
+    const QPointF circleCenter = snapper.snap(QPointF(-2.0, -2.0));
     painter->drawEllipse(circleCenter, circleRadius, circleRadius);
 
     const qreal handleLength = 5.0;
     const qreal sqrt2 = qSqrt(2.0);
     const qreal handleAttachOffset = circleRadius / sqrt2;
-    const QPointF handleStart = snapPoint(circleCenter + QPointF(handleAttachOffset, handleAttachOffset));
+    const QPointF handleStart = snapper.snap(circleCenter + QPointF(handleAttachOffset, handleAttachOffset));
     const qreal handleEndOffset = (circleRadius + handleLength) / sqrt2;
-    const QPointF handleEnd = snapPoint(circleCenter + QPointF(handleEndOffset, handleEndOffset));
+    const QPointF handleEnd = snapper.snap(circleCenter + QPointF(handleEndOffset, handleEndOffset));
     painter->drawLine(handleStart, handleEnd);
 }
 

--- a/src/SearchButton.h
+++ b/src/SearchButton.h
@@ -32,7 +32,7 @@ public:
     ~SearchButton() override;
 
 protected:
-    void paintIcon(QPainter *painter, const QRectF &iconRect, const qreal) override;
+    void paintIcon(QPainter *painter, const QRectF &iconRect, const qreal dpr) override;
 };
 
 } // namespace Material

--- a/src/SearchButton.h
+++ b/src/SearchButton.h
@@ -32,7 +32,7 @@ public:
     ~SearchButton() override;
 
 protected:
-    void paintIcon(QPainter *painter, const QRectF &iconRect, const qreal dpr) override;
+    void paintIcon(QPainter *painter, const QRectF &iconRect, const PixelSnapper &snapper) override;
 };
 
 } // namespace Material

--- a/src/ShadeButton.h
+++ b/src/ShadeButton.h
@@ -42,17 +42,8 @@ public:
     }
     static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal dpr) {
         Q_UNUSED(iconRect)
-        const qreal scaleX = qAbs(painter->transform().m11());
-        const qreal localToPhysical = scaleX * dpr;
-
-        auto snapPoint = [localToPhysical](const QPointF &p) -> QPointF {
-            if (localToPhysical > 0.0) {
-                return QPointF(
-                    qRound(p.x() * localToPhysical) / localToPhysical,
-                    qRound(p.y() * localToPhysical) / localToPhysical
-                );
-            }
-            return p;
+        auto snapPoint = [button, painter, dpr](const QPointF &p) -> QPointF {
+            return button->snapPoint(painter, p, dpr);
         };
 
         const QPointF offset(-5.0, -5.0);

--- a/src/ShadeButton.h
+++ b/src/ShadeButton.h
@@ -42,8 +42,9 @@ public:
     }
     static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal dpr) {
         Q_UNUSED(iconRect)
-        auto snapPoint = [button, painter, dpr](const QPointF &p) -> QPointF {
-            return button->snapPoint(painter, p, dpr);
+        PixelSnapper snapper(painter, dpr);
+        auto snapPoint = [&snapper](const QPointF &p) -> QPointF {
+            return snapper.snap(p);
         };
 
         const QPointF offset(-5.0, -5.0);

--- a/src/ShadeButton.h
+++ b/src/ShadeButton.h
@@ -42,31 +42,45 @@ public:
     }
     static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal) {
         Q_UNUSED(iconRect)
-        const QPointF offset(-5, -5);
+        const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : 1.0;
+        const qreal scaleX = qAbs(painter->transform().m11());
+        const qreal localToPhysical = scaleX * dpr;
+
+        auto snapPoint = [localToPhysical](const QPointF &p) -> QPointF {
+            if (localToPhysical > 0.0) {
+                return QPointF(
+                    qRound(p.x() * localToPhysical) / localToPhysical,
+                    qRound(p.y() * localToPhysical) / localToPhysical
+                );
+            }
+            return p;
+        };
+
+        const QPointF offset(-5.0, -5.0);
 
         if (button->isChecked()) {
             button->setPenWidth(painter, 1.25);
             painter->drawLine( 
-                QPointF( 0, 2 ) + offset,
-                QPointF( 10, 2 ) + offset
+                snapPoint(QPointF( 0, 2 ) + offset),
+                snapPoint(QPointF( 10, 2 ) + offset)
             );
             button->setPenWidth(painter, 1.25);
             painter->drawPolyline(  QVector<QPointF> {
-                QPointF( 0.5, 5.25 ) + offset,
-                QPointF( 5.0, 9.75 ) + offset,
-                QPointF( 9.5, 5.25 ) + offset
+                snapPoint(QPointF( 0.5, 5.25 ) + offset),
+                snapPoint(QPointF( 5.0, 9.75 ) + offset),
+                snapPoint(QPointF( 9.5, 5.25 ) + offset)
             });
         } else {
             button->setPenWidth(painter, 1.25);
             painter->drawLine( 
-                QPointF( 0, 2 ) + offset,
-                QPointF( 10, 2 ) + offset
+                snapPoint(QPointF( 0, 2 ) + offset),
+                snapPoint(QPointF( 10, 2 ) + offset)
             );
             button->setPenWidth(painter, 1.25);
             painter->drawPolyline( QVector<QPointF> {
-                QPointF( 0.5, 9.75 ) + offset,
-                QPointF( 5.0, 5.25 ) + offset,
-                QPointF( 9.5, 9.75 ) + offset
+                snapPoint(QPointF( 0.5, 9.75 ) + offset),
+                snapPoint(QPointF( 5.0, 5.25 ) + offset),
+                snapPoint(QPointF( 9.5, 5.25 ) + offset)
             });
         }
     }

--- a/src/ShadeButton.h
+++ b/src/ShadeButton.h
@@ -40,9 +40,8 @@ public:
 
         button->setVisible(decoratedClient->isShadeable());
     }
-    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal) {
+    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal dpr) {
         Q_UNUSED(iconRect)
-        const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : 1.0;
         const qreal scaleX = qAbs(painter->transform().m11());
         const qreal localToPhysical = scaleX * dpr;
 
@@ -66,9 +65,9 @@ public:
             );
             button->setPenWidth(painter, 1.25);
             painter->drawPolyline(  QVector<QPointF> {
-                snapPoint(QPointF( 0.5, 5.25 ) + offset),
-                snapPoint(QPointF( 5.0, 9.75 ) + offset),
-                snapPoint(QPointF( 9.5, 5.25 ) + offset)
+                snapPoint(QPointF( 0.0, 5.0 ) + offset),
+                snapPoint(QPointF( 5.0, 10.0 ) + offset),
+                snapPoint(QPointF( 10.0, 5.0 ) + offset)
             });
         } else {
             button->setPenWidth(painter, 1.25);
@@ -78,9 +77,9 @@ public:
             );
             button->setPenWidth(painter, 1.25);
             painter->drawPolyline( QVector<QPointF> {
-                snapPoint(QPointF( 0.5, 9.75 ) + offset),
-                snapPoint(QPointF( 5.0, 5.25 ) + offset),
-                snapPoint(QPointF( 9.5, 5.25 ) + offset)
+                snapPoint(QPointF( 0.0, 10.0 ) + offset),
+                snapPoint(QPointF( 5.0, 5.0 ) + offset),
+                snapPoint(QPointF( 10.0, 10.0 ) + offset)
             });
         }
     }

--- a/src/ShadeButton.h
+++ b/src/ShadeButton.h
@@ -43,35 +43,32 @@ public:
     static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal dpr) {
         Q_UNUSED(iconRect)
         PixelSnapper snapper(painter, dpr);
-        auto snapPoint = [&snapper](const QPointF &p) -> QPointF {
-            return snapper.snap(p);
-        };
 
         const QPointF offset(-5.0, -5.0);
 
         if (button->isChecked()) {
             button->setPenWidth(painter, 1.25);
             painter->drawLine( 
-                snapPoint(QPointF( 0, 2 ) + offset),
-                snapPoint(QPointF( 10, 2 ) + offset)
+                snapper.snap(QPointF( 0, 2 ) + offset),
+                snapper.snap(QPointF( 10, 2 ) + offset)
             );
             button->setPenWidth(painter, 1.25);
             painter->drawPolyline(  QVector<QPointF> {
-                snapPoint(QPointF( 0.0, 5.0 ) + offset),
-                snapPoint(QPointF( 5.0, 10.0 ) + offset),
-                snapPoint(QPointF( 10.0, 5.0 ) + offset)
+                snapper.snap(QPointF( 0.0, 5.0 ) + offset),
+                snapper.snap(QPointF( 5.0, 10.0 ) + offset),
+                snapper.snap(QPointF( 10.0, 5.0 ) + offset)
             });
         } else {
             button->setPenWidth(painter, 1.25);
             painter->drawLine( 
-                snapPoint(QPointF( 0, 2 ) + offset),
-                snapPoint(QPointF( 10, 2 ) + offset)
+                snapper.snap(QPointF( 0, 2 ) + offset),
+                snapper.snap(QPointF( 10, 2 ) + offset)
             );
             button->setPenWidth(painter, 1.25);
             painter->drawPolyline( QVector<QPointF> {
-                snapPoint(QPointF( 0.0, 10.0 ) + offset),
-                snapPoint(QPointF( 5.0, 5.0 ) + offset),
-                snapPoint(QPointF( 10.0, 10.0 ) + offset)
+                snapper.snap(QPointF( 0.0, 10.0 ) + offset),
+                snapper.snap(QPointF( 5.0, 5.0 ) + offset),
+                snapper.snap(QPointF( 10.0, 10.0 ) + offset)
             });
         }
     }

--- a/src/ShadeButton.h
+++ b/src/ShadeButton.h
@@ -40,9 +40,8 @@ public:
 
         button->setVisible(decoratedClient->isShadeable());
     }
-    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal dpr) {
+    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const PixelSnapper &snapper) {
         Q_UNUSED(iconRect)
-        PixelSnapper snapper(painter, dpr);
 
         const QPointF offset(-5.0, -5.0);
 

--- a/src/TextButton.cc
+++ b/src/TextButton.cc
@@ -49,10 +49,20 @@ void TextButton::paintIcon(QPainter *painter, const QRectF &iconRect, const qrea
     painter->setPen(foregroundColor());
     painter->setRenderHint(QPainter::TextAntialiasing);
 
+    const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : 1.0;
+    QRectF snappedRect = iconRect;
+    if (dpr > 0.0) {
+        snappedRect.setLeft(qRound(iconRect.left() * dpr) / dpr);
+        snappedRect.setTop(qRound(iconRect.top() * dpr) / dpr);
+        snappedRect.setRight(qRound(iconRect.right() * dpr) / dpr);
+        snappedRect.setBottom(qRound(iconRect.bottom() * dpr) / dpr);
+    }
+    const qreal pixelShift = (dpr > 0.0) ? (1.0 / dpr) : 1.0;
+
     // TODO: Use Qt::TextShowMnemonic when Alt is pressed
     const bool isAltPressed = false;
     const Qt::TextFlag mnemonicFlag = isAltPressed ? Qt::TextShowMnemonic : Qt::TextHideMnemonic;
-    painter->drawText(iconRect.translated(1.0, 0.0), mnemonicFlag | Qt::AlignCenter | Qt::TextSingleLine, m_text); // translating 1 pixel seems the only way to perfect centering the text.
+    painter->drawText(snappedRect.translated(pixelShift, 0.0), mnemonicFlag | Qt::AlignCenter | Qt::TextSingleLine, m_text); // translating 1 physical pixel seems the only way to perfect centering the text.
 }
 
 QSizeF TextButton::getTextSize() const

--- a/src/TextButton.cc
+++ b/src/TextButton.cc
@@ -49,14 +49,9 @@ void TextButton::paintIcon(QPainter *painter, const QRectF &iconRect, const qrea
     painter->setPen(foregroundColor());
     painter->setRenderHint(QPainter::TextAntialiasing);
 
-    QRectF snappedRect = iconRect;
-    if (dpr > 0.0) {
-        snappedRect.setLeft(qRound(iconRect.left() * dpr) / dpr);
-        snappedRect.setTop(qRound(iconRect.top() * dpr) / dpr);
-        snappedRect.setRight(qRound(iconRect.right() * dpr) / dpr);
-        snappedRect.setBottom(qRound(iconRect.bottom() * dpr) / dpr);
-    }
-    //const qreal pixelShift = (dpr > 0.0) ? (1.0 / dpr) : 1.0;
+    PixelSnapper snapper(painter, dpr);
+    const QPointF snappedTopLeft = snapper.snap(iconRect.topLeft());
+    const QRectF snappedRect(snappedTopLeft, iconRect.size());
 
     // TODO: Use Qt::TextShowMnemonic when Alt is pressed
     const bool isAltPressed = false;

--- a/src/TextButton.cc
+++ b/src/TextButton.cc
@@ -61,7 +61,7 @@ void TextButton::paintIcon(QPainter *painter, const QRectF &iconRect, const qrea
     // TODO: Use Qt::TextShowMnemonic when Alt is pressed
     const bool isAltPressed = false;
     const Qt::TextFlag mnemonicFlag = isAltPressed ? Qt::TextShowMnemonic : Qt::TextHideMnemonic;
-    painter->drawText(snappedRect, mnemonicFlag | Qt::AlignCenter | Qt::TextSingleLine, m_text); // translating 1 physical pixel seems the only way to perfect centering the text.
+    painter->drawText(snappedRect, mnemonicFlag | Qt::AlignCenter | Qt::TextSingleLine, m_text); 
 }
 
 QSizeF TextButton::getTextSize() const

--- a/src/TextButton.cc
+++ b/src/TextButton.cc
@@ -40,7 +40,7 @@ TextButton::~TextButton()
 {
 }
 
-void TextButton::paintIcon(QPainter *painter, const QRectF &iconRect, const qreal dpr)
+void TextButton::paintIcon(QPainter *painter, const QRectF &iconRect, const PixelSnapper &snapper)
 {
     const auto *deco = qobject_cast<Decoration *>(decoration());
 
@@ -49,7 +49,6 @@ void TextButton::paintIcon(QPainter *painter, const QRectF &iconRect, const qrea
     painter->setPen(foregroundColor());
     painter->setRenderHint(QPainter::TextAntialiasing);
 
-    PixelSnapper snapper(painter, dpr);
     const QPointF snappedTopLeft = snapper.snap(iconRect.topLeft());
     const QRectF snappedRect(snappedTopLeft, iconRect.size());
 

--- a/src/TextButton.cc
+++ b/src/TextButton.cc
@@ -40,7 +40,7 @@ TextButton::~TextButton()
 {
 }
 
-void TextButton::paintIcon(QPainter *painter, const QRectF &iconRect, const qreal)
+void TextButton::paintIcon(QPainter *painter, const QRectF &iconRect, const qreal dpr)
 {
     const auto *deco = qobject_cast<Decoration *>(decoration());
 
@@ -49,7 +49,6 @@ void TextButton::paintIcon(QPainter *painter, const QRectF &iconRect, const qrea
     painter->setPen(foregroundColor());
     painter->setRenderHint(QPainter::TextAntialiasing);
 
-    const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : 1.0;
     QRectF snappedRect = iconRect;
     if (dpr > 0.0) {
         snappedRect.setLeft(qRound(iconRect.left() * dpr) / dpr);
@@ -57,12 +56,12 @@ void TextButton::paintIcon(QPainter *painter, const QRectF &iconRect, const qrea
         snappedRect.setRight(qRound(iconRect.right() * dpr) / dpr);
         snappedRect.setBottom(qRound(iconRect.bottom() * dpr) / dpr);
     }
-    const qreal pixelShift = (dpr > 0.0) ? (1.0 / dpr) : 1.0;
+    //const qreal pixelShift = (dpr > 0.0) ? (1.0 / dpr) : 1.0;
 
     // TODO: Use Qt::TextShowMnemonic when Alt is pressed
     const bool isAltPressed = false;
     const Qt::TextFlag mnemonicFlag = isAltPressed ? Qt::TextShowMnemonic : Qt::TextHideMnemonic;
-    painter->drawText(snappedRect.translated(pixelShift, 0.0), mnemonicFlag | Qt::AlignCenter | Qt::TextSingleLine, m_text); // translating 1 physical pixel seems the only way to perfect centering the text.
+    painter->drawText(snappedRect, mnemonicFlag | Qt::AlignCenter | Qt::TextSingleLine, m_text); // translating 1 physical pixel seems the only way to perfect centering the text.
 }
 
 QSizeF TextButton::getTextSize() const

--- a/src/TextButton.h
+++ b/src/TextButton.h
@@ -40,7 +40,7 @@ public:
     Q_PROPERTY(QAction* action READ action WRITE setAction NOTIFY actionChanged)
     Q_PROPERTY(QString text READ text WRITE setText NOTIFY textChanged)
 
-    void paintIcon(QPainter *painter, const QRectF &iconRect, const qreal dpr) override;
+    void paintIcon(QPainter *painter, const QRectF &iconRect, const PixelSnapper &snapper) override;
 
     QAction* action() const;
     void setAction(QAction *set);

--- a/src/TextButton.h
+++ b/src/TextButton.h
@@ -40,7 +40,7 @@ public:
     Q_PROPERTY(QAction* action READ action WRITE setAction NOTIFY actionChanged)
     Q_PROPERTY(QString text READ text WRITE setText NOTIFY textChanged)
 
-    void paintIcon(QPainter *painter, const QRectF &iconRect, const qreal) override;
+    void paintIcon(QPainter *painter, const QRectF &iconRect, const qreal dpr) override;
 
     QAction* action() const;
     void setAction(QAction *set);


### PR DESCRIPTION
## Summary by Sourcery

Migliora il rendering di pulsanti e icone con uno snapping consapevole dell’alta densità (high-DPI), allineato ai pixel fisici, e layout e spessori delle linee (stroke widths) regolati di conseguenza.

Nuove funzionalità:
- Introdurre l’utility PixelSnapper per allineare punti, lunghezze e trasformazioni alla griglia di pixel fisici durante il rendering delle icone dei pulsanti.

Miglioramenti:
- Propagare la scalatura basata su devicePixelRatio e l’uso di PixelSnapper in tutti i percorsi di painting delle icone dei pulsanti per ottenere icone nitide sui display ad alta densità (high-DPI).
- Regolare le dimensioni e il centraggio delle icone nei pulsanti in modo che la geometria delle icone si allinei alla griglia di pixel fisici mantenendo le attuali semantiche di scalatura.
- Raffinare il calcolo della larghezza della penna in modo da allineare lo spessore delle linee ai pixel fisici per linee più uniformi sotto le trasformazioni del painter.
- Migliorare la gestione del rettangolo dell’icona nei pulsanti di testo affinché il centraggio dell’etichetta utilizzi posizionamento allineato ai pixel invece di offset manuali.

Build:
- Aggiungere `PixelSnapper.cc` alle sorgenti di build della decorazione in modo che la nuova utility venga compilata e linkata.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve button and icon rendering with high-DPI-aware, physical-pixel-aligned snapping and adjusted layout and stroke widths.

New Features:
- Introduce the PixelSnapper utility to snap points, lengths, and transforms to the physical pixel grid during button icon rendering.

Enhancements:
- Propagate devicePixelRatio-aware scaling and PixelSnapper usage through all button icon paint paths to produce crisp icons on high-DPI displays.
- Adjust icon sizing and centering in buttons so icon geometry aligns with the physical pixel grid while preserving existing scaling semantics.
- Refine pen width computation to snap stroke thickness to physical pixels for more uniform lines under painter transformations.
- Improve text button icon rectangle handling so label centering uses pixel-aligned positioning instead of manual offsets.

Build:
- Add PixelSnapper.cc to the decoration build sources so the new utility is compiled and linked.

</details>

Nuove funzionalità:
- Introduce l’utility PixelSnapper per agganciare punti, lunghezze e trasformazioni alla griglia di pixel fisici durante il rendering delle icone dei pulsanti.

Miglioramenti:
- Propaga la scalatura basata su devicePixelRatioF attraverso i percorsi di disegno dei pulsanti (button paint paths) e le funzioni di rendering specifiche delle icone (paintIcon) per supportare il rendering high-DPI.
- Regola il layout delle icone dei pulsanti, inclusa la traslazione al centro e il calcolo delle dimensioni logiche delle icone, per tenere conto dell’allineamento ai pixel fisici preservando al contempo la semantica di scalatura esistente.
- Affina il calcolo della larghezza della penna in modo da agganciare lo spessore dei tratti ai pixel fisici, garantendo un aspetto uniforme delle linee sotto le trasformazioni del painter.
- Aggiorna la gestione del rettangolo dell’icona nei pulsanti di testo per centrare il testo in modo più accurato con un posizionamento allineato ai pixel invece che con offset manuali.

Build:
- Aggiunge PixelSnapper.cc alle sorgenti di build della parte di decorazione, così che la nuova utility venga compilata e collegata.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migliora il rendering di pulsanti e icone con uno snapping consapevole dell’alta densità (high-DPI), allineato ai pixel fisici, e layout e spessori delle linee (stroke widths) regolati di conseguenza.

Nuove funzionalità:
- Introdurre l’utility PixelSnapper per allineare punti, lunghezze e trasformazioni alla griglia di pixel fisici durante il rendering delle icone dei pulsanti.

Miglioramenti:
- Propagare la scalatura basata su devicePixelRatio e l’uso di PixelSnapper in tutti i percorsi di painting delle icone dei pulsanti per ottenere icone nitide sui display ad alta densità (high-DPI).
- Regolare le dimensioni e il centraggio delle icone nei pulsanti in modo che la geometria delle icone si allinei alla griglia di pixel fisici mantenendo le attuali semantiche di scalatura.
- Raffinare il calcolo della larghezza della penna in modo da allineare lo spessore delle linee ai pixel fisici per linee più uniformi sotto le trasformazioni del painter.
- Migliorare la gestione del rettangolo dell’icona nei pulsanti di testo affinché il centraggio dell’etichetta utilizzi posizionamento allineato ai pixel invece di offset manuali.

Build:
- Aggiungere `PixelSnapper.cc` alle sorgenti di build della decorazione in modo che la nuova utility venga compilata e linkata.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve button and icon rendering with high-DPI-aware, physical-pixel-aligned snapping and adjusted layout and stroke widths.

New Features:
- Introduce the PixelSnapper utility to snap points, lengths, and transforms to the physical pixel grid during button icon rendering.

Enhancements:
- Propagate devicePixelRatio-aware scaling and PixelSnapper usage through all button icon paint paths to produce crisp icons on high-DPI displays.
- Adjust icon sizing and centering in buttons so icon geometry aligns with the physical pixel grid while preserving existing scaling semantics.
- Refine pen width computation to snap stroke thickness to physical pixels for more uniform lines under painter transformations.
- Improve text button icon rectangle handling so label centering uses pixel-aligned positioning instead of manual offsets.

Build:
- Add PixelSnapper.cc to the decoration build sources so the new utility is compiled and linked.

</details>

</details>

Miglioramenti:
- Propaga la scalatura basata su `devicePixelRatioF` attraverso tutti i percorsi di disegno delle icone dei pulsanti per supportare un rendering nitido sugli schermi ad alta densità (high-DPI).
- Introduce le utility `PixelSnapper` e le applica alle geometrie delle icone per allineare centri, forme e dimensioni alla griglia dei pixel fisici.
- Regola il calcolo della larghezza della penna per agganciare lo spessore del tratto ai pixel fisici rispettando al contempo la trasformazione del painter.
- Affina la gestione del rettangolo delle icone dei pulsanti con testo per ottenere un centraggio del testo più accurato e allineato ai pixel, senza offset manuali.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migliora il rendering di pulsanti e icone con uno snapping consapevole dell’alta densità (high-DPI), allineato ai pixel fisici, e layout e spessori delle linee (stroke widths) regolati di conseguenza.

Nuove funzionalità:
- Introdurre l’utility PixelSnapper per allineare punti, lunghezze e trasformazioni alla griglia di pixel fisici durante il rendering delle icone dei pulsanti.

Miglioramenti:
- Propagare la scalatura basata su devicePixelRatio e l’uso di PixelSnapper in tutti i percorsi di painting delle icone dei pulsanti per ottenere icone nitide sui display ad alta densità (high-DPI).
- Regolare le dimensioni e il centraggio delle icone nei pulsanti in modo che la geometria delle icone si allinei alla griglia di pixel fisici mantenendo le attuali semantiche di scalatura.
- Raffinare il calcolo della larghezza della penna in modo da allineare lo spessore delle linee ai pixel fisici per linee più uniformi sotto le trasformazioni del painter.
- Migliorare la gestione del rettangolo dell’icona nei pulsanti di testo affinché il centraggio dell’etichetta utilizzi posizionamento allineato ai pixel invece di offset manuali.

Build:
- Aggiungere `PixelSnapper.cc` alle sorgenti di build della decorazione in modo che la nuova utility venga compilata e linkata.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve button and icon rendering with high-DPI-aware, physical-pixel-aligned snapping and adjusted layout and stroke widths.

New Features:
- Introduce the PixelSnapper utility to snap points, lengths, and transforms to the physical pixel grid during button icon rendering.

Enhancements:
- Propagate devicePixelRatio-aware scaling and PixelSnapper usage through all button icon paint paths to produce crisp icons on high-DPI displays.
- Adjust icon sizing and centering in buttons so icon geometry aligns with the physical pixel grid while preserving existing scaling semantics.
- Refine pen width computation to snap stroke thickness to physical pixels for more uniform lines under painter transformations.
- Improve text button icon rectangle handling so label centering uses pixel-aligned positioning instead of manual offsets.

Build:
- Add PixelSnapper.cc to the decoration build sources so the new utility is compiled and linked.

</details>

Nuove funzionalità:
- Introduce l’utility PixelSnapper per agganciare punti, lunghezze e trasformazioni alla griglia di pixel fisici durante il rendering delle icone dei pulsanti.

Miglioramenti:
- Propaga la scalatura basata su devicePixelRatioF attraverso i percorsi di disegno dei pulsanti (button paint paths) e le funzioni di rendering specifiche delle icone (paintIcon) per supportare il rendering high-DPI.
- Regola il layout delle icone dei pulsanti, inclusa la traslazione al centro e il calcolo delle dimensioni logiche delle icone, per tenere conto dell’allineamento ai pixel fisici preservando al contempo la semantica di scalatura esistente.
- Affina il calcolo della larghezza della penna in modo da agganciare lo spessore dei tratti ai pixel fisici, garantendo un aspetto uniforme delle linee sotto le trasformazioni del painter.
- Aggiorna la gestione del rettangolo dell’icona nei pulsanti di testo per centrare il testo in modo più accurato con un posizionamento allineato ai pixel invece che con offset manuali.

Build:
- Aggiunge PixelSnapper.cc alle sorgenti di build della parte di decorazione, così che la nuova utility venga compilata e collegata.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migliora il rendering di pulsanti e icone con uno snapping consapevole dell’alta densità (high-DPI), allineato ai pixel fisici, e layout e spessori delle linee (stroke widths) regolati di conseguenza.

Nuove funzionalità:
- Introdurre l’utility PixelSnapper per allineare punti, lunghezze e trasformazioni alla griglia di pixel fisici durante il rendering delle icone dei pulsanti.

Miglioramenti:
- Propagare la scalatura basata su devicePixelRatio e l’uso di PixelSnapper in tutti i percorsi di painting delle icone dei pulsanti per ottenere icone nitide sui display ad alta densità (high-DPI).
- Regolare le dimensioni e il centraggio delle icone nei pulsanti in modo che la geometria delle icone si allinei alla griglia di pixel fisici mantenendo le attuali semantiche di scalatura.
- Raffinare il calcolo della larghezza della penna in modo da allineare lo spessore delle linee ai pixel fisici per linee più uniformi sotto le trasformazioni del painter.
- Migliorare la gestione del rettangolo dell’icona nei pulsanti di testo affinché il centraggio dell’etichetta utilizzi posizionamento allineato ai pixel invece di offset manuali.

Build:
- Aggiungere `PixelSnapper.cc` alle sorgenti di build della decorazione in modo che la nuova utility venga compilata e linkata.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve button and icon rendering with high-DPI-aware, physical-pixel-aligned snapping and adjusted layout and stroke widths.

New Features:
- Introduce the PixelSnapper utility to snap points, lengths, and transforms to the physical pixel grid during button icon rendering.

Enhancements:
- Propagate devicePixelRatio-aware scaling and PixelSnapper usage through all button icon paint paths to produce crisp icons on high-DPI displays.
- Adjust icon sizing and centering in buttons so icon geometry aligns with the physical pixel grid while preserving existing scaling semantics.
- Refine pen width computation to snap stroke thickness to physical pixels for more uniform lines under painter transformations.
- Improve text button icon rectangle handling so label centering uses pixel-aligned positioning instead of manual offsets.

Build:
- Add PixelSnapper.cc to the decoration build sources so the new utility is compiled and linked.

</details>

</details>

</details>

Miglioramenti:
- Propaga la scalatura basata su `devicePixelRatioF` in tutti i percorsi di disegno delle icone dei pulsanti per supportare un rendering nitido sui display ad alta densità (high-DPI).
- Allinea i centri, le forme e le dimensioni delle icone dei pulsanti alla griglia di pixel fisici tramite nuovi helper di snapping per punti e lunghezze.
- Modifica il calcolo della larghezza della penna per agganciare lo spessore delle linee dei simboli ai pixel fisici, rispettando al contempo la trasformazione del painter.
- Affina l’allineamento del rettangolo dell’icona dei pulsanti testuali per ottenere un centraggio del testo più accurato e allineato ai pixel, senza offset manuali.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migliora il rendering di pulsanti e icone con uno snapping consapevole dell’alta densità (high-DPI), allineato ai pixel fisici, e layout e spessori delle linee (stroke widths) regolati di conseguenza.

Nuove funzionalità:
- Introdurre l’utility PixelSnapper per allineare punti, lunghezze e trasformazioni alla griglia di pixel fisici durante il rendering delle icone dei pulsanti.

Miglioramenti:
- Propagare la scalatura basata su devicePixelRatio e l’uso di PixelSnapper in tutti i percorsi di painting delle icone dei pulsanti per ottenere icone nitide sui display ad alta densità (high-DPI).
- Regolare le dimensioni e il centraggio delle icone nei pulsanti in modo che la geometria delle icone si allinei alla griglia di pixel fisici mantenendo le attuali semantiche di scalatura.
- Raffinare il calcolo della larghezza della penna in modo da allineare lo spessore delle linee ai pixel fisici per linee più uniformi sotto le trasformazioni del painter.
- Migliorare la gestione del rettangolo dell’icona nei pulsanti di testo affinché il centraggio dell’etichetta utilizzi posizionamento allineato ai pixel invece di offset manuali.

Build:
- Aggiungere `PixelSnapper.cc` alle sorgenti di build della decorazione in modo che la nuova utility venga compilata e linkata.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve button and icon rendering with high-DPI-aware, physical-pixel-aligned snapping and adjusted layout and stroke widths.

New Features:
- Introduce the PixelSnapper utility to snap points, lengths, and transforms to the physical pixel grid during button icon rendering.

Enhancements:
- Propagate devicePixelRatio-aware scaling and PixelSnapper usage through all button icon paint paths to produce crisp icons on high-DPI displays.
- Adjust icon sizing and centering in buttons so icon geometry aligns with the physical pixel grid while preserving existing scaling semantics.
- Refine pen width computation to snap stroke thickness to physical pixels for more uniform lines under painter transformations.
- Improve text button icon rectangle handling so label centering uses pixel-aligned positioning instead of manual offsets.

Build:
- Add PixelSnapper.cc to the decoration build sources so the new utility is compiled and linked.

</details>

Nuove funzionalità:
- Introduce l’utility PixelSnapper per agganciare punti, lunghezze e trasformazioni alla griglia di pixel fisici durante il rendering delle icone dei pulsanti.

Miglioramenti:
- Propaga la scalatura basata su devicePixelRatioF attraverso i percorsi di disegno dei pulsanti (button paint paths) e le funzioni di rendering specifiche delle icone (paintIcon) per supportare il rendering high-DPI.
- Regola il layout delle icone dei pulsanti, inclusa la traslazione al centro e il calcolo delle dimensioni logiche delle icone, per tenere conto dell’allineamento ai pixel fisici preservando al contempo la semantica di scalatura esistente.
- Affina il calcolo della larghezza della penna in modo da agganciare lo spessore dei tratti ai pixel fisici, garantendo un aspetto uniforme delle linee sotto le trasformazioni del painter.
- Aggiorna la gestione del rettangolo dell’icona nei pulsanti di testo per centrare il testo in modo più accurato con un posizionamento allineato ai pixel invece che con offset manuali.

Build:
- Aggiunge PixelSnapper.cc alle sorgenti di build della parte di decorazione, così che la nuova utility venga compilata e collegata.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migliora il rendering di pulsanti e icone con uno snapping consapevole dell’alta densità (high-DPI), allineato ai pixel fisici, e layout e spessori delle linee (stroke widths) regolati di conseguenza.

Nuove funzionalità:
- Introdurre l’utility PixelSnapper per allineare punti, lunghezze e trasformazioni alla griglia di pixel fisici durante il rendering delle icone dei pulsanti.

Miglioramenti:
- Propagare la scalatura basata su devicePixelRatio e l’uso di PixelSnapper in tutti i percorsi di painting delle icone dei pulsanti per ottenere icone nitide sui display ad alta densità (high-DPI).
- Regolare le dimensioni e il centraggio delle icone nei pulsanti in modo che la geometria delle icone si allinei alla griglia di pixel fisici mantenendo le attuali semantiche di scalatura.
- Raffinare il calcolo della larghezza della penna in modo da allineare lo spessore delle linee ai pixel fisici per linee più uniformi sotto le trasformazioni del painter.
- Migliorare la gestione del rettangolo dell’icona nei pulsanti di testo affinché il centraggio dell’etichetta utilizzi posizionamento allineato ai pixel invece di offset manuali.

Build:
- Aggiungere `PixelSnapper.cc` alle sorgenti di build della decorazione in modo che la nuova utility venga compilata e linkata.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve button and icon rendering with high-DPI-aware, physical-pixel-aligned snapping and adjusted layout and stroke widths.

New Features:
- Introduce the PixelSnapper utility to snap points, lengths, and transforms to the physical pixel grid during button icon rendering.

Enhancements:
- Propagate devicePixelRatio-aware scaling and PixelSnapper usage through all button icon paint paths to produce crisp icons on high-DPI displays.
- Adjust icon sizing and centering in buttons so icon geometry aligns with the physical pixel grid while preserving existing scaling semantics.
- Refine pen width computation to snap stroke thickness to physical pixels for more uniform lines under painter transformations.
- Improve text button icon rectangle handling so label centering uses pixel-aligned positioning instead of manual offsets.

Build:
- Add PixelSnapper.cc to the decoration build sources so the new utility is compiled and linked.

</details>

</details>

Miglioramenti:
- Propaga la scalatura basata su `devicePixelRatioF` attraverso tutti i percorsi di disegno delle icone dei pulsanti per supportare un rendering nitido sugli schermi ad alta densità (high-DPI).
- Introduce le utility `PixelSnapper` e le applica alle geometrie delle icone per allineare centri, forme e dimensioni alla griglia dei pixel fisici.
- Regola il calcolo della larghezza della penna per agganciare lo spessore del tratto ai pixel fisici rispettando al contempo la trasformazione del painter.
- Affina la gestione del rettangolo delle icone dei pulsanti con testo per ottenere un centraggio del testo più accurato e allineato ai pixel, senza offset manuali.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migliora il rendering di pulsanti e icone con uno snapping consapevole dell’alta densità (high-DPI), allineato ai pixel fisici, e layout e spessori delle linee (stroke widths) regolati di conseguenza.

Nuove funzionalità:
- Introdurre l’utility PixelSnapper per allineare punti, lunghezze e trasformazioni alla griglia di pixel fisici durante il rendering delle icone dei pulsanti.

Miglioramenti:
- Propagare la scalatura basata su devicePixelRatio e l’uso di PixelSnapper in tutti i percorsi di painting delle icone dei pulsanti per ottenere icone nitide sui display ad alta densità (high-DPI).
- Regolare le dimensioni e il centraggio delle icone nei pulsanti in modo che la geometria delle icone si allinei alla griglia di pixel fisici mantenendo le attuali semantiche di scalatura.
- Raffinare il calcolo della larghezza della penna in modo da allineare lo spessore delle linee ai pixel fisici per linee più uniformi sotto le trasformazioni del painter.
- Migliorare la gestione del rettangolo dell’icona nei pulsanti di testo affinché il centraggio dell’etichetta utilizzi posizionamento allineato ai pixel invece di offset manuali.

Build:
- Aggiungere `PixelSnapper.cc` alle sorgenti di build della decorazione in modo che la nuova utility venga compilata e linkata.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve button and icon rendering with high-DPI-aware, physical-pixel-aligned snapping and adjusted layout and stroke widths.

New Features:
- Introduce the PixelSnapper utility to snap points, lengths, and transforms to the physical pixel grid during button icon rendering.

Enhancements:
- Propagate devicePixelRatio-aware scaling and PixelSnapper usage through all button icon paint paths to produce crisp icons on high-DPI displays.
- Adjust icon sizing and centering in buttons so icon geometry aligns with the physical pixel grid while preserving existing scaling semantics.
- Refine pen width computation to snap stroke thickness to physical pixels for more uniform lines under painter transformations.
- Improve text button icon rectangle handling so label centering uses pixel-aligned positioning instead of manual offsets.

Build:
- Add PixelSnapper.cc to the decoration build sources so the new utility is compiled and linked.

</details>

Nuove funzionalità:
- Introduce l’utility PixelSnapper per agganciare punti, lunghezze e trasformazioni alla griglia di pixel fisici durante il rendering delle icone dei pulsanti.

Miglioramenti:
- Propaga la scalatura basata su devicePixelRatioF attraverso i percorsi di disegno dei pulsanti (button paint paths) e le funzioni di rendering specifiche delle icone (paintIcon) per supportare il rendering high-DPI.
- Regola il layout delle icone dei pulsanti, inclusa la traslazione al centro e il calcolo delle dimensioni logiche delle icone, per tenere conto dell’allineamento ai pixel fisici preservando al contempo la semantica di scalatura esistente.
- Affina il calcolo della larghezza della penna in modo da agganciare lo spessore dei tratti ai pixel fisici, garantendo un aspetto uniforme delle linee sotto le trasformazioni del painter.
- Aggiorna la gestione del rettangolo dell’icona nei pulsanti di testo per centrare il testo in modo più accurato con un posizionamento allineato ai pixel invece che con offset manuali.

Build:
- Aggiunge PixelSnapper.cc alle sorgenti di build della parte di decorazione, così che la nuova utility venga compilata e collegata.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migliora il rendering di pulsanti e icone con uno snapping consapevole dell’alta densità (high-DPI), allineato ai pixel fisici, e layout e spessori delle linee (stroke widths) regolati di conseguenza.

Nuove funzionalità:
- Introdurre l’utility PixelSnapper per allineare punti, lunghezze e trasformazioni alla griglia di pixel fisici durante il rendering delle icone dei pulsanti.

Miglioramenti:
- Propagare la scalatura basata su devicePixelRatio e l’uso di PixelSnapper in tutti i percorsi di painting delle icone dei pulsanti per ottenere icone nitide sui display ad alta densità (high-DPI).
- Regolare le dimensioni e il centraggio delle icone nei pulsanti in modo che la geometria delle icone si allinei alla griglia di pixel fisici mantenendo le attuali semantiche di scalatura.
- Raffinare il calcolo della larghezza della penna in modo da allineare lo spessore delle linee ai pixel fisici per linee più uniformi sotto le trasformazioni del painter.
- Migliorare la gestione del rettangolo dell’icona nei pulsanti di testo affinché il centraggio dell’etichetta utilizzi posizionamento allineato ai pixel invece di offset manuali.

Build:
- Aggiungere `PixelSnapper.cc` alle sorgenti di build della decorazione in modo che la nuova utility venga compilata e linkata.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve button and icon rendering with high-DPI-aware, physical-pixel-aligned snapping and adjusted layout and stroke widths.

New Features:
- Introduce the PixelSnapper utility to snap points, lengths, and transforms to the physical pixel grid during button icon rendering.

Enhancements:
- Propagate devicePixelRatio-aware scaling and PixelSnapper usage through all button icon paint paths to produce crisp icons on high-DPI displays.
- Adjust icon sizing and centering in buttons so icon geometry aligns with the physical pixel grid while preserving existing scaling semantics.
- Refine pen width computation to snap stroke thickness to physical pixels for more uniform lines under painter transformations.
- Improve text button icon rectangle handling so label centering uses pixel-aligned positioning instead of manual offsets.

Build:
- Add PixelSnapper.cc to the decoration build sources so the new utility is compiled and linked.

</details>

</details>

</details>

</details>

Miglioramenti:
- Passare le informazioni di devicePixelRatio a tutte le routine di disegno delle icone dei pulsanti per supportare un rendering compatibile con gli schermi ad alta densità (high-DPI).
- Allineare la geometria delle icone, i centri e le dimensioni alla griglia di pixel fisici per icone dei pulsanti più nitide su tutti i tipi di decorazione.
- Regolare il calcolo della larghezza della penna in modo da agganciare lo spessore dei tratti ai pixel fisici, rispettando al contempo le trasformazioni correnti del painter.
- Perfezionare la gestione dei rettangoli delle icone dei pulsanti testuali per ottenere un centramento del testo più accurato e allineato ai pixel, senza ricorrere a offset manuali.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migliora il rendering di pulsanti e icone con uno snapping consapevole dell’alta densità (high-DPI), allineato ai pixel fisici, e layout e spessori delle linee (stroke widths) regolati di conseguenza.

Nuove funzionalità:
- Introdurre l’utility PixelSnapper per allineare punti, lunghezze e trasformazioni alla griglia di pixel fisici durante il rendering delle icone dei pulsanti.

Miglioramenti:
- Propagare la scalatura basata su devicePixelRatio e l’uso di PixelSnapper in tutti i percorsi di painting delle icone dei pulsanti per ottenere icone nitide sui display ad alta densità (high-DPI).
- Regolare le dimensioni e il centraggio delle icone nei pulsanti in modo che la geometria delle icone si allinei alla griglia di pixel fisici mantenendo le attuali semantiche di scalatura.
- Raffinare il calcolo della larghezza della penna in modo da allineare lo spessore delle linee ai pixel fisici per linee più uniformi sotto le trasformazioni del painter.
- Migliorare la gestione del rettangolo dell’icona nei pulsanti di testo affinché il centraggio dell’etichetta utilizzi posizionamento allineato ai pixel invece di offset manuali.

Build:
- Aggiungere `PixelSnapper.cc` alle sorgenti di build della decorazione in modo che la nuova utility venga compilata e linkata.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve button and icon rendering with high-DPI-aware, physical-pixel-aligned snapping and adjusted layout and stroke widths.

New Features:
- Introduce the PixelSnapper utility to snap points, lengths, and transforms to the physical pixel grid during button icon rendering.

Enhancements:
- Propagate devicePixelRatio-aware scaling and PixelSnapper usage through all button icon paint paths to produce crisp icons on high-DPI displays.
- Adjust icon sizing and centering in buttons so icon geometry aligns with the physical pixel grid while preserving existing scaling semantics.
- Refine pen width computation to snap stroke thickness to physical pixels for more uniform lines under painter transformations.
- Improve text button icon rectangle handling so label centering uses pixel-aligned positioning instead of manual offsets.

Build:
- Add PixelSnapper.cc to the decoration build sources so the new utility is compiled and linked.

</details>

Nuove funzionalità:
- Introduce l’utility PixelSnapper per agganciare punti, lunghezze e trasformazioni alla griglia di pixel fisici durante il rendering delle icone dei pulsanti.

Miglioramenti:
- Propaga la scalatura basata su devicePixelRatioF attraverso i percorsi di disegno dei pulsanti (button paint paths) e le funzioni di rendering specifiche delle icone (paintIcon) per supportare il rendering high-DPI.
- Regola il layout delle icone dei pulsanti, inclusa la traslazione al centro e il calcolo delle dimensioni logiche delle icone, per tenere conto dell’allineamento ai pixel fisici preservando al contempo la semantica di scalatura esistente.
- Affina il calcolo della larghezza della penna in modo da agganciare lo spessore dei tratti ai pixel fisici, garantendo un aspetto uniforme delle linee sotto le trasformazioni del painter.
- Aggiorna la gestione del rettangolo dell’icona nei pulsanti di testo per centrare il testo in modo più accurato con un posizionamento allineato ai pixel invece che con offset manuali.

Build:
- Aggiunge PixelSnapper.cc alle sorgenti di build della parte di decorazione, così che la nuova utility venga compilata e collegata.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migliora il rendering di pulsanti e icone con uno snapping consapevole dell’alta densità (high-DPI), allineato ai pixel fisici, e layout e spessori delle linee (stroke widths) regolati di conseguenza.

Nuove funzionalità:
- Introdurre l’utility PixelSnapper per allineare punti, lunghezze e trasformazioni alla griglia di pixel fisici durante il rendering delle icone dei pulsanti.

Miglioramenti:
- Propagare la scalatura basata su devicePixelRatio e l’uso di PixelSnapper in tutti i percorsi di painting delle icone dei pulsanti per ottenere icone nitide sui display ad alta densità (high-DPI).
- Regolare le dimensioni e il centraggio delle icone nei pulsanti in modo che la geometria delle icone si allinei alla griglia di pixel fisici mantenendo le attuali semantiche di scalatura.
- Raffinare il calcolo della larghezza della penna in modo da allineare lo spessore delle linee ai pixel fisici per linee più uniformi sotto le trasformazioni del painter.
- Migliorare la gestione del rettangolo dell’icona nei pulsanti di testo affinché il centraggio dell’etichetta utilizzi posizionamento allineato ai pixel invece di offset manuali.

Build:
- Aggiungere `PixelSnapper.cc` alle sorgenti di build della decorazione in modo che la nuova utility venga compilata e linkata.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve button and icon rendering with high-DPI-aware, physical-pixel-aligned snapping and adjusted layout and stroke widths.

New Features:
- Introduce the PixelSnapper utility to snap points, lengths, and transforms to the physical pixel grid during button icon rendering.

Enhancements:
- Propagate devicePixelRatio-aware scaling and PixelSnapper usage through all button icon paint paths to produce crisp icons on high-DPI displays.
- Adjust icon sizing and centering in buttons so icon geometry aligns with the physical pixel grid while preserving existing scaling semantics.
- Refine pen width computation to snap stroke thickness to physical pixels for more uniform lines under painter transformations.
- Improve text button icon rectangle handling so label centering uses pixel-aligned positioning instead of manual offsets.

Build:
- Add PixelSnapper.cc to the decoration build sources so the new utility is compiled and linked.

</details>

</details>

Miglioramenti:
- Propaga la scalatura basata su `devicePixelRatioF` attraverso tutti i percorsi di disegno delle icone dei pulsanti per supportare un rendering nitido sugli schermi ad alta densità (high-DPI).
- Introduce le utility `PixelSnapper` e le applica alle geometrie delle icone per allineare centri, forme e dimensioni alla griglia dei pixel fisici.
- Regola il calcolo della larghezza della penna per agganciare lo spessore del tratto ai pixel fisici rispettando al contempo la trasformazione del painter.
- Affina la gestione del rettangolo delle icone dei pulsanti con testo per ottenere un centraggio del testo più accurato e allineato ai pixel, senza offset manuali.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migliora il rendering di pulsanti e icone con uno snapping consapevole dell’alta densità (high-DPI), allineato ai pixel fisici, e layout e spessori delle linee (stroke widths) regolati di conseguenza.

Nuove funzionalità:
- Introdurre l’utility PixelSnapper per allineare punti, lunghezze e trasformazioni alla griglia di pixel fisici durante il rendering delle icone dei pulsanti.

Miglioramenti:
- Propagare la scalatura basata su devicePixelRatio e l’uso di PixelSnapper in tutti i percorsi di painting delle icone dei pulsanti per ottenere icone nitide sui display ad alta densità (high-DPI).
- Regolare le dimensioni e il centraggio delle icone nei pulsanti in modo che la geometria delle icone si allinei alla griglia di pixel fisici mantenendo le attuali semantiche di scalatura.
- Raffinare il calcolo della larghezza della penna in modo da allineare lo spessore delle linee ai pixel fisici per linee più uniformi sotto le trasformazioni del painter.
- Migliorare la gestione del rettangolo dell’icona nei pulsanti di testo affinché il centraggio dell’etichetta utilizzi posizionamento allineato ai pixel invece di offset manuali.

Build:
- Aggiungere `PixelSnapper.cc` alle sorgenti di build della decorazione in modo che la nuova utility venga compilata e linkata.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve button and icon rendering with high-DPI-aware, physical-pixel-aligned snapping and adjusted layout and stroke widths.

New Features:
- Introduce the PixelSnapper utility to snap points, lengths, and transforms to the physical pixel grid during button icon rendering.

Enhancements:
- Propagate devicePixelRatio-aware scaling and PixelSnapper usage through all button icon paint paths to produce crisp icons on high-DPI displays.
- Adjust icon sizing and centering in buttons so icon geometry aligns with the physical pixel grid while preserving existing scaling semantics.
- Refine pen width computation to snap stroke thickness to physical pixels for more uniform lines under painter transformations.
- Improve text button icon rectangle handling so label centering uses pixel-aligned positioning instead of manual offsets.

Build:
- Add PixelSnapper.cc to the decoration build sources so the new utility is compiled and linked.

</details>

Nuove funzionalità:
- Introduce l’utility PixelSnapper per agganciare punti, lunghezze e trasformazioni alla griglia di pixel fisici durante il rendering delle icone dei pulsanti.

Miglioramenti:
- Propaga la scalatura basata su devicePixelRatioF attraverso i percorsi di disegno dei pulsanti (button paint paths) e le funzioni di rendering specifiche delle icone (paintIcon) per supportare il rendering high-DPI.
- Regola il layout delle icone dei pulsanti, inclusa la traslazione al centro e il calcolo delle dimensioni logiche delle icone, per tenere conto dell’allineamento ai pixel fisici preservando al contempo la semantica di scalatura esistente.
- Affina il calcolo della larghezza della penna in modo da agganciare lo spessore dei tratti ai pixel fisici, garantendo un aspetto uniforme delle linee sotto le trasformazioni del painter.
- Aggiorna la gestione del rettangolo dell’icona nei pulsanti di testo per centrare il testo in modo più accurato con un posizionamento allineato ai pixel invece che con offset manuali.

Build:
- Aggiunge PixelSnapper.cc alle sorgenti di build della parte di decorazione, così che la nuova utility venga compilata e collegata.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migliora il rendering di pulsanti e icone con uno snapping consapevole dell’alta densità (high-DPI), allineato ai pixel fisici, e layout e spessori delle linee (stroke widths) regolati di conseguenza.

Nuove funzionalità:
- Introdurre l’utility PixelSnapper per allineare punti, lunghezze e trasformazioni alla griglia di pixel fisici durante il rendering delle icone dei pulsanti.

Miglioramenti:
- Propagare la scalatura basata su devicePixelRatio e l’uso di PixelSnapper in tutti i percorsi di painting delle icone dei pulsanti per ottenere icone nitide sui display ad alta densità (high-DPI).
- Regolare le dimensioni e il centraggio delle icone nei pulsanti in modo che la geometria delle icone si allinei alla griglia di pixel fisici mantenendo le attuali semantiche di scalatura.
- Raffinare il calcolo della larghezza della penna in modo da allineare lo spessore delle linee ai pixel fisici per linee più uniformi sotto le trasformazioni del painter.
- Migliorare la gestione del rettangolo dell’icona nei pulsanti di testo affinché il centraggio dell’etichetta utilizzi posizionamento allineato ai pixel invece di offset manuali.

Build:
- Aggiungere `PixelSnapper.cc` alle sorgenti di build della decorazione in modo che la nuova utility venga compilata e linkata.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve button and icon rendering with high-DPI-aware, physical-pixel-aligned snapping and adjusted layout and stroke widths.

New Features:
- Introduce the PixelSnapper utility to snap points, lengths, and transforms to the physical pixel grid during button icon rendering.

Enhancements:
- Propagate devicePixelRatio-aware scaling and PixelSnapper usage through all button icon paint paths to produce crisp icons on high-DPI displays.
- Adjust icon sizing and centering in buttons so icon geometry aligns with the physical pixel grid while preserving existing scaling semantics.
- Refine pen width computation to snap stroke thickness to physical pixels for more uniform lines under painter transformations.
- Improve text button icon rectangle handling so label centering uses pixel-aligned positioning instead of manual offsets.

Build:
- Add PixelSnapper.cc to the decoration build sources so the new utility is compiled and linked.

</details>

</details>

</details>

Miglioramenti:
- Propaga la scalatura basata su `devicePixelRatioF` in tutti i percorsi di disegno delle icone dei pulsanti per supportare un rendering nitido sui display ad alta densità (high-DPI).
- Allinea i centri, le forme e le dimensioni delle icone dei pulsanti alla griglia di pixel fisici tramite nuovi helper di snapping per punti e lunghezze.
- Modifica il calcolo della larghezza della penna per agganciare lo spessore delle linee dei simboli ai pixel fisici, rispettando al contempo la trasformazione del painter.
- Affina l’allineamento del rettangolo dell’icona dei pulsanti testuali per ottenere un centraggio del testo più accurato e allineato ai pixel, senza offset manuali.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migliora il rendering di pulsanti e icone con uno snapping consapevole dell’alta densità (high-DPI), allineato ai pixel fisici, e layout e spessori delle linee (stroke widths) regolati di conseguenza.

Nuove funzionalità:
- Introdurre l’utility PixelSnapper per allineare punti, lunghezze e trasformazioni alla griglia di pixel fisici durante il rendering delle icone dei pulsanti.

Miglioramenti:
- Propagare la scalatura basata su devicePixelRatio e l’uso di PixelSnapper in tutti i percorsi di painting delle icone dei pulsanti per ottenere icone nitide sui display ad alta densità (high-DPI).
- Regolare le dimensioni e il centraggio delle icone nei pulsanti in modo che la geometria delle icone si allinei alla griglia di pixel fisici mantenendo le attuali semantiche di scalatura.
- Raffinare il calcolo della larghezza della penna in modo da allineare lo spessore delle linee ai pixel fisici per linee più uniformi sotto le trasformazioni del painter.
- Migliorare la gestione del rettangolo dell’icona nei pulsanti di testo affinché il centraggio dell’etichetta utilizzi posizionamento allineato ai pixel invece di offset manuali.

Build:
- Aggiungere `PixelSnapper.cc` alle sorgenti di build della decorazione in modo che la nuova utility venga compilata e linkata.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve button and icon rendering with high-DPI-aware, physical-pixel-aligned snapping and adjusted layout and stroke widths.

New Features:
- Introduce the PixelSnapper utility to snap points, lengths, and transforms to the physical pixel grid during button icon rendering.

Enhancements:
- Propagate devicePixelRatio-aware scaling and PixelSnapper usage through all button icon paint paths to produce crisp icons on high-DPI displays.
- Adjust icon sizing and centering in buttons so icon geometry aligns with the physical pixel grid while preserving existing scaling semantics.
- Refine pen width computation to snap stroke thickness to physical pixels for more uniform lines under painter transformations.
- Improve text button icon rectangle handling so label centering uses pixel-aligned positioning instead of manual offsets.

Build:
- Add PixelSnapper.cc to the decoration build sources so the new utility is compiled and linked.

</details>

Nuove funzionalità:
- Introduce l’utility PixelSnapper per agganciare punti, lunghezze e trasformazioni alla griglia di pixel fisici durante il rendering delle icone dei pulsanti.

Miglioramenti:
- Propaga la scalatura basata su devicePixelRatioF attraverso i percorsi di disegno dei pulsanti (button paint paths) e le funzioni di rendering specifiche delle icone (paintIcon) per supportare il rendering high-DPI.
- Regola il layout delle icone dei pulsanti, inclusa la traslazione al centro e il calcolo delle dimensioni logiche delle icone, per tenere conto dell’allineamento ai pixel fisici preservando al contempo la semantica di scalatura esistente.
- Affina il calcolo della larghezza della penna in modo da agganciare lo spessore dei tratti ai pixel fisici, garantendo un aspetto uniforme delle linee sotto le trasformazioni del painter.
- Aggiorna la gestione del rettangolo dell’icona nei pulsanti di testo per centrare il testo in modo più accurato con un posizionamento allineato ai pixel invece che con offset manuali.

Build:
- Aggiunge PixelSnapper.cc alle sorgenti di build della parte di decorazione, così che la nuova utility venga compilata e collegata.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migliora il rendering di pulsanti e icone con uno snapping consapevole dell’alta densità (high-DPI), allineato ai pixel fisici, e layout e spessori delle linee (stroke widths) regolati di conseguenza.

Nuove funzionalità:
- Introdurre l’utility PixelSnapper per allineare punti, lunghezze e trasformazioni alla griglia di pixel fisici durante il rendering delle icone dei pulsanti.

Miglioramenti:
- Propagare la scalatura basata su devicePixelRatio e l’uso di PixelSnapper in tutti i percorsi di painting delle icone dei pulsanti per ottenere icone nitide sui display ad alta densità (high-DPI).
- Regolare le dimensioni e il centraggio delle icone nei pulsanti in modo che la geometria delle icone si allinei alla griglia di pixel fisici mantenendo le attuali semantiche di scalatura.
- Raffinare il calcolo della larghezza della penna in modo da allineare lo spessore delle linee ai pixel fisici per linee più uniformi sotto le trasformazioni del painter.
- Migliorare la gestione del rettangolo dell’icona nei pulsanti di testo affinché il centraggio dell’etichetta utilizzi posizionamento allineato ai pixel invece di offset manuali.

Build:
- Aggiungere `PixelSnapper.cc` alle sorgenti di build della decorazione in modo che la nuova utility venga compilata e linkata.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve button and icon rendering with high-DPI-aware, physical-pixel-aligned snapping and adjusted layout and stroke widths.

New Features:
- Introduce the PixelSnapper utility to snap points, lengths, and transforms to the physical pixel grid during button icon rendering.

Enhancements:
- Propagate devicePixelRatio-aware scaling and PixelSnapper usage through all button icon paint paths to produce crisp icons on high-DPI displays.
- Adjust icon sizing and centering in buttons so icon geometry aligns with the physical pixel grid while preserving existing scaling semantics.
- Refine pen width computation to snap stroke thickness to physical pixels for more uniform lines under painter transformations.
- Improve text button icon rectangle handling so label centering uses pixel-aligned positioning instead of manual offsets.

Build:
- Add PixelSnapper.cc to the decoration build sources so the new utility is compiled and linked.

</details>

</details>

Miglioramenti:
- Propaga la scalatura basata su `devicePixelRatioF` attraverso tutti i percorsi di disegno delle icone dei pulsanti per supportare un rendering nitido sugli schermi ad alta densità (high-DPI).
- Introduce le utility `PixelSnapper` e le applica alle geometrie delle icone per allineare centri, forme e dimensioni alla griglia dei pixel fisici.
- Regola il calcolo della larghezza della penna per agganciare lo spessore del tratto ai pixel fisici rispettando al contempo la trasformazione del painter.
- Affina la gestione del rettangolo delle icone dei pulsanti con testo per ottenere un centraggio del testo più accurato e allineato ai pixel, senza offset manuali.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migliora il rendering di pulsanti e icone con uno snapping consapevole dell’alta densità (high-DPI), allineato ai pixel fisici, e layout e spessori delle linee (stroke widths) regolati di conseguenza.

Nuove funzionalità:
- Introdurre l’utility PixelSnapper per allineare punti, lunghezze e trasformazioni alla griglia di pixel fisici durante il rendering delle icone dei pulsanti.

Miglioramenti:
- Propagare la scalatura basata su devicePixelRatio e l’uso di PixelSnapper in tutti i percorsi di painting delle icone dei pulsanti per ottenere icone nitide sui display ad alta densità (high-DPI).
- Regolare le dimensioni e il centraggio delle icone nei pulsanti in modo che la geometria delle icone si allinei alla griglia di pixel fisici mantenendo le attuali semantiche di scalatura.
- Raffinare il calcolo della larghezza della penna in modo da allineare lo spessore delle linee ai pixel fisici per linee più uniformi sotto le trasformazioni del painter.
- Migliorare la gestione del rettangolo dell’icona nei pulsanti di testo affinché il centraggio dell’etichetta utilizzi posizionamento allineato ai pixel invece di offset manuali.

Build:
- Aggiungere `PixelSnapper.cc` alle sorgenti di build della decorazione in modo che la nuova utility venga compilata e linkata.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve button and icon rendering with high-DPI-aware, physical-pixel-aligned snapping and adjusted layout and stroke widths.

New Features:
- Introduce the PixelSnapper utility to snap points, lengths, and transforms to the physical pixel grid during button icon rendering.

Enhancements:
- Propagate devicePixelRatio-aware scaling and PixelSnapper usage through all button icon paint paths to produce crisp icons on high-DPI displays.
- Adjust icon sizing and centering in buttons so icon geometry aligns with the physical pixel grid while preserving existing scaling semantics.
- Refine pen width computation to snap stroke thickness to physical pixels for more uniform lines under painter transformations.
- Improve text button icon rectangle handling so label centering uses pixel-aligned positioning instead of manual offsets.

Build:
- Add PixelSnapper.cc to the decoration build sources so the new utility is compiled and linked.

</details>

Nuove funzionalità:
- Introduce l’utility PixelSnapper per agganciare punti, lunghezze e trasformazioni alla griglia di pixel fisici durante il rendering delle icone dei pulsanti.

Miglioramenti:
- Propaga la scalatura basata su devicePixelRatioF attraverso i percorsi di disegno dei pulsanti (button paint paths) e le funzioni di rendering specifiche delle icone (paintIcon) per supportare il rendering high-DPI.
- Regola il layout delle icone dei pulsanti, inclusa la traslazione al centro e il calcolo delle dimensioni logiche delle icone, per tenere conto dell’allineamento ai pixel fisici preservando al contempo la semantica di scalatura esistente.
- Affina il calcolo della larghezza della penna in modo da agganciare lo spessore dei tratti ai pixel fisici, garantendo un aspetto uniforme delle linee sotto le trasformazioni del painter.
- Aggiorna la gestione del rettangolo dell’icona nei pulsanti di testo per centrare il testo in modo più accurato con un posizionamento allineato ai pixel invece che con offset manuali.

Build:
- Aggiunge PixelSnapper.cc alle sorgenti di build della parte di decorazione, così che la nuova utility venga compilata e collegata.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migliora il rendering di pulsanti e icone con uno snapping consapevole dell’alta densità (high-DPI), allineato ai pixel fisici, e layout e spessori delle linee (stroke widths) regolati di conseguenza.

Nuove funzionalità:
- Introdurre l’utility PixelSnapper per allineare punti, lunghezze e trasformazioni alla griglia di pixel fisici durante il rendering delle icone dei pulsanti.

Miglioramenti:
- Propagare la scalatura basata su devicePixelRatio e l’uso di PixelSnapper in tutti i percorsi di painting delle icone dei pulsanti per ottenere icone nitide sui display ad alta densità (high-DPI).
- Regolare le dimensioni e il centraggio delle icone nei pulsanti in modo che la geometria delle icone si allinei alla griglia di pixel fisici mantenendo le attuali semantiche di scalatura.
- Raffinare il calcolo della larghezza della penna in modo da allineare lo spessore delle linee ai pixel fisici per linee più uniformi sotto le trasformazioni del painter.
- Migliorare la gestione del rettangolo dell’icona nei pulsanti di testo affinché il centraggio dell’etichetta utilizzi posizionamento allineato ai pixel invece di offset manuali.

Build:
- Aggiungere `PixelSnapper.cc` alle sorgenti di build della decorazione in modo che la nuova utility venga compilata e linkata.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve button and icon rendering with high-DPI-aware, physical-pixel-aligned snapping and adjusted layout and stroke widths.

New Features:
- Introduce the PixelSnapper utility to snap points, lengths, and transforms to the physical pixel grid during button icon rendering.

Enhancements:
- Propagate devicePixelRatio-aware scaling and PixelSnapper usage through all button icon paint paths to produce crisp icons on high-DPI displays.
- Adjust icon sizing and centering in buttons so icon geometry aligns with the physical pixel grid while preserving existing scaling semantics.
- Refine pen width computation to snap stroke thickness to physical pixels for more uniform lines under painter transformations.
- Improve text button icon rectangle handling so label centering uses pixel-aligned positioning instead of manual offsets.

Build:
- Add PixelSnapper.cc to the decoration build sources so the new utility is compiled and linked.

</details>

</details>

</details>

</details>

</details>