### PR TITLE
Track key navigation to avoid it stucks on empty menues

### DIFF
--- a/src/AppMenuButton.cc
+++ b/src/AppMenuButton.cc
@@ -127,7 +127,10 @@ void AppMenuButton::trigger() {
     // qCDebug(category) << "AppMenuButton::trigger" << m_buttonIndex;
 
     auto *buttonGroup = qobject_cast<AppMenuButtonGroup *>(parent());
-    buttonGroup->trigger(m_buttonIndex);
+    if (buttonGroup) {
+        buttonGroup->m_navigationDirection = AppMenuButtonGroup::NavigationDirection::None;
+        buttonGroup->trigger(m_buttonIndex);
+    }
 }
 
 } // namespace Material

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -366,7 +366,6 @@ void AppMenuButtonGroup::resetButtons()
     m_searchButton = nullptr;
     m_overflowIndex = -1;
     m_searchIndex = -1;
-    m_cachedWidths.clear();
 
     if (m_overflowMenu) {
         m_overflowMenu->deleteLater();
@@ -477,7 +476,6 @@ void AppMenuButtonGroup::performDebouncedMenuUpdate()
 void AppMenuButtonGroup::updateAppMenuModel()
 {
     m_search->invalidateCandidates();
-    m_cachedWidths.clear();
 
     auto *deco = qobject_cast<Decoration *>(decoration());
     if (!deco) {
@@ -637,21 +635,9 @@ void AppMenuButtonGroup::updateOverflow(QRectF availableRect)
         qreal totalTextWidth = 0;
         int enabledCount = 0;
         bool allFit = true;
-        const int buttonCount = m_textButtons.size();
-        // Cache geometry widths in first pass so second pass can reuse them without calling geometry() again.
-        // Re-use class member vector to completely avoid repeat dynamic allocations during layout updates.
-        if (m_cachedWidths.size() != buttonCount) {
-            m_cachedWidths.resize(buttonCount);
-        }
-        // Ensure all entries are initialized to avoid stale reads if we bail early from the first pass.
-        m_cachedWidths.fill(0);
-
-        for (int i = 0; i < buttonCount; ++i) {
-            auto &tb = m_textButtons[i];
+        for (auto &tb : std::as_const(m_textButtons)) {
             if (tb && tb->isEnabled()) {
-                const qreal w = tb->geometry().width();
-                m_cachedWidths[i] = w;
-                totalTextWidth += w;
+                totalTextWidth += tb->geometry().width();
                 enabledCount++;
                 if (fixedWidth + totalTextWidth > availableWidth) {
                     allFit = false;
@@ -676,13 +662,12 @@ void AppMenuButtonGroup::updateOverflow(QRectF availableRect)
 
             // Second pass: apply visibility and calculate final width
             bool fits = true;
-            for (int i = 0; i < buttonCount; ++i) {
-                auto &tb = m_textButtons[i];
+            for (auto &tb : std::as_const(m_textButtons)) {
                 if (!tb) {
                     continue;
                 }
                 if (fits && tb->isEnabled()) {
-                    const qreal w = m_cachedWidths[i];
+                    const qreal w = tb->geometry().width();
                     if (w <= remainingWidth) {
                         tb->setVisible(true);
                         currentVisibleWidth += w;
@@ -749,6 +734,7 @@ void AppMenuButtonGroup::popupMenu(QMenu *menu, int buttonIndex)
     setCurrentIndex(buttonIndex);
     button->setChecked(true);
     m_currentMenu = menu;
+    m_navigationDirection = NavigationDirection::None;
 
     // 2. Calculate position and show the new menu. This must happen before hiding the old one to prevent flicker.
     if (auto navMenu = qobject_cast<NavigableMenu *>(menu)) {
@@ -1009,16 +995,19 @@ void AppMenuButtonGroup::onMenuAboutToHide()
     setCurrentIndex(-1);
     m_currentMenu = nullptr;
     m_hoveredButton = nullptr;
+    m_navigationDirection = NavigationDirection::None;
 }
 
 void AppMenuButtonGroup::onHitLeft()
 {
+    m_navigationDirection = NavigationDirection::Left;
     int desiredIndex = findNextVisibleButtonIndex(m_currentIndex, false);
     trigger(desiredIndex);
 }
 
 void AppMenuButtonGroup::onHitRight()
 {
+    m_navigationDirection = NavigationDirection::Right;
     int desiredIndex = findNextVisibleButtonIndex(m_currentIndex, true);
     trigger(desiredIndex);
 }
@@ -1086,7 +1075,15 @@ void AppMenuButtonGroup::onSubMenuReady(QMenu *menu)
         m_buttonIndexWaitingForPopup = -1;
 
         if (menu->actions().isEmpty()) {
-            popupMenu(menu, buttonIndex);
+            if (m_navigationDirection == NavigationDirection::Left || m_navigationDirection == NavigationDirection::Right) {
+                const bool forward = (m_navigationDirection == NavigationDirection::Right);
+                const int desiredIndex = findNextVisibleButtonIndex(buttonIndex, forward);
+                if (desiredIndex != -1 && desiredIndex != buttonIndex && desiredIndex != m_currentIndex) {
+                    trigger(desiredIndex);
+                }
+            } else {
+                popupMenu(menu, buttonIndex);
+            }
         } else {
             trigger(buttonIndex);
         }
@@ -1155,6 +1152,7 @@ void AppMenuButtonGroup::handleHoverMove(const QPointF &pos)
         return;
     }
 
+    m_navigationDirection = NavigationDirection::None;
     KDecoration3::DecorationButton *newHoveredButton = buttonAt(pos.toPoint());
 
     if (m_hoveredButton != newHoveredButton) {

--- a/src/AppMenuButtonGroup.h
+++ b/src/AppMenuButtonGroup.h
@@ -30,7 +30,6 @@
 #include <QMenu>
 #include <QLineEdit>
 #include <QPointer>
-#include <QVector>
 
 class QTimer;
 class QVariantAnimation;
@@ -191,9 +190,15 @@ private:
 
     QPointer<KDecoration3::DecorationButton> m_hoveredButton = nullptr;
 
-    // Cached text button widths to avoid querying geometry().width() twice during overflow layout.
-    // Invariant: m_cachedWidths.size() == m_textButtons.size() when in use.
-    QVector<qreal> m_cachedWidths;
+public:
+    enum class NavigationDirection {
+        None,
+        Left,
+        Right
+    };
+
+private:
+    NavigationDirection m_navigationDirection = NavigationDirection::None;
 
     friend class AppMenuButton;
     friend class Decoration;


### PR DESCRIPTION
## Summary by Sourcery

Tieni traccia della direzione di navigazione tramite tastiera nel gruppo di pulsanti del menu dell’app per evitare di rimanere bloccati su menu vuoti e semplificare la gestione della larghezza del layout di overflow.

Miglioramenti:
- Introdurre uno stato `NavigationDirection` su `AppMenuButtonGroup` per distinguere la navigazione tramite tastiera a sinistra/destra dalle altre interazioni.
- Reimpostare la direzione di navigazione all’apertura/chiusura del menu popup, all’attivazione del pulsante e allo spostamento del puntatore (hover) per mantenere lo stato di navigazione coerente.
- Ripiegare sulla navigazione verso il pulsante visibile successivo invece di aprire un sottomenu vuoto quando si naviga tramite tastiera.
- Semplificare la logica del layout di overflow rimuovendo la memorizzazione nella cache della larghezza del pulsante di testo e interrogando direttamente le larghezze della geometria.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Track keyboard navigation direction in the app menu button group to avoid getting stuck on empty menus and simplify overflow layout width handling.

Enhancements:
- Introduce a NavigationDirection state on AppMenuButtonGroup to distinguish left/right keyboard navigation from other interactions.
- Reset navigation direction on menu popup, menu hide, button trigger, and hover moves to keep navigation state consistent.
- Fallback to navigating to the next visible button instead of opening an empty submenu when navigating via keyboard.
- Simplify overflow layout logic by removing cached text button width storage and querying geometry widths directly.

</details>