### PR TITLE
Cache Geometry Widths in AppMenuButtonGroup Layout Loop

### DIFF
--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -643,6 +643,8 @@ void AppMenuButtonGroup::updateOverflow(QRectF availableRect)
         if (m_cachedWidths.size() != buttonCount) {
             m_cachedWidths.resize(buttonCount);
         }
+        // Ensure all entries are initialized to avoid stale reads if we bail early from the first pass.
+        m_cachedWidths.fill(0);
 
         for (int i = 0; i < buttonCount; ++i) {
             auto &tb = m_textButtons[i];

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -366,6 +366,7 @@ void AppMenuButtonGroup::resetButtons()
     m_searchButton = nullptr;
     m_overflowIndex = -1;
     m_searchIndex = -1;
+    m_cachedWidths.clear();
 
     if (m_overflowMenu) {
         m_overflowMenu->deleteLater();
@@ -639,8 +640,6 @@ void AppMenuButtonGroup::updateOverflow(QRectF availableRect)
         // Cache geometry widths in first pass so second pass can reuse them without calling geometry() again.
         // Re-use class member vector to completely avoid repeat dynamic allocations during layout updates.
         m_cachedWidths.resize(buttonCount);
-        m_cachedWidths.fill(0.0);
-        Q_ASSERT(m_cachedWidths.size() == buttonCount);
 
         for (int i = 0; i < buttonCount; ++i) {
             auto &tb = m_textButtons[i];

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -52,6 +52,7 @@
 #include <QWidgetAction>
 
 #include <utility>
+#include <vector>
 
 namespace Material
 {
@@ -635,9 +636,15 @@ void AppMenuButtonGroup::updateOverflow(QRectF availableRect)
         qreal totalTextWidth = 0;
         int enabledCount = 0;
         bool allFit = true;
-        for (auto &tb : std::as_const(m_textButtons)) {
+        const int buttonCount = m_textButtons.size();
+        std::vector<qreal> cachedWidths(buttonCount, -1.0);
+
+        for (int i = 0; i < buttonCount; ++i) {
+            auto &tb = m_textButtons[i];
             if (tb && tb->isEnabled()) {
-                totalTextWidth += tb->geometry().width();
+                const qreal w = tb->geometry().width();
+                cachedWidths[i] = w;
+                totalTextWidth += w;
                 enabledCount++;
                 if (fixedWidth + totalTextWidth > availableWidth) {
                     allFit = false;
@@ -662,12 +669,16 @@ void AppMenuButtonGroup::updateOverflow(QRectF availableRect)
 
             // Second pass: apply visibility and calculate final width
             bool fits = true;
-            for (auto &tb : std::as_const(m_textButtons)) {
+            for (int i = 0; i < buttonCount; ++i) {
+                auto &tb = m_textButtons[i];
                 if (!tb) {
                     continue;
                 }
                 if (fits && tb->isEnabled()) {
-                    const qreal w = tb->geometry().width();
+                    qreal w = cachedWidths[i];
+                    if (w < 0) {
+                        w = tb->geometry().width();
+                    }
                     if (w <= remainingWidth) {
                         tb->setVisible(true);
                         currentVisibleWidth += w;

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -639,7 +639,10 @@ void AppMenuButtonGroup::updateOverflow(QRectF availableRect)
         const int buttonCount = m_textButtons.size();
         // Cache geometry widths in first pass so second pass can reuse them without calling geometry() again.
         // Re-use class member vector to completely avoid repeat dynamic allocations during layout updates.
-        m_cachedWidths.resize(buttonCount);
+        if (m_cachedWidths.size() != buttonCount) {
+            m_cachedWidths.resize(buttonCount);
+        }
+        Q_ASSERT(m_cachedWidths.size() == buttonCount);
 
         for (int i = 0; i < buttonCount; ++i) {
             auto &tb = m_textButtons[i];

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -52,7 +52,6 @@
 #include <QWidgetAction>
 
 #include <utility>
-#include <vector>
 
 namespace Material
 {
@@ -637,7 +636,7 @@ void AppMenuButtonGroup::updateOverflow(QRectF availableRect)
         int enabledCount = 0;
         bool allFit = true;
         const int buttonCount = m_textButtons.size();
-        std::vector<qreal> cachedWidths(buttonCount, -1.0);
+        QList<qreal> cachedWidths(buttonCount, 0.0);
 
         for (int i = 0; i < buttonCount; ++i) {
             auto &tb = m_textButtons[i];
@@ -675,10 +674,7 @@ void AppMenuButtonGroup::updateOverflow(QRectF availableRect)
                     continue;
                 }
                 if (fits && tb->isEnabled()) {
-                    qreal w = cachedWidths[i];
-                    if (w < 0) {
-                        w = tb->geometry().width();
-                    }
+                    const qreal w = cachedWidths[i];
                     if (w <= remainingWidth) {
                         tb->setVisible(true);
                         currentVisibleWidth += w;

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -477,6 +477,7 @@ void AppMenuButtonGroup::performDebouncedMenuUpdate()
 void AppMenuButtonGroup::updateAppMenuModel()
 {
     m_search->invalidateCandidates();
+    m_cachedWidths.clear();
 
     auto *deco = qobject_cast<Decoration *>(decoration());
     if (!deco) {
@@ -642,7 +643,6 @@ void AppMenuButtonGroup::updateOverflow(QRectF availableRect)
         if (m_cachedWidths.size() != buttonCount) {
             m_cachedWidths.resize(buttonCount);
         }
-        Q_ASSERT(m_cachedWidths.size() == buttonCount);
 
         for (int i = 0; i < buttonCount; ++i) {
             auto &tb = m_textButtons[i];

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -636,7 +636,8 @@ void AppMenuButtonGroup::updateOverflow(QRectF availableRect)
         int enabledCount = 0;
         bool allFit = true;
         const int buttonCount = m_textButtons.size();
-        QList<qreal> cachedWidths(buttonCount, 0.0);
+        // Cache geometry widths in first pass so second pass can reuse them without calling geometry() again.
+        QVector<qreal> cachedWidths(buttonCount, 0.0);
 
         for (int i = 0; i < buttonCount; ++i) {
             auto &tb = m_textButtons[i];
@@ -674,6 +675,7 @@ void AppMenuButtonGroup::updateOverflow(QRectF availableRect)
                     continue;
                 }
                 if (fits && tb->isEnabled()) {
+                    Q_ASSERT(i < cachedWidths.size());
                     const qreal w = cachedWidths[i];
                     if (w <= remainingWidth) {
                         tb->setVisible(true);

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -637,13 +637,16 @@ void AppMenuButtonGroup::updateOverflow(QRectF availableRect)
         bool allFit = true;
         const int buttonCount = m_textButtons.size();
         // Cache geometry widths in first pass so second pass can reuse them without calling geometry() again.
-        QVector<qreal> cachedWidths(buttonCount, 0.0);
+        // Re-use class member vector to completely avoid repeat dynamic allocations during layout updates.
+        m_cachedWidths.resize(buttonCount);
+        m_cachedWidths.fill(0.0);
+        Q_ASSERT(m_cachedWidths.size() == buttonCount);
 
         for (int i = 0; i < buttonCount; ++i) {
             auto &tb = m_textButtons[i];
             if (tb && tb->isEnabled()) {
                 const qreal w = tb->geometry().width();
-                cachedWidths[i] = w;
+                m_cachedWidths[i] = w;
                 totalTextWidth += w;
                 enabledCount++;
                 if (fixedWidth + totalTextWidth > availableWidth) {
@@ -675,8 +678,7 @@ void AppMenuButtonGroup::updateOverflow(QRectF availableRect)
                     continue;
                 }
                 if (fits && tb->isEnabled()) {
-                    Q_ASSERT(i < cachedWidths.size());
-                    const qreal w = cachedWidths[i];
+                    const qreal w = m_cachedWidths[i];
                     if (w <= remainingWidth) {
                         tb->setVisible(true);
                         currentVisibleWidth += w;

--- a/src/AppMenuButtonGroup.h
+++ b/src/AppMenuButtonGroup.h
@@ -191,6 +191,8 @@ private:
 
     QPointer<KDecoration3::DecorationButton> m_hoveredButton = nullptr;
 
+    // Cached text button widths to avoid querying geometry().width() twice during overflow layout.
+    // Invariant: m_cachedWidths.size() == m_textButtons.size() when in use.
     QVector<qreal> m_cachedWidths;
 
     friend class AppMenuButton;

--- a/src/AppMenuButtonGroup.h
+++ b/src/AppMenuButtonGroup.h
@@ -30,6 +30,7 @@
 #include <QMenu>
 #include <QLineEdit>
 #include <QPointer>
+#include <QVector>
 
 class QTimer;
 class QVariantAnimation;
@@ -189,6 +190,8 @@ private:
     QPointer<SearchButton> m_searchButton;
 
     QPointer<KDecoration3::DecorationButton> m_hoveredButton = nullptr;
+
+    QVector<qreal> m_cachedWidths;
 
     friend class AppMenuButton;
     friend class Decoration;


### PR DESCRIPTION
## Summary by Sourcery

Memorizza in cache le larghezze dei pulsanti di testo durante il layout di overflow per migliorare le prestazioni e riutilizzarle tra i vari passaggi di layout.

Enhancements:
- Aggiungi un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo utilizzate nei calcoli del layout di overflow.
- Usa le larghezze memorizzate in cache nel secondo passaggio del layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Pulisci le larghezze memorizzate in cache quando i pulsanti vengono reimpostati o il modello del menu dell’app viene aggiornato, per mantenere lo stato del layout coerente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Cache text button widths during overflow layout to improve performance and reuse them across layout passes.

Enhancements:
- Add a persistent QVector member to store cached text button widths for overflow layout calculations.
- Use cached widths in the second overflow layout pass instead of querying button geometry again.
- Clear the cached widths when buttons are reset or the app menu model is updated to keep layout state consistent.

</details>

Miglioramenti:
- Introdurre un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo tra più passaggi di layout di overflow.
- Riutilizzare le larghezze in cache nel secondo passaggio di layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Svuotare l’archivio delle larghezze in cache quando si reimpostano i pulsanti, per mantenere coerente lo stato del layout.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Memorizza in cache le larghezze dei pulsanti di testo durante il layout di overflow per migliorare le prestazioni e riutilizzarle tra i vari passaggi di layout.

Enhancements:
- Aggiungi un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo utilizzate nei calcoli del layout di overflow.
- Usa le larghezze memorizzate in cache nel secondo passaggio del layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Pulisci le larghezze memorizzate in cache quando i pulsanti vengono reimpostati o il modello del menu dell’app viene aggiornato, per mantenere lo stato del layout coerente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Cache text button widths during overflow layout to improve performance and reuse them across layout passes.

Enhancements:
- Add a persistent QVector member to store cached text button widths for overflow layout calculations.
- Use cached widths in the second overflow layout pass instead of querying button geometry again.
- Clear the cached widths when buttons are reset or the app menu model is updated to keep layout state consistent.

</details>

</details>

Miglioramenti:
- Introdurre un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo tra i vari passaggi del layout di overflow.
- Riutilizzare le larghezze memorizzate in cache nel secondo passaggio del layout di overflow invece di chiamare `geometry()` di nuovo per ogni pulsante.
- Svuotare l’archivio delle larghezze memorizzate in cache quando si reimpostano i pulsanti per mantenere lo stato coerente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Memorizza in cache le larghezze dei pulsanti di testo durante il layout di overflow per migliorare le prestazioni e riutilizzarle tra i vari passaggi di layout.

Enhancements:
- Aggiungi un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo utilizzate nei calcoli del layout di overflow.
- Usa le larghezze memorizzate in cache nel secondo passaggio del layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Pulisci le larghezze memorizzate in cache quando i pulsanti vengono reimpostati o il modello del menu dell’app viene aggiornato, per mantenere lo stato del layout coerente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Cache text button widths during overflow layout to improve performance and reuse them across layout passes.

Enhancements:
- Add a persistent QVector member to store cached text button widths for overflow layout calculations.
- Use cached widths in the second overflow layout pass instead of querying button geometry again.
- Clear the cached widths when buttons are reset or the app menu model is updated to keep layout state consistent.

</details>

Miglioramenti:
- Introdurre un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo tra più passaggi di layout di overflow.
- Riutilizzare le larghezze in cache nel secondo passaggio di layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Svuotare l’archivio delle larghezze in cache quando si reimpostano i pulsanti, per mantenere coerente lo stato del layout.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Memorizza in cache le larghezze dei pulsanti di testo durante il layout di overflow per migliorare le prestazioni e riutilizzarle tra i vari passaggi di layout.

Enhancements:
- Aggiungi un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo utilizzate nei calcoli del layout di overflow.
- Usa le larghezze memorizzate in cache nel secondo passaggio del layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Pulisci le larghezze memorizzate in cache quando i pulsanti vengono reimpostati o il modello del menu dell’app viene aggiornato, per mantenere lo stato del layout coerente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Cache text button widths during overflow layout to improve performance and reuse them across layout passes.

Enhancements:
- Add a persistent QVector member to store cached text button widths for overflow layout calculations.
- Use cached widths in the second overflow layout pass instead of querying button geometry again.
- Clear the cached widths when buttons are reset or the app menu model is updated to keep layout state consistent.

</details>

</details>

</details>

Miglioramenti:
- Memorizzare nella cache le larghezze dei pulsanti di testo durante il primo passaggio di layout di overflow e riutilizzarle nel secondo passaggio per evitare calcoli ridondanti della geometria.
- Introdurre un membro `QVector` persistente per archiviare le larghezze memorizzate nella cache e prevenire allocazioni dinamiche ripetute durante gli aggiornamenti del layout.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Memorizza in cache le larghezze dei pulsanti di testo durante il layout di overflow per migliorare le prestazioni e riutilizzarle tra i vari passaggi di layout.

Enhancements:
- Aggiungi un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo utilizzate nei calcoli del layout di overflow.
- Usa le larghezze memorizzate in cache nel secondo passaggio del layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Pulisci le larghezze memorizzate in cache quando i pulsanti vengono reimpostati o il modello del menu dell’app viene aggiornato, per mantenere lo stato del layout coerente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Cache text button widths during overflow layout to improve performance and reuse them across layout passes.

Enhancements:
- Add a persistent QVector member to store cached text button widths for overflow layout calculations.
- Use cached widths in the second overflow layout pass instead of querying button geometry again.
- Clear the cached widths when buttons are reset or the app menu model is updated to keep layout state consistent.

</details>

Miglioramenti:
- Introdurre un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo tra più passaggi di layout di overflow.
- Riutilizzare le larghezze in cache nel secondo passaggio di layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Svuotare l’archivio delle larghezze in cache quando si reimpostano i pulsanti, per mantenere coerente lo stato del layout.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Memorizza in cache le larghezze dei pulsanti di testo durante il layout di overflow per migliorare le prestazioni e riutilizzarle tra i vari passaggi di layout.

Enhancements:
- Aggiungi un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo utilizzate nei calcoli del layout di overflow.
- Usa le larghezze memorizzate in cache nel secondo passaggio del layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Pulisci le larghezze memorizzate in cache quando i pulsanti vengono reimpostati o il modello del menu dell’app viene aggiornato, per mantenere lo stato del layout coerente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Cache text button widths during overflow layout to improve performance and reuse them across layout passes.

Enhancements:
- Add a persistent QVector member to store cached text button widths for overflow layout calculations.
- Use cached widths in the second overflow layout pass instead of querying button geometry again.
- Clear the cached widths when buttons are reset or the app menu model is updated to keep layout state consistent.

</details>

</details>

Miglioramenti:
- Introdurre un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo tra i vari passaggi del layout di overflow.
- Riutilizzare le larghezze memorizzate in cache nel secondo passaggio del layout di overflow invece di chiamare `geometry()` di nuovo per ogni pulsante.
- Svuotare l’archivio delle larghezze memorizzate in cache quando si reimpostano i pulsanti per mantenere lo stato coerente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Memorizza in cache le larghezze dei pulsanti di testo durante il layout di overflow per migliorare le prestazioni e riutilizzarle tra i vari passaggi di layout.

Enhancements:
- Aggiungi un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo utilizzate nei calcoli del layout di overflow.
- Usa le larghezze memorizzate in cache nel secondo passaggio del layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Pulisci le larghezze memorizzate in cache quando i pulsanti vengono reimpostati o il modello del menu dell’app viene aggiornato, per mantenere lo stato del layout coerente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Cache text button widths during overflow layout to improve performance and reuse them across layout passes.

Enhancements:
- Add a persistent QVector member to store cached text button widths for overflow layout calculations.
- Use cached widths in the second overflow layout pass instead of querying button geometry again.
- Clear the cached widths when buttons are reset or the app menu model is updated to keep layout state consistent.

</details>

Miglioramenti:
- Introdurre un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo tra più passaggi di layout di overflow.
- Riutilizzare le larghezze in cache nel secondo passaggio di layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Svuotare l’archivio delle larghezze in cache quando si reimpostano i pulsanti, per mantenere coerente lo stato del layout.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Memorizza in cache le larghezze dei pulsanti di testo durante il layout di overflow per migliorare le prestazioni e riutilizzarle tra i vari passaggi di layout.

Enhancements:
- Aggiungi un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo utilizzate nei calcoli del layout di overflow.
- Usa le larghezze memorizzate in cache nel secondo passaggio del layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Pulisci le larghezze memorizzate in cache quando i pulsanti vengono reimpostati o il modello del menu dell’app viene aggiornato, per mantenere lo stato del layout coerente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Cache text button widths during overflow layout to improve performance and reuse them across layout passes.

Enhancements:
- Add a persistent QVector member to store cached text button widths for overflow layout calculations.
- Use cached widths in the second overflow layout pass instead of querying button geometry again.
- Clear the cached widths when buttons are reset or the app menu model is updated to keep layout state consistent.

</details>

</details>

</details>

</details>
- Introdurre un array memorizzato in cache per le larghezze dei pulsanti di testo durante il layout in overflow, per migliorare le prestazioni e ridurre le chiamate ripetute a `geometry()`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Memorizza in cache le larghezze dei pulsanti di testo durante il layout di overflow per migliorare le prestazioni e riutilizzarle tra i vari passaggi di layout.

Enhancements:
- Aggiungi un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo utilizzate nei calcoli del layout di overflow.
- Usa le larghezze memorizzate in cache nel secondo passaggio del layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Pulisci le larghezze memorizzate in cache quando i pulsanti vengono reimpostati o il modello del menu dell’app viene aggiornato, per mantenere lo stato del layout coerente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Cache text button widths during overflow layout to improve performance and reuse them across layout passes.

Enhancements:
- Add a persistent QVector member to store cached text button widths for overflow layout calculations.
- Use cached widths in the second overflow layout pass instead of querying button geometry again.
- Clear the cached widths when buttons are reset or the app menu model is updated to keep layout state consistent.

</details>

Miglioramenti:
- Introdurre un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo tra più passaggi di layout di overflow.
- Riutilizzare le larghezze in cache nel secondo passaggio di layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Svuotare l’archivio delle larghezze in cache quando si reimpostano i pulsanti, per mantenere coerente lo stato del layout.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Memorizza in cache le larghezze dei pulsanti di testo durante il layout di overflow per migliorare le prestazioni e riutilizzarle tra i vari passaggi di layout.

Enhancements:
- Aggiungi un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo utilizzate nei calcoli del layout di overflow.
- Usa le larghezze memorizzate in cache nel secondo passaggio del layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Pulisci le larghezze memorizzate in cache quando i pulsanti vengono reimpostati o il modello del menu dell’app viene aggiornato, per mantenere lo stato del layout coerente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Cache text button widths during overflow layout to improve performance and reuse them across layout passes.

Enhancements:
- Add a persistent QVector member to store cached text button widths for overflow layout calculations.
- Use cached widths in the second overflow layout pass instead of querying button geometry again.
- Clear the cached widths when buttons are reset or the app menu model is updated to keep layout state consistent.

</details>

</details>

Miglioramenti:
- Introdurre un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo tra i vari passaggi del layout di overflow.
- Riutilizzare le larghezze memorizzate in cache nel secondo passaggio del layout di overflow invece di chiamare `geometry()` di nuovo per ogni pulsante.
- Svuotare l’archivio delle larghezze memorizzate in cache quando si reimpostano i pulsanti per mantenere lo stato coerente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Memorizza in cache le larghezze dei pulsanti di testo durante il layout di overflow per migliorare le prestazioni e riutilizzarle tra i vari passaggi di layout.

Enhancements:
- Aggiungi un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo utilizzate nei calcoli del layout di overflow.
- Usa le larghezze memorizzate in cache nel secondo passaggio del layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Pulisci le larghezze memorizzate in cache quando i pulsanti vengono reimpostati o il modello del menu dell’app viene aggiornato, per mantenere lo stato del layout coerente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Cache text button widths during overflow layout to improve performance and reuse them across layout passes.

Enhancements:
- Add a persistent QVector member to store cached text button widths for overflow layout calculations.
- Use cached widths in the second overflow layout pass instead of querying button geometry again.
- Clear the cached widths when buttons are reset or the app menu model is updated to keep layout state consistent.

</details>

Miglioramenti:
- Introdurre un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo tra più passaggi di layout di overflow.
- Riutilizzare le larghezze in cache nel secondo passaggio di layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Svuotare l’archivio delle larghezze in cache quando si reimpostano i pulsanti, per mantenere coerente lo stato del layout.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Memorizza in cache le larghezze dei pulsanti di testo durante il layout di overflow per migliorare le prestazioni e riutilizzarle tra i vari passaggi di layout.

Enhancements:
- Aggiungi un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo utilizzate nei calcoli del layout di overflow.
- Usa le larghezze memorizzate in cache nel secondo passaggio del layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Pulisci le larghezze memorizzate in cache quando i pulsanti vengono reimpostati o il modello del menu dell’app viene aggiornato, per mantenere lo stato del layout coerente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Cache text button widths during overflow layout to improve performance and reuse them across layout passes.

Enhancements:
- Add a persistent QVector member to store cached text button widths for overflow layout calculations.
- Use cached widths in the second overflow layout pass instead of querying button geometry again.
- Clear the cached widths when buttons are reset or the app menu model is updated to keep layout state consistent.

</details>

</details>

</details>

Miglioramenti:
- Memorizzare nella cache le larghezze dei pulsanti di testo durante il primo passaggio di layout di overflow e riutilizzarle nel secondo passaggio per evitare calcoli ridondanti della geometria.
- Introdurre un membro `QVector` persistente per archiviare le larghezze memorizzate nella cache e prevenire allocazioni dinamiche ripetute durante gli aggiornamenti del layout.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Memorizza in cache le larghezze dei pulsanti di testo durante il layout di overflow per migliorare le prestazioni e riutilizzarle tra i vari passaggi di layout.

Enhancements:
- Aggiungi un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo utilizzate nei calcoli del layout di overflow.
- Usa le larghezze memorizzate in cache nel secondo passaggio del layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Pulisci le larghezze memorizzate in cache quando i pulsanti vengono reimpostati o il modello del menu dell’app viene aggiornato, per mantenere lo stato del layout coerente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Cache text button widths during overflow layout to improve performance and reuse them across layout passes.

Enhancements:
- Add a persistent QVector member to store cached text button widths for overflow layout calculations.
- Use cached widths in the second overflow layout pass instead of querying button geometry again.
- Clear the cached widths when buttons are reset or the app menu model is updated to keep layout state consistent.

</details>

Miglioramenti:
- Introdurre un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo tra più passaggi di layout di overflow.
- Riutilizzare le larghezze in cache nel secondo passaggio di layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Svuotare l’archivio delle larghezze in cache quando si reimpostano i pulsanti, per mantenere coerente lo stato del layout.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Memorizza in cache le larghezze dei pulsanti di testo durante il layout di overflow per migliorare le prestazioni e riutilizzarle tra i vari passaggi di layout.

Enhancements:
- Aggiungi un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo utilizzate nei calcoli del layout di overflow.
- Usa le larghezze memorizzate in cache nel secondo passaggio del layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Pulisci le larghezze memorizzate in cache quando i pulsanti vengono reimpostati o il modello del menu dell’app viene aggiornato, per mantenere lo stato del layout coerente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Cache text button widths during overflow layout to improve performance and reuse them across layout passes.

Enhancements:
- Add a persistent QVector member to store cached text button widths for overflow layout calculations.
- Use cached widths in the second overflow layout pass instead of querying button geometry again.
- Clear the cached widths when buttons are reset or the app menu model is updated to keep layout state consistent.

</details>

</details>

Miglioramenti:
- Introdurre un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo tra i vari passaggi del layout di overflow.
- Riutilizzare le larghezze memorizzate in cache nel secondo passaggio del layout di overflow invece di chiamare `geometry()` di nuovo per ogni pulsante.
- Svuotare l’archivio delle larghezze memorizzate in cache quando si reimpostano i pulsanti per mantenere lo stato coerente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Memorizza in cache le larghezze dei pulsanti di testo durante il layout di overflow per migliorare le prestazioni e riutilizzarle tra i vari passaggi di layout.

Enhancements:
- Aggiungi un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo utilizzate nei calcoli del layout di overflow.
- Usa le larghezze memorizzate in cache nel secondo passaggio del layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Pulisci le larghezze memorizzate in cache quando i pulsanti vengono reimpostati o il modello del menu dell’app viene aggiornato, per mantenere lo stato del layout coerente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Cache text button widths during overflow layout to improve performance and reuse them across layout passes.

Enhancements:
- Add a persistent QVector member to store cached text button widths for overflow layout calculations.
- Use cached widths in the second overflow layout pass instead of querying button geometry again.
- Clear the cached widths when buttons are reset or the app menu model is updated to keep layout state consistent.

</details>

Miglioramenti:
- Introdurre un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo tra più passaggi di layout di overflow.
- Riutilizzare le larghezze in cache nel secondo passaggio di layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Svuotare l’archivio delle larghezze in cache quando si reimpostano i pulsanti, per mantenere coerente lo stato del layout.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Memorizza in cache le larghezze dei pulsanti di testo durante il layout di overflow per migliorare le prestazioni e riutilizzarle tra i vari passaggi di layout.

Enhancements:
- Aggiungi un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo utilizzate nei calcoli del layout di overflow.
- Usa le larghezze memorizzate in cache nel secondo passaggio del layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Pulisci le larghezze memorizzate in cache quando i pulsanti vengono reimpostati o il modello del menu dell’app viene aggiornato, per mantenere lo stato del layout coerente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Cache text button widths during overflow layout to improve performance and reuse them across layout passes.

Enhancements:
- Add a persistent QVector member to store cached text button widths for overflow layout calculations.
- Use cached widths in the second overflow layout pass instead of querying button geometry again.
- Clear the cached widths when buttons are reset or the app menu model is updated to keep layout state consistent.

</details>

</details>

</details>

</details>

</details>
- Memorizzare nella cache le larghezze della geometria dei pulsanti di testo durante il primo passaggio di layout e riutilizzarle nel secondo passaggio per evitare calcoli ridondanti delle larghezze.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Memorizza in cache le larghezze dei pulsanti di testo durante il layout di overflow per migliorare le prestazioni e riutilizzarle tra i vari passaggi di layout.

Enhancements:
- Aggiungi un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo utilizzate nei calcoli del layout di overflow.
- Usa le larghezze memorizzate in cache nel secondo passaggio del layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Pulisci le larghezze memorizzate in cache quando i pulsanti vengono reimpostati o il modello del menu dell’app viene aggiornato, per mantenere lo stato del layout coerente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Cache text button widths during overflow layout to improve performance and reuse them across layout passes.

Enhancements:
- Add a persistent QVector member to store cached text button widths for overflow layout calculations.
- Use cached widths in the second overflow layout pass instead of querying button geometry again.
- Clear the cached widths when buttons are reset or the app menu model is updated to keep layout state consistent.

</details>

Miglioramenti:
- Introdurre un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo tra più passaggi di layout di overflow.
- Riutilizzare le larghezze in cache nel secondo passaggio di layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Svuotare l’archivio delle larghezze in cache quando si reimpostano i pulsanti, per mantenere coerente lo stato del layout.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Memorizza in cache le larghezze dei pulsanti di testo durante il layout di overflow per migliorare le prestazioni e riutilizzarle tra i vari passaggi di layout.

Enhancements:
- Aggiungi un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo utilizzate nei calcoli del layout di overflow.
- Usa le larghezze memorizzate in cache nel secondo passaggio del layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Pulisci le larghezze memorizzate in cache quando i pulsanti vengono reimpostati o il modello del menu dell’app viene aggiornato, per mantenere lo stato del layout coerente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Cache text button widths during overflow layout to improve performance and reuse them across layout passes.

Enhancements:
- Add a persistent QVector member to store cached text button widths for overflow layout calculations.
- Use cached widths in the second overflow layout pass instead of querying button geometry again.
- Clear the cached widths when buttons are reset or the app menu model is updated to keep layout state consistent.

</details>

</details>

Miglioramenti:
- Introdurre un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo tra i vari passaggi del layout di overflow.
- Riutilizzare le larghezze memorizzate in cache nel secondo passaggio del layout di overflow invece di chiamare `geometry()` di nuovo per ogni pulsante.
- Svuotare l’archivio delle larghezze memorizzate in cache quando si reimpostano i pulsanti per mantenere lo stato coerente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Memorizza in cache le larghezze dei pulsanti di testo durante il layout di overflow per migliorare le prestazioni e riutilizzarle tra i vari passaggi di layout.

Enhancements:
- Aggiungi un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo utilizzate nei calcoli del layout di overflow.
- Usa le larghezze memorizzate in cache nel secondo passaggio del layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Pulisci le larghezze memorizzate in cache quando i pulsanti vengono reimpostati o il modello del menu dell’app viene aggiornato, per mantenere lo stato del layout coerente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Cache text button widths during overflow layout to improve performance and reuse them across layout passes.

Enhancements:
- Add a persistent QVector member to store cached text button widths for overflow layout calculations.
- Use cached widths in the second overflow layout pass instead of querying button geometry again.
- Clear the cached widths when buttons are reset or the app menu model is updated to keep layout state consistent.

</details>

Miglioramenti:
- Introdurre un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo tra più passaggi di layout di overflow.
- Riutilizzare le larghezze in cache nel secondo passaggio di layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Svuotare l’archivio delle larghezze in cache quando si reimpostano i pulsanti, per mantenere coerente lo stato del layout.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Memorizza in cache le larghezze dei pulsanti di testo durante il layout di overflow per migliorare le prestazioni e riutilizzarle tra i vari passaggi di layout.

Enhancements:
- Aggiungi un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo utilizzate nei calcoli del layout di overflow.
- Usa le larghezze memorizzate in cache nel secondo passaggio del layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Pulisci le larghezze memorizzate in cache quando i pulsanti vengono reimpostati o il modello del menu dell’app viene aggiornato, per mantenere lo stato del layout coerente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Cache text button widths during overflow layout to improve performance and reuse them across layout passes.

Enhancements:
- Add a persistent QVector member to store cached text button widths for overflow layout calculations.
- Use cached widths in the second overflow layout pass instead of querying button geometry again.
- Clear the cached widths when buttons are reset or the app menu model is updated to keep layout state consistent.

</details>

</details>

</details>

Miglioramenti:
- Memorizzare nella cache le larghezze dei pulsanti di testo durante il primo passaggio di layout di overflow e riutilizzarle nel secondo passaggio per evitare calcoli ridondanti della geometria.
- Introdurre un membro `QVector` persistente per archiviare le larghezze memorizzate nella cache e prevenire allocazioni dinamiche ripetute durante gli aggiornamenti del layout.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Memorizza in cache le larghezze dei pulsanti di testo durante il layout di overflow per migliorare le prestazioni e riutilizzarle tra i vari passaggi di layout.

Enhancements:
- Aggiungi un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo utilizzate nei calcoli del layout di overflow.
- Usa le larghezze memorizzate in cache nel secondo passaggio del layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Pulisci le larghezze memorizzate in cache quando i pulsanti vengono reimpostati o il modello del menu dell’app viene aggiornato, per mantenere lo stato del layout coerente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Cache text button widths during overflow layout to improve performance and reuse them across layout passes.

Enhancements:
- Add a persistent QVector member to store cached text button widths for overflow layout calculations.
- Use cached widths in the second overflow layout pass instead of querying button geometry again.
- Clear the cached widths when buttons are reset or the app menu model is updated to keep layout state consistent.

</details>

Miglioramenti:
- Introdurre un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo tra più passaggi di layout di overflow.
- Riutilizzare le larghezze in cache nel secondo passaggio di layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Svuotare l’archivio delle larghezze in cache quando si reimpostano i pulsanti, per mantenere coerente lo stato del layout.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Memorizza in cache le larghezze dei pulsanti di testo durante il layout di overflow per migliorare le prestazioni e riutilizzarle tra i vari passaggi di layout.

Enhancements:
- Aggiungi un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo utilizzate nei calcoli del layout di overflow.
- Usa le larghezze memorizzate in cache nel secondo passaggio del layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Pulisci le larghezze memorizzate in cache quando i pulsanti vengono reimpostati o il modello del menu dell’app viene aggiornato, per mantenere lo stato del layout coerente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Cache text button widths during overflow layout to improve performance and reuse them across layout passes.

Enhancements:
- Add a persistent QVector member to store cached text button widths for overflow layout calculations.
- Use cached widths in the second overflow layout pass instead of querying button geometry again.
- Clear the cached widths when buttons are reset or the app menu model is updated to keep layout state consistent.

</details>

</details>

Miglioramenti:
- Introdurre un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo tra i vari passaggi del layout di overflow.
- Riutilizzare le larghezze memorizzate in cache nel secondo passaggio del layout di overflow invece di chiamare `geometry()` di nuovo per ogni pulsante.
- Svuotare l’archivio delle larghezze memorizzate in cache quando si reimpostano i pulsanti per mantenere lo stato coerente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Memorizza in cache le larghezze dei pulsanti di testo durante il layout di overflow per migliorare le prestazioni e riutilizzarle tra i vari passaggi di layout.

Enhancements:
- Aggiungi un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo utilizzate nei calcoli del layout di overflow.
- Usa le larghezze memorizzate in cache nel secondo passaggio del layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Pulisci le larghezze memorizzate in cache quando i pulsanti vengono reimpostati o il modello del menu dell’app viene aggiornato, per mantenere lo stato del layout coerente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Cache text button widths during overflow layout to improve performance and reuse them across layout passes.

Enhancements:
- Add a persistent QVector member to store cached text button widths for overflow layout calculations.
- Use cached widths in the second overflow layout pass instead of querying button geometry again.
- Clear the cached widths when buttons are reset or the app menu model is updated to keep layout state consistent.

</details>

Miglioramenti:
- Introdurre un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo tra più passaggi di layout di overflow.
- Riutilizzare le larghezze in cache nel secondo passaggio di layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Svuotare l’archivio delle larghezze in cache quando si reimpostano i pulsanti, per mantenere coerente lo stato del layout.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Memorizza in cache le larghezze dei pulsanti di testo durante il layout di overflow per migliorare le prestazioni e riutilizzarle tra i vari passaggi di layout.

Enhancements:
- Aggiungi un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo utilizzate nei calcoli del layout di overflow.
- Usa le larghezze memorizzate in cache nel secondo passaggio del layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Pulisci le larghezze memorizzate in cache quando i pulsanti vengono reimpostati o il modello del menu dell’app viene aggiornato, per mantenere lo stato del layout coerente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Cache text button widths during overflow layout to improve performance and reuse them across layout passes.

Enhancements:
- Add a persistent QVector member to store cached text button widths for overflow layout calculations.
- Use cached widths in the second overflow layout pass instead of querying button geometry again.
- Clear the cached widths when buttons are reset or the app menu model is updated to keep layout state consistent.

</details>

</details>

</details>

</details>
- Introdurre un array memorizzato in cache per le larghezze dei pulsanti di testo durante il layout in overflow, per migliorare le prestazioni e ridurre le chiamate ripetute a `geometry()`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Memorizza in cache le larghezze dei pulsanti di testo durante il layout di overflow per migliorare le prestazioni e riutilizzarle tra i vari passaggi di layout.

Enhancements:
- Aggiungi un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo utilizzate nei calcoli del layout di overflow.
- Usa le larghezze memorizzate in cache nel secondo passaggio del layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Pulisci le larghezze memorizzate in cache quando i pulsanti vengono reimpostati o il modello del menu dell’app viene aggiornato, per mantenere lo stato del layout coerente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Cache text button widths during overflow layout to improve performance and reuse them across layout passes.

Enhancements:
- Add a persistent QVector member to store cached text button widths for overflow layout calculations.
- Use cached widths in the second overflow layout pass instead of querying button geometry again.
- Clear the cached widths when buttons are reset or the app menu model is updated to keep layout state consistent.

</details>

Miglioramenti:
- Introdurre un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo tra più passaggi di layout di overflow.
- Riutilizzare le larghezze in cache nel secondo passaggio di layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Svuotare l’archivio delle larghezze in cache quando si reimpostano i pulsanti, per mantenere coerente lo stato del layout.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Memorizza in cache le larghezze dei pulsanti di testo durante il layout di overflow per migliorare le prestazioni e riutilizzarle tra i vari passaggi di layout.

Enhancements:
- Aggiungi un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo utilizzate nei calcoli del layout di overflow.
- Usa le larghezze memorizzate in cache nel secondo passaggio del layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Pulisci le larghezze memorizzate in cache quando i pulsanti vengono reimpostati o il modello del menu dell’app viene aggiornato, per mantenere lo stato del layout coerente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Cache text button widths during overflow layout to improve performance and reuse them across layout passes.

Enhancements:
- Add a persistent QVector member to store cached text button widths for overflow layout calculations.
- Use cached widths in the second overflow layout pass instead of querying button geometry again.
- Clear the cached widths when buttons are reset or the app menu model is updated to keep layout state consistent.

</details>

</details>

Miglioramenti:
- Introdurre un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo tra i vari passaggi del layout di overflow.
- Riutilizzare le larghezze memorizzate in cache nel secondo passaggio del layout di overflow invece di chiamare `geometry()` di nuovo per ogni pulsante.
- Svuotare l’archivio delle larghezze memorizzate in cache quando si reimpostano i pulsanti per mantenere lo stato coerente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Memorizza in cache le larghezze dei pulsanti di testo durante il layout di overflow per migliorare le prestazioni e riutilizzarle tra i vari passaggi di layout.

Enhancements:
- Aggiungi un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo utilizzate nei calcoli del layout di overflow.
- Usa le larghezze memorizzate in cache nel secondo passaggio del layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Pulisci le larghezze memorizzate in cache quando i pulsanti vengono reimpostati o il modello del menu dell’app viene aggiornato, per mantenere lo stato del layout coerente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Cache text button widths during overflow layout to improve performance and reuse them across layout passes.

Enhancements:
- Add a persistent QVector member to store cached text button widths for overflow layout calculations.
- Use cached widths in the second overflow layout pass instead of querying button geometry again.
- Clear the cached widths when buttons are reset or the app menu model is updated to keep layout state consistent.

</details>

Miglioramenti:
- Introdurre un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo tra più passaggi di layout di overflow.
- Riutilizzare le larghezze in cache nel secondo passaggio di layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Svuotare l’archivio delle larghezze in cache quando si reimpostano i pulsanti, per mantenere coerente lo stato del layout.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Memorizza in cache le larghezze dei pulsanti di testo durante il layout di overflow per migliorare le prestazioni e riutilizzarle tra i vari passaggi di layout.

Enhancements:
- Aggiungi un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo utilizzate nei calcoli del layout di overflow.
- Usa le larghezze memorizzate in cache nel secondo passaggio del layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Pulisci le larghezze memorizzate in cache quando i pulsanti vengono reimpostati o il modello del menu dell’app viene aggiornato, per mantenere lo stato del layout coerente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Cache text button widths during overflow layout to improve performance and reuse them across layout passes.

Enhancements:
- Add a persistent QVector member to store cached text button widths for overflow layout calculations.
- Use cached widths in the second overflow layout pass instead of querying button geometry again.
- Clear the cached widths when buttons are reset or the app menu model is updated to keep layout state consistent.

</details>

</details>

</details>

Miglioramenti:
- Memorizzare nella cache le larghezze dei pulsanti di testo durante il primo passaggio di layout di overflow e riutilizzarle nel secondo passaggio per evitare calcoli ridondanti della geometria.
- Introdurre un membro `QVector` persistente per archiviare le larghezze memorizzate nella cache e prevenire allocazioni dinamiche ripetute durante gli aggiornamenti del layout.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Memorizza in cache le larghezze dei pulsanti di testo durante il layout di overflow per migliorare le prestazioni e riutilizzarle tra i vari passaggi di layout.

Enhancements:
- Aggiungi un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo utilizzate nei calcoli del layout di overflow.
- Usa le larghezze memorizzate in cache nel secondo passaggio del layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Pulisci le larghezze memorizzate in cache quando i pulsanti vengono reimpostati o il modello del menu dell’app viene aggiornato, per mantenere lo stato del layout coerente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Cache text button widths during overflow layout to improve performance and reuse them across layout passes.

Enhancements:
- Add a persistent QVector member to store cached text button widths for overflow layout calculations.
- Use cached widths in the second overflow layout pass instead of querying button geometry again.
- Clear the cached widths when buttons are reset or the app menu model is updated to keep layout state consistent.

</details>

Miglioramenti:
- Introdurre un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo tra più passaggi di layout di overflow.
- Riutilizzare le larghezze in cache nel secondo passaggio di layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Svuotare l’archivio delle larghezze in cache quando si reimpostano i pulsanti, per mantenere coerente lo stato del layout.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Memorizza in cache le larghezze dei pulsanti di testo durante il layout di overflow per migliorare le prestazioni e riutilizzarle tra i vari passaggi di layout.

Enhancements:
- Aggiungi un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo utilizzate nei calcoli del layout di overflow.
- Usa le larghezze memorizzate in cache nel secondo passaggio del layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Pulisci le larghezze memorizzate in cache quando i pulsanti vengono reimpostati o il modello del menu dell’app viene aggiornato, per mantenere lo stato del layout coerente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Cache text button widths during overflow layout to improve performance and reuse them across layout passes.

Enhancements:
- Add a persistent QVector member to store cached text button widths for overflow layout calculations.
- Use cached widths in the second overflow layout pass instead of querying button geometry again.
- Clear the cached widths when buttons are reset or the app menu model is updated to keep layout state consistent.

</details>

</details>

Miglioramenti:
- Introdurre un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo tra i vari passaggi del layout di overflow.
- Riutilizzare le larghezze memorizzate in cache nel secondo passaggio del layout di overflow invece di chiamare `geometry()` di nuovo per ogni pulsante.
- Svuotare l’archivio delle larghezze memorizzate in cache quando si reimpostano i pulsanti per mantenere lo stato coerente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Memorizza in cache le larghezze dei pulsanti di testo durante il layout di overflow per migliorare le prestazioni e riutilizzarle tra i vari passaggi di layout.

Enhancements:
- Aggiungi un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo utilizzate nei calcoli del layout di overflow.
- Usa le larghezze memorizzate in cache nel secondo passaggio del layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Pulisci le larghezze memorizzate in cache quando i pulsanti vengono reimpostati o il modello del menu dell’app viene aggiornato, per mantenere lo stato del layout coerente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Cache text button widths during overflow layout to improve performance and reuse them across layout passes.

Enhancements:
- Add a persistent QVector member to store cached text button widths for overflow layout calculations.
- Use cached widths in the second overflow layout pass instead of querying button geometry again.
- Clear the cached widths when buttons are reset or the app menu model is updated to keep layout state consistent.

</details>

Miglioramenti:
- Introdurre un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo tra più passaggi di layout di overflow.
- Riutilizzare le larghezze in cache nel secondo passaggio di layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Svuotare l’archivio delle larghezze in cache quando si reimpostano i pulsanti, per mantenere coerente lo stato del layout.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Memorizza in cache le larghezze dei pulsanti di testo durante il layout di overflow per migliorare le prestazioni e riutilizzarle tra i vari passaggi di layout.

Enhancements:
- Aggiungi un membro `QVector` persistente per memorizzare in cache le larghezze dei pulsanti di testo utilizzate nei calcoli del layout di overflow.
- Usa le larghezze memorizzate in cache nel secondo passaggio del layout di overflow invece di interrogare nuovamente la geometria dei pulsanti.
- Pulisci le larghezze memorizzate in cache quando i pulsanti vengono reimpostati o il modello del menu dell’app viene aggiornato, per mantenere lo stato del layout coerente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Cache text button widths during overflow layout to improve performance and reuse them across layout passes.

Enhancements:
- Add a persistent QVector member to store cached text button widths for overflow layout calculations.
- Use cached widths in the second overflow layout pass instead of querying button geometry again.
- Clear the cached widths when buttons are reset or the app menu model is updated to keep layout state consistent.

</details>

</details>

</details>

</details>

</details>

</details>