### PR TITLE
AppMenuSearch: cache action text by QAction* and clear per filter

### DIFF
--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -53,6 +53,8 @@ void AppMenuSearch::setSearchMenu(QMenu *searchMenu)
 
 void AppMenuSearch::filter(const QString &text, const FilterOptions &options)
 {
+    // Synchronous lifetime cache guard: the text cache lives 
+    // only during the synchronous execution of this filter() call. 
     QPointer<AppMenuSearch> safeThis(this);
     auto clearActionTextCacheGuard = qScopeGuard([safeThis]() {
         if (safeThis) {

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -53,16 +53,16 @@ void AppMenuSearch::setSearchMenu(QMenu *searchMenu)
 
 void AppMenuSearch::filter(const QString &text, const FilterOptions &options)
 {
-    if (!m_searchMenu) {
-        return;
-    }
-
     QPointer<AppMenuSearch> safeThis(this);
-    auto cleanupCache = qScopeGuard([safeThis]() {
+    auto clearActionTextCacheGuard = qScopeGuard([safeThis]() {
         if (safeThis) {
             safeThis->m_actionTextCache.clear();
         }
     });
+
+    if (!m_searchMenu) {
+        return;
+    }
 
     // Clear results if search text is too short or model is unavailable
     if (isQueryTooShort(text) || !m_appMenuModel) {

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -23,6 +23,7 @@
 
 // Qt
 #include <QDebug>
+#include <QScopeGuard>
 #include <utility>
 
 static constexpr int MAX_SEARCH_RESULTS = 100;
@@ -55,6 +56,10 @@ void AppMenuSearch::filter(const QString &text, const FilterOptions &options)
     if (!m_searchMenu) {
         return;
     }
+
+    auto cleanupCache = qScopeGuard([this]() {
+        m_actionTextCache.clear();
+    });
 
     // Clear results if search text is too short or model is unavailable
     if (isQueryTooShort(text) || !m_appMenuModel) {
@@ -435,13 +440,13 @@ QString AppMenuSearch::getActionText(QAction *action) const
     if (!action) {
         return QString();
     }
-    const QString rawText = action->text();
-    auto it = m_actionTextCache.find(rawText);
+    auto it = m_actionTextCache.find(action);
     if (it != m_actionTextCache.end()) {
         return it.value();
     }
+    const QString rawText = action->text();
     const QString cleanedText = KLocalizedString::removeAcceleratorMarker(rawText.trimmed());
-    m_actionTextCache.insert(rawText, cleanedText);
+    m_actionTextCache.insert(action, cleanedText);
     return cleanedText;
 }
 

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -57,8 +57,11 @@ void AppMenuSearch::filter(const QString &text, const FilterOptions &options)
         return;
     }
 
-    auto cleanupCache = qScopeGuard([this]() {
-        m_actionTextCache.clear();
+    QPointer<AppMenuSearch> safeThis(this);
+    auto cleanupCache = qScopeGuard([safeThis]() {
+        if (safeThis) {
+            safeThis->m_actionTextCache.clear();
+        }
     });
 
     // Clear results if search text is too short or model is unavailable

--- a/src/AppMenuSearch.h
+++ b/src/AppMenuSearch.h
@@ -132,6 +132,9 @@ private:
     bool m_menuIsRendered = false;
     bool m_candidateTruncationLogged = false;
     QList<QPointer<QActionGroup>> m_searchResultGroups;
+    
+    // This cache maps QAction* pointers directly to their cleansed text labels (accelerator markers removed).
+    // It is automatically cleared on exit of each filter() pass using a qScopeGuard.
     mutable QHash<QAction *, QString> m_actionTextCache;
 };
 

--- a/src/AppMenuSearch.h
+++ b/src/AppMenuSearch.h
@@ -132,7 +132,7 @@ private:
     bool m_menuIsRendered = false;
     bool m_candidateTruncationLogged = false;
     QList<QPointer<QActionGroup>> m_searchResultGroups;
-    mutable QHash<QString, QString> m_actionTextCache;
+    mutable QHash<QAction *, QString> m_actionTextCache;
 };
 
 } // namespace Material


### PR DESCRIPTION
…ring> instead of <QString, QString>

## Summary by Sourcery

Aggiorna il comportamento di caching del testo dell'azione di AppMenuSearch e la gestione del ciclo di vita.

Miglioramenti:
- Cancella la cache del testo dell'azione alla fine di ogni operazione di filtro tramite uno scope guard per evitare voci obsolete.
- Modifica la cache del testo dell'azione per utilizzare puntatori `QAction*` come chiavi invece di stringhe di testo dell'azione, in modo da associare meglio i valori memorizzati nella cache alle singole azioni.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update AppMenuSearch action text caching behavior and lifecycle management.

Enhancements:
- Clear the action text cache at the end of each filter operation via a scope guard to avoid stale entries.
- Change the action text cache to use QAction* keys instead of action text strings to better associate cached values with specific actions.

</details>