### PR TITLE
Use PuxelSnapper for Decoration::paintCaption

### DIFF
--- a/src/Decoration.cc
+++ b/src/Decoration.cc
@@ -1265,6 +1265,9 @@ void Decoration::paintCaption(QPainter *painter, const QRectF &repaintRegion) co
 
     drawingRect.translate(0, offset);
 
+    PixelSnapper snapper(painter);
+    drawingRect = snapper.snap(drawingRect);
+
     if (!drawingRect.intersects(repaintRegion)) {
         return;
     }
@@ -1273,9 +1276,6 @@ void Decoration::paintCaption(QPainter *painter, const QRectF &repaintRegion) co
     painter->save();
     painter->setFont(font);
     painter->setPen(titleBarForegroundColor());
-
-    PixelSnapper snapper(painter);
-    drawingRect = snapper.snap(drawingRect);
 
     // Opacity logic
     if (appMenuVisible) {

--- a/src/Decoration.cc
+++ b/src/Decoration.cc
@@ -30,6 +30,7 @@
 #include "TextButton.h"
 #include "InternalSettings.h"
 #include "Material.h"
+#include "PixelSnapper.h"
 
 // KDecoration
 #include <KDecoration3/DecoratedWindow>
@@ -1272,6 +1273,9 @@ void Decoration::paintCaption(QPainter *painter, const QRectF &repaintRegion) co
     painter->save();
     painter->setFont(font);
     painter->setPen(titleBarForegroundColor());
+
+    PixelSnapper snapper(painter);
+    drawingRect = snapper.snap(drawingRect);
 
     // Opacity logic
     if (appMenuVisible) {


### PR DESCRIPTION
## Summary by Sourcery

Miglioramenti:
- Integrare PixelSnapper in Decoration::paintCaption per agganciare il rettangolo di disegno della didascalia ai pixel del dispositivo, ottenendo così una resa del testo più nitida.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Integrate PixelSnapper into Decoration::paintCaption to snap the caption drawing rectangle to device pixels for crisper text rendering.

</details>