### PR TITLE
Introduce PixelSnapping helper class and adjust buttons to use it

### DIFF
--- a/src/AppIconButton.h
+++ b/src/AppIconButton.h
@@ -47,7 +47,8 @@ public:
         );
     }
     
-    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal) {
+    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const PixelSnapper &snapper) {
+        Q_UNUSED(snapper)
         //const QRectF contentRect = button->contentArea();
         const QSizeF appIconSize(
             iconRect.width() * 0.7,

--- a/src/ApplicationMenuButton.h
+++ b/src/ApplicationMenuButton.h
@@ -37,15 +37,15 @@ public:
     static void init(Button *button, KDecoration3::DecoratedWindow *decoratedClient) {
         button->setVisible(decoratedClient->hasApplicationMenu());
     }
-    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal) {
+    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const PixelSnapper &snapper) {
         Q_UNUSED(iconRect)
         button->setPenWidth(painter, 1.5);
-
-        const qreal spacing = 4.0;
+        
+        const qreal spacing = painter->pen().widthF() * 2.5;
         for (int i = -1; i <= 1; ++i) {
             const qreal y = i * spacing;
-            const QPointF left { -5.5, y };
-            const QPointF right { 5.5, y };
+            const QPointF left = snapper.snap(QPointF { -5.5, y });
+            const QPointF right = snapper.snap(QPointF { 5.5, y });
 
             painter->drawLine(left, right);
         }

--- a/src/Button.cc
+++ b/src/Button.cc
@@ -321,11 +321,9 @@ void Button::paint(QPainter *painter, const QRectF &repaintRegion)
     painter->setRenderHint(QPainter::Antialiasing, true);
     painter->setBrush(Qt::NoBrush);
 
-    const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : 1.0;
-
     const QRectF contentRect = contentArea();
 
-    PixelSnapper snapper(painter, dpr);
+    PixelSnapper snapper(painter);
 
     // TextButton and AppIconButton are special, so we don't scale the painter
     if (auto textButton = qobject_cast<TextButton*>(this)) {
@@ -356,8 +354,8 @@ void Button::paint(QPainter *painter, const QRectF &repaintRegion)
 
         // For a sharper image, we use physical-pixel-aligned positioning and scaling
         const qreal localToPhysicalScale = snapper.localToPhysicalScale();
-        const qreal physicalIconSize = (localToPhysicalScale > 0.0) ? qRound(size * localToPhysicalScale) : qRound(size * dpr);
-        const qreal iconLogicalSize = (localToPhysicalScale > 0.0) ? (physicalIconSize / localToPhysicalScale) : (physicalIconSize / dpr);
+        const qreal physicalIconSize = (localToPhysicalScale > 0.0) ? qRound(size * localToPhysicalScale) : qRound(size * snapper.dpr());
+        const qreal iconLogicalSize = (localToPhysicalScale > 0.0) ? (physicalIconSize / localToPhysicalScale) : (physicalIconSize / snapper.dpr());
 
         // Translate to a center aligned with physical pixel grid
         const QPointF center = contentRect.center();
@@ -369,7 +367,7 @@ void Button::paint(QPainter *painter, const QRectF &repaintRegion)
         
         setPenWidth(painter, KDecoration3::pixelSize(deco->window()->scale()));
 
-        PixelSnapper iconSnapper(painter, dpr);
+        PixelSnapper iconSnapper(painter);
 
         // Icons
         const QRectF iconRect(-9, -9, 18, 18);
@@ -453,8 +451,7 @@ void Button::setPenWidth(QPainter *painter, const qreal scale)
     pen.setCapStyle(Qt::RoundCap);
     pen.setJoinStyle(Qt::MiterJoin);
 
-    const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : 1.0;
-    PixelSnapper snapper(painter, dpr);
+    PixelSnapper snapper(painter);
     const qreal localToPhysicalScale = snapper.localToPhysicalScale();
 
     if (localToPhysicalScale > 0.0) {

--- a/src/Button.cc
+++ b/src/Button.cc
@@ -59,6 +59,7 @@
 #include <QTimer>
 #include <QDBusConnection>
 #include <QDBusMessage>
+#include <cmath>
 
 #define UPDATE_GEOM() update(geometry().adjusted(-1, -1, 1, 1))
 
@@ -320,13 +321,17 @@ void Button::paint(QPainter *painter, const QRectF &repaintRegion)
     painter->setRenderHint(QPainter::Antialiasing, true);
     painter->setBrush(Qt::NoBrush);
 
+    const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : 1.0;
+
     const QRectF contentRect = contentArea();
+
+    PixelSnapper snapper(painter, dpr);
 
     // TextButton and AppIconButton are special, so we don't scale the painter
     if (auto textButton = qobject_cast<TextButton*>(this)) {
-        textButton->paintIcon(painter, contentRect, 0);
+        textButton->paintIcon(painter, contentRect, snapper);
     } else if (type() == KDecoration3::DecorationButtonType::Menu) {
-        AppIconButton::paintIcon(this, painter, contentRect, 0);
+        AppIconButton::paintIcon(this, painter, contentRect, snapper);
     } else {
         // All further rendering is performed inside a 18x18 square
         const qreal width = contentRect.width();
@@ -349,64 +354,69 @@ void Button::paint(QPainter *painter, const QRectF &repaintRegion)
             size = qMin(width, height) * 0.6; // 60% of the Kwin Deco
         }
 
-        // For a sharper image, we use integer-based positioning
-        const int iconSize = qRound(size);
+        // For a sharper image, we use physical-pixel-aligned positioning and scaling
+        const qreal localToPhysicalScale = snapper.localToPhysicalScale();
+        const qreal physicalIconSize = (localToPhysicalScale > 0.0) ? qRound(size * localToPhysicalScale) : qRound(size * dpr);
+        const qreal iconLogicalSize = (localToPhysicalScale > 0.0) ? (physicalIconSize / localToPhysicalScale) : (physicalIconSize / dpr);
 
-        // Translate to a rounded center
+        // Translate to a center aligned with physical pixel grid
         const QPointF center = contentRect.center();
-        painter->translate(qRound(center.x()), qRound(center.y()));
+        const QPointF centerSnapped = snapper.snap(center);
+        painter->translate(centerSnapped);
 
-        // Scale by an integer-based factor
-        painter->scale(static_cast<qreal>(iconSize) / 18.0, static_cast<qreal>(iconSize) / 18.0);
+        // Scale by physical-aligned factor
+        painter->scale(iconLogicalSize / 18.0, iconLogicalSize / 18.0);
         
         setPenWidth(painter, KDecoration3::pixelSize(deco->window()->scale()));
+
+        PixelSnapper iconSnapper(painter, dpr);
 
         // Icons
         const QRectF iconRect(-9, -9, 18, 18);
         switch (type()) {
         // NOTE: Menu and ApplicationMenu are handled above
         case KDecoration3::DecorationButtonType::OnAllDesktops:
-            OnAllDesktopsButton::paintIcon(this, painter, iconRect, 0);
+            OnAllDesktopsButton::paintIcon(this, painter, iconRect, iconSnapper);
             break;
 
         case KDecoration3::DecorationButtonType::ContextHelp:
-            ContextHelpButton::paintIcon(this, painter, iconRect, 0);
+            ContextHelpButton::paintIcon(this, painter, iconRect, iconSnapper);
             break;
 
         case KDecoration3::DecorationButtonType::Shade:
-            ShadeButton::paintIcon(this, painter, iconRect, 0);
+            ShadeButton::paintIcon(this, painter, iconRect, iconSnapper);
             break;
 
         case KDecoration3::DecorationButtonType::KeepAbove:
-            KeepAboveButton::paintIcon(this, painter, iconRect, 0);
+            KeepAboveButton::paintIcon(this, painter, iconRect, iconSnapper);
             break;
 
         case KDecoration3::DecorationButtonType::KeepBelow:
-            KeepBelowButton::paintIcon(this, painter, iconRect, 0);
+            KeepBelowButton::paintIcon(this, painter, iconRect, iconSnapper);
             break;
 
         case KDecoration3::DecorationButtonType::Close:
-            CloseButton::paintIcon(this, painter, iconRect, 0);
+            CloseButton::paintIcon(this, painter, iconRect, iconSnapper);
             break;
 
         case KDecoration3::DecorationButtonType::Maximize:
-            MaximizeButton::paintIcon(this, painter, iconRect, 0);
+            MaximizeButton::paintIcon(this, painter, iconRect, iconSnapper);
             break;
 
         case KDecoration3::DecorationButtonType::Minimize:
-            MinimizeButton::paintIcon(this, painter, iconRect, 0);
+            MinimizeButton::paintIcon(this, painter, iconRect, iconSnapper);
             break;
         case KDecoration3::DecorationButtonType::Spacer:  
             break;            
 
 #if HAVE_EXCLUDE_FROM_CAPTURE
         case KDecoration3::DecorationButtonType::ExcludeFromCapture:
-            ExcludeFromCaptureButton::paintIcon(this, painter, iconRect, 0);
+            ExcludeFromCaptureButton::paintIcon(this, painter, iconRect, iconSnapper);
             break;
 #endif
 
         default:
-            paintIcon(painter, iconRect, 0);
+            paintIcon(painter, iconRect, iconSnapper);
             break;
         }
     }
@@ -414,10 +424,11 @@ void Button::paint(QPainter *painter, const QRectF &repaintRegion)
     painter->restore();
 }
 
-void Button::paintIcon(QPainter *painter, const QRectF &iconRect, const qreal)
+void Button::paintIcon(QPainter *painter, const QRectF &iconRect, const PixelSnapper &snapper)
 {
     Q_UNUSED(painter)
     Q_UNUSED(iconRect)
+    Q_UNUSED(snapper)
 }
 
 void Button::updateSize(qreal contentWidth, qreal contentHeight)
@@ -441,12 +452,22 @@ void Button::setPenWidth(QPainter *painter, const qreal scale)
     QPen pen(foregroundColor());
     pen.setCapStyle(Qt::RoundCap);
     pen.setJoinStyle(Qt::MiterJoin);
-    // Set the base pen width. This will be correctly scaled by the painter's
-    // transformation in the paint() method, preserving the behavior of
-    // lines getting thicker as the icon scales up.
-    pen.setWidthF(PenWidth::Symbol * scale);
+
+    const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : 1.0;
+    PixelSnapper snapper(painter, dpr);
+    const qreal localToPhysicalScale = snapper.localToPhysicalScale();
+
+    if (localToPhysicalScale > 0.0) {
+        const qreal nominalPhysicalWidth = PenWidth::Symbol * scale * localToPhysicalScale;
+        const qreal snappedPhysicalWidth = qMax(1.0, qRound(nominalPhysicalWidth * 2.0) / 2.0);
+        pen.setWidthF(snappedPhysicalWidth / localToPhysicalScale);
+    } else {
+        pen.setWidthF(PenWidth::Symbol * scale);
+    }
+
     painter->setPen(pen);
 }
+
 
 QColor Button::backgroundColor() const
 {

--- a/src/Button.h
+++ b/src/Button.h
@@ -27,8 +27,12 @@
 #include <QMouseEvent>
 #include <QRectF>
 #include <QVariantAnimation>
+#include <QTransform>
 
 class QTimer;
+class QPainter;
+
+#include "PixelSnapper.h"
 
 namespace Material
 {
@@ -93,7 +97,7 @@ signals:
     void paddingChanged();
 
 protected:
-    virtual void paintIcon(QPainter *painter, const QRectF &iconRect, const qreal);
+    virtual void paintIcon(QPainter *painter, const QRectF &iconRect, const PixelSnapper &snapper);
     virtual void updateSize(qreal contentWidth, qreal contentHeight);
     virtual void setHeight(qreal buttonHeight);
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,6 +63,7 @@ set (decoration_SRCS
     Button.cc
     Decoration.cc
     MenuOverflowButton.cc
+    PixelSnapper.cc
     SearchButton.cc
     TextButton.cc
     plugin.cc

--- a/src/CloseButton.h
+++ b/src/CloseButton.h
@@ -39,17 +39,18 @@ public:
 
         button->setVisible(decoratedClient->isCloseable());
     }
-    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal) {
-        Q_UNUSED(button)
+    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const PixelSnapper &snapper) {
         Q_UNUSED(iconRect)
-
-        //painter->setRenderHints(QPainter::Antialiasing, true);
 
         button->setPenWidth(painter, 1.5);
 
-        const qreal s = 5;
-        painter->drawLine(QPointF(-s, -s), QPointF(s, s));
-        painter->drawLine(QPointF(s, -s), QPointF(-s, s));
+        const QPointF p1 = snapper.snap(QPointF(-5.0, -5.0));
+        const QPointF p2 = snapper.snap(QPointF(5.0, 5.0));
+        const QPointF p3 = snapper.snap(QPointF(5.0, -5.0));
+        const QPointF p4 = snapper.snap(QPointF(-5.0, 5.0));
+
+        painter->drawLine(p1, p2);
+        painter->drawLine(p3, p4);
     }
 };
 

--- a/src/ContextHelpButton.h
+++ b/src/ContextHelpButton.h
@@ -50,9 +50,7 @@ public:
 
         const QPointF offset(-5.5, -5.5);
 
-        const QPointF topCurveTopLeft = snapper.snap(QPointF(1.5, 0.5) + offset);
-        const QPointF topCurveBottomRight = snapper.snap(QPointF(9.5, 6.5) + offset);
-        const QRectF topCurveRect(topCurveTopLeft, topCurveBottomRight);
+        const QRectF topCurveRect = snapper.snap(QRectF(QPointF(1.5, 0.5) + offset, QPointF(9.5, 6.5) + offset));
 
         QPainterPath path;
         path.moveTo(QPointF(topCurveRect.left(), topCurveRect.top() + topCurveRect.height() / 2.0));
@@ -69,9 +67,7 @@ public:
         painter->drawPath(path);
 
         // Dot
-        const QPointF dotTopLeft = snapper.snap(QPointF(5.0, 10.0) + offset);
-        const QPointF dotBottomRight = snapper.snap(QPointF(5.5, 10.5) + offset);
-        painter->drawRect(QRectF(dotTopLeft, dotBottomRight));
+        painter->drawRect(snapper.snap(QRectF(QPointF(5.0, 10.0) + offset, QPointF(5.5, 10.5) + offset)));
     }
 };
 

--- a/src/ContextHelpButton.h
+++ b/src/ContextHelpButton.h
@@ -44,37 +44,34 @@ public:
 
         button->setVisible(decoratedClient->providesContextHelp());
     }
-    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal) {
+    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const PixelSnapper &snapper) {
         Q_UNUSED(iconRect)
         button->setPenWidth(painter, 1.25);
 
-        //painter->setRenderHints(QPainter::Antialiasing, true);
-        
         const QPointF offset(-5.5, -5.5);
 
-        const QRectF topCurveRect = QRectF(
-            QPointF( 1.5, 0.5 ) + offset,
-            QSizeF( 8, 6 )
-        );
+        const QPointF topCurveTopLeft = snapper.snap(QPointF(1.5, 0.5) + offset);
+        const QPointF topCurveBottomRight = snapper.snap(QPointF(9.5, 6.5) + offset);
+        const QRectF topCurveRect(topCurveTopLeft, topCurveBottomRight);
+
         QPainterPath path;
-        path.moveTo( topCurveRect.center() - QPointF(topCurveRect.width()/2, 0) );
+        path.moveTo(QPointF(topCurveRect.left(), topCurveRect.top() + topCurveRect.height() / 2.0));
         path.arcTo(
             topCurveRect,
             180,
             -180
         );
         path.cubicTo(
-            QPointF( 7.8125, 5.9375 ) + offset,
-            QPointF( 5.625, 4.6875 ) + offset,
-            QPointF( 5, 8 ) + offset
+            snapper.snap(QPointF( 7.8125, 5.9375 ) + offset),
+            snapper.snap(QPointF( 5.625, 4.6875 ) + offset),
+            snapper.snap(QPointF( 5.0, 8.0 ) + offset)
         );
         painter->drawPath(path);
 
         // Dot
-        painter->drawRect( QRectF(
-            QPointF( 5, 10 ) + offset,
-            QSizeF( 0.5, 0.5 )
-        ));
+        const QPointF dotTopLeft = snapper.snap(QPointF(5.0, 10.0) + offset);
+        const QPointF dotBottomRight = snapper.snap(QPointF(5.5, 10.5) + offset);
+        painter->drawRect(QRectF(dotTopLeft, dotBottomRight));
     }
 };
 

--- a/src/ExcludeFromCaptureButton.h
+++ b/src/ExcludeFromCaptureButton.h
@@ -72,13 +72,8 @@ public:
         painter->drawLine(snapper.snap(QPointF(-6.2, -0.5)), snapper.snap(QPointF(6.2, -0.5)));
 
         // Glasses' lenses
-        const QPointF lensLeftTopLeft = snapper.snap(QPointF(-6.3, 1.5));
-        const QPointF lensLeftBottomRight = snapper.snap(QPointF(-1.7, 6.1));
-        painter->drawEllipse(QRectF(lensLeftTopLeft, lensLeftBottomRight));
-
-        const QPointF lensRightTopLeft = snapper.snap(QPointF(1.7, 1.5));
-        const QPointF lensRightBottomRight = snapper.snap(QPointF(6.3, 6.1));
-        painter->drawEllipse(QRectF(lensRightTopLeft, lensRightBottomRight));
+        painter->drawEllipse(snapper.snap(QRectF(QPointF(-6.3, 1.5), QPointF(-1.7, 6.1))));
+        painter->drawEllipse(snapper.snap(QRectF(QPointF(1.7, 1.5), QPointF(6.3, 6.1))));
 
         // Bridge between lenses
         painter->drawLine(snapper.snap(QPointF(-1.5, 3.8)), snapper.snap(QPointF(1.5, 3.8)));

--- a/src/ExcludeFromCaptureButton.h
+++ b/src/ExcludeFromCaptureButton.h
@@ -47,7 +47,7 @@ public:
     }
     
     //--- copied from Breeze for now. Copyright goes to KDE Developers
-    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal) {
+    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const PixelSnapper &snapper) {
         Q_UNUSED(iconRect)
         const auto *deco = qobject_cast<Decoration *>(button->decoration());
         if (!deco) {
@@ -58,25 +58,30 @@ public:
         // A spy hat (like view-private.svg icon)
         // Hat crown with dip/crease at top (filled)
         const QVector<QPointF> crownPoints {
-            QPointF(-4.1, -2.5),
-            QPointF(-3.2, -6.1),
-            QPointF(0, -5),
-            QPointF(3.2, -6.1),
-            QPointF(4.1, -2.5)
+            snapper.snap(QPointF(-4.1, -2.5)),
+            snapper.snap(QPointF(-3.2, -6.1)),
+            snapper.snap(QPointF(0, -5)),
+            snapper.snap(QPointF(3.2, -6.1)),
+            snapper.snap(QPointF(4.1, -2.5))
         };
         painter->setBrush(painter->pen().color());
         painter->drawPolygon(crownPoints);
         painter->setBrush(Qt::NoBrush);
 
         // Hat brim
-        painter->drawLine(QPointF(-6.2, -0.5), QPointF(6.2, -0.5));
+        painter->drawLine(snapper.snap(QPointF(-6.2, -0.5)), snapper.snap(QPointF(6.2, -0.5)));
 
         // Glasses' lenses
-        painter->drawEllipse(QPointF(-4, 3.8), 2.3, 2.3);
-        painter->drawEllipse(QPointF(4, 3.8), 2.3, 2.3);
+        const QPointF lensLeftTopLeft = snapper.snap(QPointF(-6.3, 1.5));
+        const QPointF lensLeftBottomRight = snapper.snap(QPointF(-1.7, 6.1));
+        painter->drawEllipse(QRectF(lensLeftTopLeft, lensLeftBottomRight));
+
+        const QPointF lensRightTopLeft = snapper.snap(QPointF(1.7, 1.5));
+        const QPointF lensRightBottomRight = snapper.snap(QPointF(6.3, 6.1));
+        painter->drawEllipse(QRectF(lensRightTopLeft, lensRightBottomRight));
 
         // Bridge between lenses
-        painter->drawLine(QPointF(-1.5, 3.8), QPointF(1.5, 3.8));
+        painter->drawLine(snapper.snap(QPointF(-1.5, 3.8)), snapper.snap(QPointF(1.5, 3.8)));
     }
 };
 #endif

--- a/src/KeepAboveButton.h
+++ b/src/KeepAboveButton.h
@@ -39,21 +39,21 @@ public:
 
         button->setVisible(true);
     }
-    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal) {
+    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const PixelSnapper &snapper) {
         Q_UNUSED(iconRect)
         button->setPenWidth(painter, 1.25);
 
-        const QPointF offset(-5, -5);
+        const QPointF offset(-5.0, -5.0);
         painter->drawPolyline(  QVector<QPointF> {
-            QPointF( 0.5, 4.75 ) + offset,
-            QPointF( 5.0, 0.25 ) + offset,
-            QPointF( 9.5, 4.75 ) + offset
+            snapper.snap(QPointF( 0.0, 5.0 ) + offset),
+            snapper.snap(QPointF( 5.0, 0.0 ) + offset),
+            snapper.snap(QPointF( 10.0, 5.0 ) + offset)
         });
 
         painter->drawPolyline(  QVector<QPointF> {
-            QPointF( 0.5, 9.75 ) + offset,
-            QPointF( 5.0, 5.25 ) + offset,
-            QPointF( 9.5, 9.75 ) + offset
+            snapper.snap(QPointF( 0.0, 10.0 ) + offset),
+            snapper.snap(QPointF( 5.0, 5.0 ) + offset),
+            snapper.snap(QPointF( 10.0, 10.0 ) + offset)
         });
     }
 };

--- a/src/KeepBelowButton.h
+++ b/src/KeepBelowButton.h
@@ -39,21 +39,21 @@ public:
 
         button->setVisible(true);
     }
-    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal) {
+    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const PixelSnapper &snapper) {
         Q_UNUSED(iconRect)
         button->setPenWidth(painter, 1.25);
 
-        const QPointF offset(-5, -5);
+        const QPointF offset(-5.0, -5.0);
         painter->drawPolyline(  QVector<QPointF> {
-            QPointF( 0.5, 0.25 ) + offset,
-            QPointF( 5.0, 4.75 ) + offset,
-            QPointF( 9.5, 0.25 ) + offset
+            snapper.snap(QPointF( 0.0, 0.0 ) + offset),
+            snapper.snap(QPointF( 5.0, 5.0 ) + offset),
+            snapper.snap(QPointF( 10.0, 0.0 ) + offset)
         });
 
         painter->drawPolyline(  QVector<QPointF> {
-            QPointF( 0.5, 5.25 ) + offset,
-            QPointF( 5.0, 9.75 ) + offset,
-            QPointF( 9.5, 5.25 ) + offset
+            snapper.snap(QPointF( 0.0, 5.0 ) + offset),
+            snapper.snap(QPointF( 5.0, 10.0 ) + offset),
+            snapper.snap(QPointF( 10.0, 5.0 ) + offset)
         });
     }
 };

--- a/src/MaximizeButton.h
+++ b/src/MaximizeButton.h
@@ -62,10 +62,7 @@ public:
                 snapper.snap(QPointF(5.0 - offset, 5.0 - offset))
             });
         } else {
-            const QPointF topLeft = snapper.snap(QPointF(-5.0, -5.0));
-            const QPointF bottomRight = snapper.snap(QPointF(5.0, 5.0));
-            const QRectF innerRect(topLeft, bottomRight);
-            painter->drawRect(innerRect);
+            painter->drawRect(snapper.snap(QRectF(QPointF(-5.0, -5.0), QPointF(5.0, 5.0))));
         }
     }
 };

--- a/src/MaximizeButton.h
+++ b/src/MaximizeButton.h
@@ -39,29 +39,32 @@ public:
 
         button->setVisible(decoratedClient->isMaximizeable());
     }
-    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal) {
+    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const PixelSnapper &snapper) {
         Q_UNUSED(iconRect)
-        const QRectF innerRect(-5, -5, 10, 10);
         button->setPenWidth(painter, 1.5);
+
         if (button->isChecked()) {
-            const int offset = 2;
+            const qreal offset = painter->pen().widthF() * 1.5;
             // Outline of first square, "on top", aligned bottom left.
             painter->drawPolygon(QVector<QPointF> {
-                innerRect.bottomLeft(),
-                innerRect.topLeft() + QPointF(0, offset),
-                innerRect.topRight() + QPointF(-offset, offset),
-                innerRect.bottomRight() + QPointF(-offset, 0)
+                snapper.snap(QPointF(-5.0, 5.0)),
+                snapper.snap(QPointF(-5.0, -5.0 + offset)),
+                snapper.snap(QPointF(5.0 - offset, -5.0 + offset)),
+                snapper.snap(QPointF(5.0 - offset, 5.0))
             });
 
             // Partially occluded square, "below" first square, aligned top right.
             painter->drawPolyline(QVector<QPointF> {
-                innerRect.topLeft() + QPointF(offset, offset),
-                innerRect.topLeft() + QPointF(offset, 0),
-                innerRect.topRight(),
-                innerRect.bottomRight() + QPointF(0, -offset),
-                innerRect.bottomRight() + QPointF(-offset, -offset)
+                snapper.snap(QPointF(-5.0 + offset, -5.0 + offset)),
+                snapper.snap(QPointF(-5.0 + offset, -5.0)),
+                snapper.snap(QPointF(5.0, -5.0)),
+                snapper.snap(QPointF(5.0, 5.0 - offset)),
+                snapper.snap(QPointF(5.0 - offset, 5.0 - offset))
             });
         } else {
+            const QPointF topLeft = snapper.snap(QPointF(-5.0, -5.0));
+            const QPointF bottomRight = snapper.snap(QPointF(5.0, 5.0));
+            const QRectF innerRect(topLeft, bottomRight);
             painter->drawRect(innerRect);
         }
     }

--- a/src/MenuOverflowButton.cc
+++ b/src/MenuOverflowButton.cc
@@ -41,9 +41,9 @@ MenuOverflowButton::~MenuOverflowButton()
 {
 }
 
-void MenuOverflowButton::paintIcon(QPainter *painter, const QRectF &iconRect, const qreal)
+void MenuOverflowButton::paintIcon(QPainter *painter, const QRectF &iconRect, const PixelSnapper &snapper)
 {
-    ApplicationMenuButton::paintIcon(this, painter, iconRect, 0);
+    ApplicationMenuButton::paintIcon(this, painter, iconRect, snapper);
 }
 
 } // namespace Material

--- a/src/MenuOverflowButton.h
+++ b/src/MenuOverflowButton.h
@@ -34,7 +34,7 @@ public:
     MenuOverflowButton(Decoration *decoration, const int buttonIndex, QObject *parent = nullptr);
     ~MenuOverflowButton() override;
 
-    void paintIcon(QPainter *painter, const QRectF &iconRect, const qreal) override;
+    void paintIcon(QPainter *painter, const QRectF &iconRect, const PixelSnapper &snapper) override;
 };
 
 } // namespace Material

--- a/src/MinimizeButton.h
+++ b/src/MinimizeButton.h
@@ -39,12 +39,15 @@ public:
 
         button->setVisible(decoratedClient->isMinimizeable());
     }
-    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal) {
-        //Q_UNUSED(button)
+    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const PixelSnapper &snapper) {
         Q_UNUSED(iconRect)
         
         button->setPenWidth(painter, 1.75);
-        painter->drawLine(QPointF(-5, 0), QPointF(5, 0));
+
+        const QPointF p1 = snapper.snap(QPointF(-5.0, 0.0));
+        const QPointF p2 = snapper.snap(QPointF(5.0, 0.0));
+
+        painter->drawLine(p1, p2);
     }
 };
 

--- a/src/OnAllDesktopsButton.h
+++ b/src/OnAllDesktopsButton.h
@@ -39,17 +39,15 @@ public:
 
         button->setVisible(true);
     }
-    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal) {
+    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const PixelSnapper &snapper) {
         Q_UNUSED(iconRect)
-        //painter->setRenderHints(QPainter::Antialiasing, true);
         button->setPenWidth(painter, 1.25);
 
-        const int radius = 6;
         painter->drawPolygon( QVector<QPointF> {
-            QPointF(-radius, 0),
-            QPointF(0, -radius),
-            QPointF(radius, 0),
-            QPointF(0, radius)
+            snapper.snap(QPointF(-6.0, 0.0)),
+            snapper.snap(QPointF(0.0, -6.0)),
+            snapper.snap(QPointF(6.0, 0.0)),
+            snapper.snap(QPointF(0.0, 6.0))
         });
     }
 };

--- a/src/PixelSnapper.cc
+++ b/src/PixelSnapper.cc
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026 Guido Iodice <guido[dot]iodice[at]gmail[dot]com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "PixelSnapper.h"
+#include <QPainter>
+#include <cmath>
+
+namespace Material
+{
+
+PixelSnapper::PixelSnapper(QPainter *painter, const qreal dpr)
+    : m_trans(painter->transform())
+    , m_dpr(dpr)
+    , m_invertible(false)
+{
+    m_inv = m_trans.inverted(&m_invertible);
+}
+
+QPointF PixelSnapper::snap(const QPointF &p) const
+{
+    if (m_dpr > 0.0 && m_invertible) {
+        const QPointF devInd = m_trans.map(p);
+        const QPointF phys(devInd.x() * m_dpr, devInd.y() * m_dpr);
+        const QPointF physSnapped(qRound(phys.x()), qRound(phys.y()));
+        const QPointF devIndSnapped(physSnapped.x() / m_dpr, physSnapped.y() / m_dpr);
+        return m_inv.map(devIndSnapped);
+    }
+    return p;
+}
+
+qreal PixelSnapper::localToPhysicalScale() const
+{
+    return std::hypot(m_trans.m11(), m_trans.m12()) * m_dpr;
+}
+
+} // namespace Material

--- a/src/PixelSnapper.cc
+++ b/src/PixelSnapper.cc
@@ -44,7 +44,8 @@ QPointF PixelSnapper::snap(const QPointF &p) const
 
 QRectF PixelSnapper::snap(const QRectF &rect) const
 {
-    return QRectF(snap(rect.topLeft()), snap(rect.bottomRight()));
+    const QRectF normRect = rect.normalized();
+    return QRectF(snap(normRect.topLeft()), snap(normRect.bottomRight()));
 }
 
 qreal PixelSnapper::localToPhysicalScale() const

--- a/src/PixelSnapper.cc
+++ b/src/PixelSnapper.cc
@@ -42,8 +42,16 @@ QPointF PixelSnapper::snap(const QPointF &p) const
     return p;
 }
 
+QRectF PixelSnapper::snap(const QRectF &rect) const
+{
+    return QRectF(snap(rect.topLeft()), snap(rect.bottomRight()));
+}
+
 qreal PixelSnapper::localToPhysicalScale() const
 {
+    // Semantics & Assumptions check:
+    // This assumes uniform scale and no rotation/shear. If those assumptions are violated, 
+    // it computes the scale factor of the X-axis mapping under the transformation.
     if (m_dpr > 0.0 && m_invertible) {
         return std::hypot(m_trans.m11(), m_trans.m12()) * m_dpr;
     }

--- a/src/PixelSnapper.cc
+++ b/src/PixelSnapper.cc
@@ -22,9 +22,9 @@
 namespace Material
 {
 
-PixelSnapper::PixelSnapper(QPainter *painter, const qreal dpr)
-    : m_trans(painter->transform())
-    , m_dpr(dpr)
+PixelSnapper::PixelSnapper(QPainter *painter)
+    : m_trans(painter ? painter->transform() : QTransform())
+    , m_dpr(painter && painter->device() ? painter->device()->devicePixelRatioF() : 1.0)
     , m_invertible(false)
 {
     m_inv = m_trans.inverted(&m_invertible);
@@ -44,7 +44,10 @@ QPointF PixelSnapper::snap(const QPointF &p) const
 
 qreal PixelSnapper::localToPhysicalScale() const
 {
-    return std::hypot(m_trans.m11(), m_trans.m12()) * m_dpr;
+    if (m_dpr > 0.0 && m_invertible) {
+        return std::hypot(m_trans.m11(), m_trans.m12()) * m_dpr;
+    }
+    return 0.0;
 }
 
 } // namespace Material

--- a/src/PixelSnapper.h
+++ b/src/PixelSnapper.h
@@ -19,6 +19,7 @@
 
 #include <QTransform>
 #include <QPointF>
+#include <QRectF>
 
 class QPainter;
 
@@ -31,7 +32,20 @@ public:
     explicit PixelSnapper(QPainter *painter);
 
     QPointF snap(const QPointF &p) const;
+    QRectF snap(const QRectF &rect) const;
+
+    /**
+     * @brief Computes the scaling factor from local coordinates to physical device pixels.
+     * 
+     * @note Semantics & Assumptions:
+     * - This method assumes uniform scaling (scaling on the X axis is identical to the Y axis).
+     * - It assumes there is no rotation or shear applied to the transformation matrix.
+     * - In the presence of non-uniform scaling or rotation/shear, it returns the scaling factor
+     *   along the transformed X axis (calculating the magnitude/hypotenuse of the first column
+     *   of the transformation matrix), multiplied by the device pixel ratio (DPR).
+     */
     qreal localToPhysicalScale() const;
+    
     qreal dpr() const { return m_dpr; }
 
 private:

--- a/src/PixelSnapper.h
+++ b/src/PixelSnapper.h
@@ -28,7 +28,7 @@ namespace Material
 class PixelSnapper
 {
 public:
-    PixelSnapper(QPainter *painter, const qreal dpr);
+    explicit PixelSnapper(QPainter *painter);
 
     QPointF snap(const QPointF &p) const;
     qreal localToPhysicalScale() const;

--- a/src/PixelSnapper.h
+++ b/src/PixelSnapper.h
@@ -1,5 +1,5 @@
 /*
- * * Copyright (C) 2025 Guido Iodice <guido[dot]iodice[at]gmail[dot]com>
+ * Copyright (C) 2026 Guido Iodice <guido[dot]iodice[at]gmail[dot]com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,22 +17,28 @@
 
 #pragma once
 
-#include "AppMenuButton.h"
+#include <QTransform>
+#include <QPointF>
+
+class QPainter;
 
 namespace Material
 {
 
-class Decoration;
-
-class SearchButton : public AppMenuButton
+class PixelSnapper
 {
-    Q_OBJECT
 public:
-    explicit SearchButton(Decoration *decoration, const int buttonIndex, QObject *parent = nullptr);
-    ~SearchButton() override;
+    PixelSnapper(QPainter *painter, const qreal dpr);
 
-protected:
-    void paintIcon(QPainter *painter, const QRectF &iconRect, const PixelSnapper &snapper) override;
+    QPointF snap(const QPointF &p) const;
+    qreal localToPhysicalScale() const;
+    qreal dpr() const { return m_dpr; }
+
+private:
+    QTransform m_trans;
+    QTransform m_inv;
+    qreal m_dpr;
+    bool m_invertible;
 };
 
 } // namespace Material

--- a/src/SearchButton.cc
+++ b/src/SearchButton.cc
@@ -38,9 +38,7 @@ void SearchButton::paintIcon(QPainter *painter, const QRectF &iconRect, const Pi
     //painter->setRenderHint(QPainter::Antialiasing, true);
     setPenWidth(painter, 1.25);
 
-    const QPointF circleTopLeft = snapper.snap(QPointF(-6.0, -6.0));
-    const QPointF circleBottomRight = snapper.snap(QPointF(2.0, 2.0));
-    const QRectF circleRect(circleTopLeft, circleBottomRight);
+    const QRectF circleRect = snapper.snap(QRectF(QPointF(-6.0, -6.0), QPointF(2.0, 2.0)));
     painter->drawEllipse(circleRect);
 
     const qreal sqrt2 = std::sqrt(2.0);

--- a/src/SearchButton.cc
+++ b/src/SearchButton.cc
@@ -50,11 +50,12 @@ void SearchButton::paintIcon(QPainter *painter, const QRectF &iconRect, const Pi
     const QPointF circleCenter = circleRect.center();
     const qreal rx = circleRect.width() / 2.0;
     const qreal ry = circleRect.height() / 2.0;
-    const QPointF handleStart(circleCenter.x() + rx / sqrt2, circleCenter.y() + ry / sqrt2);
-
-    const QPointF center(-2.0, -2.0);
-    const QPointF endLogical = center + QPointF((radius + handleLength) / sqrt2, (radius + handleLength) / sqrt2);
-    const QPointF handleEnd = snapper.snap(endLogical);
+    const QPointF handleStart = snapper.snap(
+        circleCenter + QPointF(rx / sqrt2, ry / sqrt2));
+    const QPointF handleEnd = snapper.snap(
+        circleCenter + QPointF(
+            (rx + handleLength) / sqrt2,
+            (ry + handleLength) / sqrt2));
     painter->drawLine(handleStart, handleEnd);
 }
 

--- a/src/SearchButton.cc
+++ b/src/SearchButton.cc
@@ -32,22 +32,29 @@ SearchButton::SearchButton(Decoration *decoration, const int buttonIndex, QObjec
 
 SearchButton::~SearchButton() = default;
 
-void SearchButton::paintIcon(QPainter *painter, const QRectF &iconRect, const qreal)
+void SearchButton::paintIcon(QPainter *painter, const QRectF &iconRect, const PixelSnapper &snapper)
 {
     Q_UNUSED(iconRect)
     //painter->setRenderHint(QPainter::Antialiasing, true);
     setPenWidth(painter, 1.25);
 
-    const qreal circleRadius = 4.0;
-    const QPointF circleCenter(-2, -2);
-    painter->drawEllipse(circleCenter, circleRadius, circleRadius);
+    const QPointF circleTopLeft = snapper.snap(QPointF(-6.0, -6.0));
+    const QPointF circleBottomRight = snapper.snap(QPointF(2.0, 2.0));
+    const QRectF circleRect(circleTopLeft, circleBottomRight);
+    painter->drawEllipse(circleRect);
 
+    const qreal sqrt2 = std::sqrt(2.0);
+    const qreal radius = 4.0;
     const qreal handleLength = 5.0;
-    const qreal sqrt2 = qSqrt(2);
-    const qreal handleAttachOffset = circleRadius / sqrt2;
-    const QPointF handleStart = circleCenter + QPointF(handleAttachOffset, handleAttachOffset);
-    const qreal handleEndOffset = (circleRadius + handleLength) / sqrt2;
-    const QPointF handleEnd = circleCenter + QPointF(handleEndOffset, handleEndOffset);
+
+    const QPointF circleCenter = circleRect.center();
+    const qreal rx = circleRect.width() / 2.0;
+    const qreal ry = circleRect.height() / 2.0;
+    const QPointF handleStart(circleCenter.x() + rx / sqrt2, circleCenter.y() + ry / sqrt2);
+
+    const QPointF center(-2.0, -2.0);
+    const QPointF endLogical = center + QPointF((radius + handleLength) / sqrt2, (radius + handleLength) / sqrt2);
+    const QPointF handleEnd = snapper.snap(endLogical);
     painter->drawLine(handleStart, handleEnd);
 }
 

--- a/src/SearchButton.cc
+++ b/src/SearchButton.cc
@@ -44,7 +44,6 @@ void SearchButton::paintIcon(QPainter *painter, const QRectF &iconRect, const Pi
     painter->drawEllipse(circleRect);
 
     const qreal sqrt2 = std::sqrt(2.0);
-    const qreal radius = 4.0;
     const qreal handleLength = 5.0;
 
     const QPointF circleCenter = circleRect.center();

--- a/src/ShadeButton.h
+++ b/src/ShadeButton.h
@@ -40,33 +40,34 @@ public:
 
         button->setVisible(decoratedClient->isShadeable());
     }
-    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const qreal) {
+    static void paintIcon(Button *button, QPainter *painter, const QRectF &iconRect, const PixelSnapper &snapper) {
         Q_UNUSED(iconRect)
-        const QPointF offset(-5, -5);
+
+        const QPointF offset(-5.0, -5.0);
 
         if (button->isChecked()) {
             button->setPenWidth(painter, 1.25);
             painter->drawLine( 
-                QPointF( 0, 2 ) + offset,
-                QPointF( 10, 2 ) + offset
+                snapper.snap(QPointF( 0, 2 ) + offset),
+                snapper.snap(QPointF( 10, 2 ) + offset)
             );
             button->setPenWidth(painter, 1.25);
             painter->drawPolyline(  QVector<QPointF> {
-                QPointF( 0.5, 5.25 ) + offset,
-                QPointF( 5.0, 9.75 ) + offset,
-                QPointF( 9.5, 5.25 ) + offset
+                snapper.snap(QPointF( 0.0, 5.0 ) + offset),
+                snapper.snap(QPointF( 5.0, 10.0 ) + offset),
+                snapper.snap(QPointF( 10.0, 5.0 ) + offset)
             });
         } else {
             button->setPenWidth(painter, 1.25);
             painter->drawLine( 
-                QPointF( 0, 2 ) + offset,
-                QPointF( 10, 2 ) + offset
+                snapper.snap(QPointF( 0, 2 ) + offset),
+                snapper.snap(QPointF( 10, 2 ) + offset)
             );
             button->setPenWidth(painter, 1.25);
             painter->drawPolyline( QVector<QPointF> {
-                QPointF( 0.5, 9.75 ) + offset,
-                QPointF( 5.0, 5.25 ) + offset,
-                QPointF( 9.5, 9.75 ) + offset
+                snapper.snap(QPointF( 0.0, 10.0 ) + offset),
+                snapper.snap(QPointF( 5.0, 5.0 ) + offset),
+                snapper.snap(QPointF( 10.0, 10.0 ) + offset)
             });
         }
     }

--- a/src/TextButton.cc
+++ b/src/TextButton.cc
@@ -50,12 +50,9 @@ void TextButton::paintIcon(QPainter *painter, const QRectF &iconRect, const Pixe
     painter->setRenderHint(QPainter::TextAntialiasing);
 
     // Compute stable, physical-pixel-aligned dimensions to prevent subpixel text blurring
-    const QPointF p0 = snapper.snap(QPointF(0.0, 0.0));
-    const QPointF pSize = snapper.snap(QPointF(iconRect.width(), iconRect.height()));
-    const QSizeF snappedSize(pSize.x() - p0.x(), pSize.y() - p0.y());
-
     const QPointF snappedTopLeft = snapper.snap(iconRect.topLeft());
-    const QRectF snappedRect(snappedTopLeft, snappedSize);
+    const QPointF snappedBottomRight = snapper.snap(iconRect.bottomRight());
+    const QRectF snappedRect(snappedTopLeft, snappedBottomRight);
 
     // TODO: Use Qt::TextShowMnemonic when Alt is pressed
     const bool isAltPressed = false;

--- a/src/TextButton.cc
+++ b/src/TextButton.cc
@@ -40,7 +40,7 @@ TextButton::~TextButton()
 {
 }
 
-void TextButton::paintIcon(QPainter *painter, const QRectF &iconRect, const qreal)
+void TextButton::paintIcon(QPainter *painter, const QRectF &iconRect, const PixelSnapper &snapper)
 {
     const auto *deco = qobject_cast<Decoration *>(decoration());
 
@@ -49,10 +49,18 @@ void TextButton::paintIcon(QPainter *painter, const QRectF &iconRect, const qrea
     painter->setPen(foregroundColor());
     painter->setRenderHint(QPainter::TextAntialiasing);
 
+    // Compute stable, physical-pixel-aligned dimensions to prevent subpixel text blurring
+    const QPointF p0 = snapper.snap(QPointF(0.0, 0.0));
+    const QPointF pSize = snapper.snap(QPointF(iconRect.width(), iconRect.height()));
+    const QSizeF snappedSize(pSize.x() - p0.x(), pSize.y() - p0.y());
+
+    const QPointF snappedTopLeft = snapper.snap(iconRect.topLeft());
+    const QRectF snappedRect(snappedTopLeft, snappedSize);
+
     // TODO: Use Qt::TextShowMnemonic when Alt is pressed
     const bool isAltPressed = false;
     const Qt::TextFlag mnemonicFlag = isAltPressed ? Qt::TextShowMnemonic : Qt::TextHideMnemonic;
-    painter->drawText(iconRect.translated(1.0, 0.0), mnemonicFlag | Qt::AlignCenter | Qt::TextSingleLine, m_text); // translating 1 pixel seems the only way to perfect centering the text.
+    painter->drawText(snappedRect, mnemonicFlag | Qt::AlignCenter | Qt::TextSingleLine, m_text); 
 }
 
 QSizeF TextButton::getTextSize() const

--- a/src/TextButton.cc
+++ b/src/TextButton.cc
@@ -50,9 +50,7 @@ void TextButton::paintIcon(QPainter *painter, const QRectF &iconRect, const Pixe
     painter->setRenderHint(QPainter::TextAntialiasing);
 
     // Compute stable, physical-pixel-aligned dimensions to prevent subpixel text blurring
-    const QPointF snappedTopLeft = snapper.snap(iconRect.topLeft());
-    const QPointF snappedBottomRight = snapper.snap(iconRect.bottomRight());
-    const QRectF snappedRect(snappedTopLeft, snappedBottomRight);
+    const QRectF snappedRect = snapper.snap(iconRect);
 
     // TODO: Use Qt::TextShowMnemonic when Alt is pressed
     const bool isAltPressed = false;

--- a/src/TextButton.h
+++ b/src/TextButton.h
@@ -40,7 +40,7 @@ public:
     Q_PROPERTY(QAction* action READ action WRITE setAction NOTIFY actionChanged)
     Q_PROPERTY(QString text READ text WRITE setText NOTIFY textChanged)
 
-    void paintIcon(QPainter *painter, const QRectF &iconRect, const qreal) override;
+    void paintIcon(QPainter *painter, const QRectF &iconRect, const PixelSnapper &snapper) override;
 
     QAction* action() const;
     void setAction(QAction *set);


### PR DESCRIPTION
## Summary by Sourcery

Introdurre un helper riutilizzabile PixelSnapper e aggiornare il rendering dei pulsanti per allineare icone e testo alle griglie di pixel fisici, ottenendo una resa più nitida su display ad alta DPI e con scaling.

Nuove funzionalità:
- Aggiungere un’utility PixelSnapper che aggancia punti e rettangoli ai pixel fisici del dispositivo e espone le informazioni di scalatura locale‑a‑fisico.

Miglioramenti:
- Rifinire le dimensioni delle icone dei pulsanti, il loro centraggio e lo spessore dei tratti in modo da utilizzare lo snapping basato su PixelSnapper per un aspetto più definito su tutte le impostazioni di DPI e scalatura.
- Aggiornare tutte le routine di painting delle icone dei pulsanti di decorazione per accettare PixelSnapper e disegnare forme allineate alla griglia di pixel fisici.
- Regolare il rendering dei pulsanti testuali per disegnare le didascalie all’interno di un rettangolo di delimitazione “agganciato”, riducendo la sfocatura da subpixel.

Build:
- Registrare il nuovo file sorgente PixelSnapper nella configurazione di build CMake.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a reusable PixelSnapper helper and update button rendering to align icons and text to physical pixel grids for sharper visuals on high-DPI and scaled displays.

New Features:
- Add a PixelSnapper utility that snaps points and rectangles to physical device pixels and exposes local-to-physical scaling information.

Enhancements:
- Refine button icon sizing, centering, and stroke thickness to use PixelSnapper-based snapping for crisper appearance across DPI and scaling settings.
- Update all decoration button icon painting routines to accept PixelSnapper and render shapes aligned to the physical pixel grid.
- Adjust text button rendering to draw captions within a snapped bounding rectangle to reduce subpixel blurring.

Build:
- Register the new PixelSnapper source file in the CMake build configuration.

</details>

Miglioramenti:
- Aggiungere un helper riutilizzabile PixelSnapper che mappa le coordinate locali alle posizioni allineate ai pixel fisici più vicini e espone le informazioni di scala locale–fisica.
- Rifinire le dimensioni delle icone dei pulsanti, il loro centraggio e gli spessori delle linee per rispettare le griglie di pixel fisici e i rapporti di pixel dei dispositivi, migliorando la nitidezza su schermi scalati e ad alta DPI.
- Aggiornare tutte le routine di disegno delle icone dei pulsanti (chiudi, ingrandisci, minimizza, ombreggia, mantieni sopra/sotto, guida contestuale, su-tutti-i-desktop, cerca, testo, overflow menu, menu app, escludi-dalla-cattura) per usare lo snapping basato su PixelSnapper.
- Regolare il rendering dei pulsanti di testo per utilizzare un rettangolo di bounding “snapppato” per ridurre la sfocatura sub-pixel delle didascalie.

Build:
- Registrare il nuovo file sorgente PixelSnapper nella configurazione di build di CMake.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introdurre un helper riutilizzabile PixelSnapper e aggiornare il rendering dei pulsanti per allineare icone e testo alle griglie di pixel fisici, ottenendo una resa più nitida su display ad alta DPI e con scaling.

Nuove funzionalità:
- Aggiungere un’utility PixelSnapper che aggancia punti e rettangoli ai pixel fisici del dispositivo e espone le informazioni di scalatura locale‑a‑fisico.

Miglioramenti:
- Rifinire le dimensioni delle icone dei pulsanti, il loro centraggio e lo spessore dei tratti in modo da utilizzare lo snapping basato su PixelSnapper per un aspetto più definito su tutte le impostazioni di DPI e scalatura.
- Aggiornare tutte le routine di painting delle icone dei pulsanti di decorazione per accettare PixelSnapper e disegnare forme allineate alla griglia di pixel fisici.
- Regolare il rendering dei pulsanti testuali per disegnare le didascalie all’interno di un rettangolo di delimitazione “agganciato”, riducendo la sfocatura da subpixel.

Build:
- Registrare il nuovo file sorgente PixelSnapper nella configurazione di build CMake.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a reusable PixelSnapper helper and update button rendering to align icons and text to physical pixel grids for sharper visuals on high-DPI and scaled displays.

New Features:
- Add a PixelSnapper utility that snaps points and rectangles to physical device pixels and exposes local-to-physical scaling information.

Enhancements:
- Refine button icon sizing, centering, and stroke thickness to use PixelSnapper-based snapping for crisper appearance across DPI and scaling settings.
- Update all decoration button icon painting routines to accept PixelSnapper and render shapes aligned to the physical pixel grid.
- Adjust text button rendering to draw captions within a snapped bounding rectangle to reduce subpixel blurring.

Build:
- Register the new PixelSnapper source file in the CMake build configuration.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introdurre un helper riutilizzabile PixelSnapper e aggiornare il rendering dei pulsanti per allineare icone e testo alle griglie di pixel fisici, ottenendo una resa più nitida su display ad alta DPI e con scaling.

Nuove funzionalità:
- Aggiungere un’utility PixelSnapper che aggancia punti e rettangoli ai pixel fisici del dispositivo e espone le informazioni di scalatura locale‑a‑fisico.

Miglioramenti:
- Rifinire le dimensioni delle icone dei pulsanti, il loro centraggio e lo spessore dei tratti in modo da utilizzare lo snapping basato su PixelSnapper per un aspetto più definito su tutte le impostazioni di DPI e scalatura.
- Aggiornare tutte le routine di painting delle icone dei pulsanti di decorazione per accettare PixelSnapper e disegnare forme allineate alla griglia di pixel fisici.
- Regolare il rendering dei pulsanti testuali per disegnare le didascalie all’interno di un rettangolo di delimitazione “agganciato”, riducendo la sfocatura da subpixel.

Build:
- Registrare il nuovo file sorgente PixelSnapper nella configurazione di build CMake.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a reusable PixelSnapper helper and update button rendering to align icons and text to physical pixel grids for sharper visuals on high-DPI and scaled displays.

New Features:
- Add a PixelSnapper utility that snaps points and rectangles to physical device pixels and exposes local-to-physical scaling information.

Enhancements:
- Refine button icon sizing, centering, and stroke thickness to use PixelSnapper-based snapping for crisper appearance across DPI and scaling settings.
- Update all decoration button icon painting routines to accept PixelSnapper and render shapes aligned to the physical pixel grid.
- Adjust text button rendering to draw captions within a snapped bounding rectangle to reduce subpixel blurring.

Build:
- Register the new PixelSnapper source file in the CMake build configuration.

</details>

Miglioramenti:
- Aggiungere un helper riutilizzabile PixelSnapper che mappa le coordinate locali alle posizioni allineate ai pixel fisici più vicini e espone le informazioni di scala locale–fisica.
- Rifinire le dimensioni delle icone dei pulsanti, il loro centraggio e gli spessori delle linee per rispettare le griglie di pixel fisici e i rapporti di pixel dei dispositivi, migliorando la nitidezza su schermi scalati e ad alta DPI.
- Aggiornare tutte le routine di disegno delle icone dei pulsanti (chiudi, ingrandisci, minimizza, ombreggia, mantieni sopra/sotto, guida contestuale, su-tutti-i-desktop, cerca, testo, overflow menu, menu app, escludi-dalla-cattura) per usare lo snapping basato su PixelSnapper.
- Regolare il rendering dei pulsanti di testo per utilizzare un rettangolo di bounding “snapppato” per ridurre la sfocatura sub-pixel delle didascalie.

Build:
- Registrare il nuovo file sorgente PixelSnapper nella configurazione di build di CMake.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introdurre un helper riutilizzabile PixelSnapper e aggiornare il rendering dei pulsanti per allineare icone e testo alle griglie di pixel fisici, ottenendo una resa più nitida su display ad alta DPI e con scaling.

Nuove funzionalità:
- Aggiungere un’utility PixelSnapper che aggancia punti e rettangoli ai pixel fisici del dispositivo e espone le informazioni di scalatura locale‑a‑fisico.

Miglioramenti:
- Rifinire le dimensioni delle icone dei pulsanti, il loro centraggio e lo spessore dei tratti in modo da utilizzare lo snapping basato su PixelSnapper per un aspetto più definito su tutte le impostazioni di DPI e scalatura.
- Aggiornare tutte le routine di painting delle icone dei pulsanti di decorazione per accettare PixelSnapper e disegnare forme allineate alla griglia di pixel fisici.
- Regolare il rendering dei pulsanti testuali per disegnare le didascalie all’interno di un rettangolo di delimitazione “agganciato”, riducendo la sfocatura da subpixel.

Build:
- Registrare il nuovo file sorgente PixelSnapper nella configurazione di build CMake.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a reusable PixelSnapper helper and update button rendering to align icons and text to physical pixel grids for sharper visuals on high-DPI and scaled displays.

New Features:
- Add a PixelSnapper utility that snaps points and rectangles to physical device pixels and exposes local-to-physical scaling information.

Enhancements:
- Refine button icon sizing, centering, and stroke thickness to use PixelSnapper-based snapping for crisper appearance across DPI and scaling settings.
- Update all decoration button icon painting routines to accept PixelSnapper and render shapes aligned to the physical pixel grid.
- Adjust text button rendering to draw captions within a snapped bounding rectangle to reduce subpixel blurring.

Build:
- Register the new PixelSnapper source file in the CMake build configuration.

</details>

</details>

</details>