### PR TITLE
Track key navigation to avoid it stucks on empty menues

### DIFF
--- a/src/AppMenuButton.cc
+++ b/src/AppMenuButton.cc
@@ -127,7 +127,10 @@ void AppMenuButton::trigger() {
     // qCDebug(category) << "AppMenuButton::trigger" << m_buttonIndex;
 
     auto *buttonGroup = qobject_cast<AppMenuButtonGroup *>(parent());
-    buttonGroup->trigger(m_buttonIndex);
+    if (buttonGroup) {
+        buttonGroup->m_navigationDirection = AppMenuButtonGroup::NavigationDirection::None;
+        buttonGroup->trigger(m_buttonIndex);
+    }
 }
 
 } // namespace Material

--- a/src/AppMenuButton.cc
+++ b/src/AppMenuButton.cc
@@ -127,6 +127,8 @@ void AppMenuButton::trigger() {
     // qCDebug(category) << "AppMenuButton::trigger" << m_buttonIndex;
 
     auto *buttonGroup = qobject_cast<AppMenuButtonGroup *>(parent());
+    Q_ASSERT_X(buttonGroup, "AppMenuButton::trigger", "Parent of AppMenuButton must be an AppMenuButtonGroup");
+    
     if (buttonGroup) {
         buttonGroup->resetNavigationDirection();
         buttonGroup->trigger(m_buttonIndex);

--- a/src/AppMenuButton.cc
+++ b/src/AppMenuButton.cc
@@ -128,7 +128,7 @@ void AppMenuButton::trigger() {
 
     auto *buttonGroup = qobject_cast<AppMenuButtonGroup *>(parent());
     if (buttonGroup) {
-        buttonGroup->m_navigationDirection = AppMenuButtonGroup::NavigationDirection::None;
+        buttonGroup->resetNavigationDirection();
         buttonGroup->trigger(m_buttonIndex);
     }
 }

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -479,6 +479,9 @@ void AppMenuButtonGroup::performDebouncedMenuUpdate()
 
 void AppMenuButtonGroup::updateAppMenuModel()
 {
+    m_buttonIndexWaitingForPopup = -1;
+    resetNavigationDirection();
+
     m_search->invalidateCandidates();
     m_cachedWidths.clear();
 

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -749,6 +749,7 @@ void AppMenuButtonGroup::popupMenu(QMenu *menu, int buttonIndex)
     setCurrentIndex(buttonIndex);
     button->setChecked(true);
     m_currentMenu = menu;
+    m_buttonIndexWaitingForPopup = -1;
     resetNavigationDirection();
 
     // 2. Calculate position and show the new menu. This must happen before hiding the old one to prevent flicker.
@@ -1015,6 +1016,7 @@ void AppMenuButtonGroup::onMenuAboutToHide()
     setCurrentIndex(-1);
     m_currentMenu = nullptr;
     m_hoveredButton = nullptr;
+    m_buttonIndexWaitingForPopup = -1;
     resetNavigationDirection();
 }
 
@@ -1186,6 +1188,7 @@ void AppMenuButtonGroup::handleHoverMove(const QPointF &pos)
 
     if (m_hoveredButton != newHoveredButton) {
         m_hoveredButton = newHoveredButton;
+        m_buttonIndexWaitingForPopup = -1;
 
         if (m_hoveredButton) {
             // All buttons in this group are AppMenuButtons

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -749,7 +749,7 @@ void AppMenuButtonGroup::popupMenu(QMenu *menu, int buttonIndex)
     setCurrentIndex(buttonIndex);
     button->setChecked(true);
     m_currentMenu = menu;
-    m_navigationDirection = NavigationDirection::None;
+    resetNavigationDirection();
 
     // 2. Calculate position and show the new menu. This must happen before hiding the old one to prevent flicker.
     if (auto navMenu = qobject_cast<NavigableMenu *>(menu)) {
@@ -1015,7 +1015,7 @@ void AppMenuButtonGroup::onMenuAboutToHide()
     setCurrentIndex(-1);
     m_currentMenu = nullptr;
     m_hoveredButton = nullptr;
-    m_navigationDirection = NavigationDirection::None;
+    resetNavigationDirection();
 }
 
 void AppMenuButtonGroup::onHitLeft()
@@ -1095,21 +1095,26 @@ void AppMenuButtonGroup::onSubMenuReady(QMenu *menu)
         m_buttonIndexWaitingForPopup = -1;
 
         if (menu->actions().isEmpty()) {
-            if (m_navigationDirection == NavigationDirection::Left || m_navigationDirection == NavigationDirection::Right) {
-                const bool forward = (m_navigationDirection == NavigationDirection::Right);
-                const int desiredIndex = findNextVisibleButtonIndex(buttonIndex, forward);
-                if (desiredIndex != -1 && desiredIndex != buttonIndex && desiredIndex != m_currentIndex) {
-                    trigger(desiredIndex);
-                } else {
-                    popupMenu(menu, buttonIndex);
-                    m_navigationDirection = NavigationDirection::None;
-                }
-            } else {
-                popupMenu(menu, buttonIndex);
-            }
+            handleEmptySubMenu(menu, buttonIndex);
         } else {
             trigger(buttonIndex);
         }
+    }
+}
+
+void AppMenuButtonGroup::handleEmptySubMenu(QMenu *menu, int buttonIndex)
+{
+    if (m_navigationDirection == NavigationDirection::Left || m_navigationDirection == NavigationDirection::Right) {
+        const bool forward = (m_navigationDirection == NavigationDirection::Right);
+        const int desiredIndex = findNextVisibleButtonIndex(buttonIndex, forward);
+        if (desiredIndex != -1 && desiredIndex != buttonIndex && desiredIndex != m_currentIndex) {
+            trigger(desiredIndex);
+        } else {
+            popupMenu(menu, buttonIndex);
+            resetNavigationDirection();
+        }
+    } else {
+        popupMenu(menu, buttonIndex);
     }
 }
 
@@ -1175,7 +1180,7 @@ void AppMenuButtonGroup::handleHoverMove(const QPointF &pos)
         return;
     }
 
-    m_navigationDirection = NavigationDirection::None;
+    resetNavigationDirection();
     KDecoration3::DecorationButton *newHoveredButton = buttonAt(pos.toPoint());
 
     if (m_hoveredButton != newHoveredButton) {

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -354,6 +354,9 @@ KDecoration3::DecorationButton* AppMenuButtonGroup::buttonAt(QPoint pos) const
 
 void AppMenuButtonGroup::resetButtons()
 {
+    m_buttonIndexWaitingForPopup = -1;
+    resetNavigationDirection();
+
     if (buttons().isEmpty()) {
         return;
     }
@@ -1024,14 +1027,22 @@ void AppMenuButtonGroup::onHitLeft()
 {
     m_navigationDirection = NavigationDirection::Left;
     int desiredIndex = findNextVisibleButtonIndex(m_currentIndex, false);
-    trigger(desiredIndex);
+    if (desiredIndex == -1 || desiredIndex == m_currentIndex) {
+        resetNavigationDirection();
+    } else {
+        trigger(desiredIndex);
+    }
 }
 
 void AppMenuButtonGroup::onHitRight()
 {
     m_navigationDirection = NavigationDirection::Right;
     int desiredIndex = findNextVisibleButtonIndex(m_currentIndex, true);
-    trigger(desiredIndex);
+    if (desiredIndex == -1 || desiredIndex == m_currentIndex) {
+        resetNavigationDirection();
+    } else {
+        trigger(desiredIndex);
+    }
 }
 
 void AppMenuButtonGroup::onShowingChanged(bool showing)

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -979,6 +979,11 @@ void AppMenuButtonGroup::updateShowing()
     }
 }
 
+void AppMenuButtonGroup::resetNavigationDirection()
+{
+    m_navigationDirection = NavigationDirection::None;
+}
+
 void AppMenuButtonGroup::onMenuAboutToHide()
 {
     QMenu *menu = qobject_cast<QMenu *>(sender());
@@ -1095,6 +1100,9 @@ void AppMenuButtonGroup::onSubMenuReady(QMenu *menu)
                 const int desiredIndex = findNextVisibleButtonIndex(buttonIndex, forward);
                 if (desiredIndex != -1 && desiredIndex != buttonIndex && desiredIndex != m_currentIndex) {
                     trigger(desiredIndex);
+                } else {
+                    popupMenu(menu, buttonIndex);
+                    m_navigationDirection = NavigationDirection::None;
                 }
             } else {
                 popupMenu(menu, buttonIndex);

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -749,6 +749,7 @@ void AppMenuButtonGroup::popupMenu(QMenu *menu, int buttonIndex)
     setCurrentIndex(buttonIndex);
     button->setChecked(true);
     m_currentMenu = menu;
+    m_navigationDirection = NavigationDirection::None;
 
     // 2. Calculate position and show the new menu. This must happen before hiding the old one to prevent flicker.
     if (auto navMenu = qobject_cast<NavigableMenu *>(menu)) {
@@ -1009,16 +1010,19 @@ void AppMenuButtonGroup::onMenuAboutToHide()
     setCurrentIndex(-1);
     m_currentMenu = nullptr;
     m_hoveredButton = nullptr;
+    m_navigationDirection = NavigationDirection::None;
 }
 
 void AppMenuButtonGroup::onHitLeft()
 {
+    m_navigationDirection = NavigationDirection::Left;
     int desiredIndex = findNextVisibleButtonIndex(m_currentIndex, false);
     trigger(desiredIndex);
 }
 
 void AppMenuButtonGroup::onHitRight()
 {
+    m_navigationDirection = NavigationDirection::Right;
     int desiredIndex = findNextVisibleButtonIndex(m_currentIndex, true);
     trigger(desiredIndex);
 }
@@ -1086,7 +1090,15 @@ void AppMenuButtonGroup::onSubMenuReady(QMenu *menu)
         m_buttonIndexWaitingForPopup = -1;
 
         if (menu->actions().isEmpty()) {
-            popupMenu(menu, buttonIndex);
+            if (m_navigationDirection == NavigationDirection::Left || m_navigationDirection == NavigationDirection::Right) {
+                const bool forward = (m_navigationDirection == NavigationDirection::Right);
+                const int desiredIndex = findNextVisibleButtonIndex(buttonIndex, forward);
+                if (desiredIndex != -1 && desiredIndex != buttonIndex && desiredIndex != m_currentIndex) {
+                    trigger(desiredIndex);
+                }
+            } else {
+                popupMenu(menu, buttonIndex);
+            }
         } else {
             trigger(buttonIndex);
         }
@@ -1155,6 +1167,7 @@ void AppMenuButtonGroup::handleHoverMove(const QPointF &pos)
         return;
     }
 
+    m_navigationDirection = NavigationDirection::None;
     KDecoration3::DecorationButton *newHoveredButton = buttonAt(pos.toPoint());
 
     if (m_hoveredButton != newHoveredButton) {

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -1107,11 +1107,12 @@ void AppMenuButtonGroup::handleEmptySubMenu(QMenu *menu, int buttonIndex)
     if (m_navigationDirection == NavigationDirection::Left || m_navigationDirection == NavigationDirection::Right) {
         const bool forward = (m_navigationDirection == NavigationDirection::Right);
         const int desiredIndex = findNextVisibleButtonIndex(buttonIndex, forward);
-        if (desiredIndex != -1 && desiredIndex != buttonIndex && desiredIndex != m_currentIndex) {
+        const bool isCurrentMenuNonEmpty = m_currentMenu && !m_currentMenu->actions().isEmpty();
+        
+        if (desiredIndex != -1 && desiredIndex != buttonIndex && (desiredIndex != m_currentIndex || isCurrentMenuNonEmpty)) {
             trigger(desiredIndex);
         } else {
             popupMenu(menu, buttonIndex);
-            resetNavigationDirection();
         }
     } else {
         popupMenu(menu, buttonIndex);

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -1123,9 +1123,8 @@ void AppMenuButtonGroup::handleEmptySubMenu(QMenu *menu, int buttonIndex)
     if (m_navigationDirection == NavigationDirection::Left || m_navigationDirection == NavigationDirection::Right) {
         const bool forward = (m_navigationDirection == NavigationDirection::Right);
         const int desiredIndex = findNextVisibleButtonIndex(buttonIndex, forward);
-        const bool isCurrentMenuNonEmpty = m_currentMenu && !m_currentMenu->actions().isEmpty();
         
-        if (desiredIndex != -1 && desiredIndex != buttonIndex && (desiredIndex != m_currentIndex || isCurrentMenuNonEmpty)) {
+        if (desiredIndex != -1 && desiredIndex != buttonIndex && desiredIndex != m_currentIndex) {
             trigger(desiredIndex);
         } else {
             popupMenu(menu, buttonIndex);

--- a/src/AppMenuButtonGroup.h
+++ b/src/AppMenuButtonGroup.h
@@ -106,6 +106,7 @@ private:
     void filterMenu(const QString &text);
     void onSearchTimerTimeout();
     void onSubMenuReady(QMenu *menu);
+    void handleEmptySubMenu(QMenu *menu, int buttonIndex);
 
 signals:
     void menuUpdated();

--- a/src/AppMenuButtonGroup.h
+++ b/src/AppMenuButtonGroup.h
@@ -195,6 +195,16 @@ private:
     // Invariant: m_cachedWidths.size() == m_textButtons.size() when in use.
     QVector<qreal> m_cachedWidths;
 
+public:
+    enum class NavigationDirection {
+        None,
+        Left,
+        Right
+    };
+
+private:
+    NavigationDirection m_navigationDirection = NavigationDirection::None;
+    
     friend class AppMenuButton;
     friend class Decoration;
 };

--- a/src/AppMenuButtonGroup.h
+++ b/src/AppMenuButtonGroup.h
@@ -89,6 +89,7 @@ public:
     void updateAppMenuModel();
     void updateOverflow(QRectF availableRect);
     void updateShowing();
+    void resetNavigationDirection();
 
 private:
     void onMenuReadyForSearch();
@@ -195,14 +196,12 @@ private:
     // Invariant: m_cachedWidths.size() == m_textButtons.size() when in use.
     QVector<qreal> m_cachedWidths;
 
-public:
     enum class NavigationDirection {
         None,
         Left,
         Right
     };
 
-private:
     NavigationDirection m_navigationDirection = NavigationDirection::None;
     
     friend class AppMenuButton;


### PR DESCRIPTION
## Summary by Sourcery

Traccia e reimposta la direzione di navigazione del menu quando ci si sposta tra i pulsanti del menu dell'app, garantendo che la navigazione da tastiera salti i menu vuoti senza bloccarsi.

New Features:
- Introdurre il tracciamento della direzione di navigazione (sinistra/destra/nessuna) nel gruppo di pulsanti del menu dell'app per determinare il comportamento di navigazione.
- Aggiungere una API sui pulsanti del menu dell'app per reimpostare la direzione di navigazione prima di attivare l'azione di un pulsante.

Bug Fixes:
- Assicurarsi che la navigazione da tastiera salti i menu dell'app vuoti invece di bloccarsi su di essi, pur aprendo comunque un menu vuoto quando non è disponibile alcuna alternativa.

Enhancements:
- Reimpostare la direzione di navigazione in vari percorsi di interazione (popup del menu, nascondi, hover) per mantenere lo stato coerente ed evitare un contesto di navigazione obsoleto.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Track and reset menu navigation direction when moving between app menu buttons, ensuring keyboard navigation skips empty menus without getting stuck.

New Features:
- Introduce tracking of navigation direction (left/right/none) in the app menu button group to inform navigation behavior.
- Add an API on app menu buttons to reset navigation direction before triggering a button action.

Bug Fixes:
- Ensure keyboard navigation skips over empty app menus instead of getting stuck on them, while still opening an empty menu when no alternative is available.

Enhancements:
- Reset navigation direction in various interaction paths (menu popup, hide, hover) to keep state consistent and avoid stale navigation context.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Traccia e reimposta la direzione di navigazione del menu quando ci si sposta tra i pulsanti del menu dell'app, garantendo che la navigazione da tastiera salti i menu vuoti senza bloccarsi.

New Features:
- Introdurre il tracciamento della direzione di navigazione (sinistra/destra/nessuna) nel gruppo di pulsanti del menu dell'app per determinare il comportamento di navigazione.
- Aggiungere una API sui pulsanti del menu dell'app per reimpostare la direzione di navigazione prima di attivare l'azione di un pulsante.

Bug Fixes:
- Assicurarsi che la navigazione da tastiera salti i menu dell'app vuoti invece di bloccarsi su di essi, pur aprendo comunque un menu vuoto quando non è disponibile alcuna alternativa.

Enhancements:
- Reimpostare la direzione di navigazione in vari percorsi di interazione (popup del menu, nascondi, hover) per mantenere lo stato coerente ed evitare un contesto di navigazione obsoleto.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Track and reset menu navigation direction when moving between app menu buttons, ensuring keyboard navigation skips empty menus without getting stuck.

New Features:
- Introduce tracking of navigation direction (left/right/none) in the app menu button group to inform navigation behavior.
- Add an API on app menu buttons to reset navigation direction before triggering a button action.

Bug Fixes:
- Ensure keyboard navigation skips over empty app menus instead of getting stuck on them, while still opening an empty menu when no alternative is available.

Enhancements:
- Reset navigation direction in various interaction paths (menu popup, hide, hover) to keep state consistent and avoid stale navigation context.

</details>

</details>