### PR TITLE
Lazy-initialize QFontMetricsF in Decoration::paintCaption

### DIFF
--- a/src/Decoration.cc
+++ b/src/Decoration.cc
@@ -20,6 +20,7 @@
  */
 
 #include <atomic>
+#include <optional>
 
 // own
 #include "Decoration.h"
@@ -1188,6 +1189,14 @@ void Decoration::paintCaption(QPainter *painter, const QRectF &repaintRegion) co
     const QString fullCaption = decoratedClient->caption();
     const qreal offset = topOffset();
 
+    std::optional<QFontMetricsF> lazyFontMetrics;
+    auto getFontMetrics = [&]() -> const QFontMetricsF & {
+        if (!lazyFontMetrics) {
+            lazyFontMetrics.emplace(font);
+        }
+        return *lazyFontMetrics;
+    };
+
     // 2. Baseline constrained geometry (used to determine if space is limited)
     QRectF constrainedRect = centerRect();
     if (appMenuVisible && m_menuButtons->alwaysShow()) {
@@ -1203,8 +1212,7 @@ void Decoration::paintCaption(QPainter *painter, const QRectF &repaintRegion) co
     if (m_captionCache.textWidth < 0 || m_captionCache.fullCaption != fullCaption || m_captionCache.font != font) {
         m_captionCache.fullCaption = fullCaption;
         m_captionCache.font = font;
-        const QFontMetricsF fontMetrics(font);
-        m_captionCache.textWidth = fontMetrics.boundingRect(fullCaption).width();
+        m_captionCache.textWidth = getFontMetrics().boundingRect(fullCaption).width();
         m_captionCache.availableWidth = -1.0;
     }
     const qreal textWidth = m_captionCache.textWidth;
@@ -1287,8 +1295,7 @@ void Decoration::paintCaption(QPainter *painter, const QRectF &repaintRegion) co
     if (m_captionCache.availableWidth != drawingRect.width() || m_captionCache.alignment != alignment) {
         m_captionCache.availableWidth = drawingRect.width();
         m_captionCache.alignment = alignment;
-        const QFontMetricsF fontMetrics(font);
-        m_captionCache.elidedCaption = fontMetrics.elidedText(fullCaption, Qt::ElideMiddle, drawingRect.width());
+        m_captionCache.elidedCaption = getFontMetrics().elidedText(fullCaption, Qt::ElideMiddle, drawingRect.width());
     }    
     
 

--- a/src/Decoration.cc
+++ b/src/Decoration.cc
@@ -1185,7 +1185,6 @@ void Decoration::paintCaption(QPainter *painter, const QRectF &repaintRegion) co
     }
 
     const QFont font = settings()->font();
-    const QFontMetricsF fontMetrics(font);
     const QString fullCaption = decoratedClient->caption();
     const qreal offset = topOffset();
 
@@ -1204,6 +1203,7 @@ void Decoration::paintCaption(QPainter *painter, const QRectF &repaintRegion) co
     if (m_captionCache.textWidth < 0 || m_captionCache.fullCaption != fullCaption || m_captionCache.font != font) {
         m_captionCache.fullCaption = fullCaption;
         m_captionCache.font = font;
+        const QFontMetricsF fontMetrics(font);
         m_captionCache.textWidth = fontMetrics.boundingRect(fullCaption).width();
         m_captionCache.availableWidth = -1.0;
     }
@@ -1287,6 +1287,7 @@ void Decoration::paintCaption(QPainter *painter, const QRectF &repaintRegion) co
     if (m_captionCache.availableWidth != drawingRect.width() || m_captionCache.alignment != alignment) {
         m_captionCache.availableWidth = drawingRect.width();
         m_captionCache.alignment = alignment;
+        const QFontMetricsF fontMetrics(font);
         m_captionCache.elidedCaption = fontMetrics.elidedText(fullCaption, Qt::ElideMiddle, drawingRect.width());
     }    
     

--- a/src/Decoration.cc
+++ b/src/Decoration.cc
@@ -1189,8 +1189,11 @@ void Decoration::paintCaption(QPainter *painter, const QRectF &repaintRegion) co
     const QString fullCaption = decoratedClient->caption();
     const qreal offset = topOffset();
 
+    // Defer QFontMetricsF construction until actually needed to avoid unnecessary work during painting.
+    // QFontMetricsF construction can be non-trivial; create it only when bounding/eliding is required.
     std::optional<QFontMetricsF> lazyFontMetrics;
-    auto getFontMetrics = [&]() -> const QFontMetricsF & {
+    // Capture only the variables we need: lazyFontMetrics by reference and font by value.
+    auto getFontMetrics = [&lazyFontMetrics, font]() -> const QFontMetricsF & {
         if (!lazyFontMetrics) {
             lazyFontMetrics.emplace(font);
         }


### PR DESCRIPTION
## Summary by Sourcery

Miglioramenti:
- Introdurre l'inizializzazione lazy di `QFontMetricsF` tramite un accessor in `Decoration::paintCaption` per evitare la costruzione non necessaria dei metrici durante il rendering.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Introduce lazy initialization of QFontMetricsF via an accessor in Decoration::paintCaption to avoid unnecessary metric construction during painting.

</details>
- Introdotta l'inizializzazione lazy di `QFontMetricsF` utilizzando un `optional` e un apposito accessor, in modo da costruire i font metrics solo quando la larghezza della didascalia o l'elisione vengono ricalcolate.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Miglioramenti:
- Introdurre l'inizializzazione lazy di `QFontMetricsF` tramite un accessor in `Decoration::paintCaption` per evitare la costruzione non necessaria dei metrici durante il rendering.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Introduce lazy initialization of QFontMetricsF via an accessor in Decoration::paintCaption to avoid unnecessary metric construction during painting.

</details>

</details>
- Evita la costruzione non necessaria di `QFontMetricsF` in `Decoration::paintCaption` collegando l'istanziazione dei font metrics agli aggiornamenti della cache della didascalia.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Miglioramenti:
- Introdurre l'inizializzazione lazy di `QFontMetricsF` tramite un accessor in `Decoration::paintCaption` per evitare la costruzione non necessaria dei metrici durante il rendering.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Introduce lazy initialization of QFontMetricsF via an accessor in Decoration::paintCaption to avoid unnecessary metric construction during painting.

</details>
- Introdotta l'inizializzazione lazy di `QFontMetricsF` utilizzando un `optional` e un apposito accessor, in modo da costruire i font metrics solo quando la larghezza della didascalia o l'elisione vengono ricalcolate.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Miglioramenti:
- Introdurre l'inizializzazione lazy di `QFontMetricsF` tramite un accessor in `Decoration::paintCaption` per evitare la costruzione non necessaria dei metrici durante il rendering.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Introduce lazy initialization of QFontMetricsF via an accessor in Decoration::paintCaption to avoid unnecessary metric construction during painting.

</details>

</details>

</details>