### PR TITLE
some hardening

### DIFF
--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -62,6 +62,7 @@ AppMenuButtonGroup::AppMenuButtonGroup(Decoration *decoration)
     , m_currentIndex(-1)
     , m_overflowIndex(-1)
     , m_searchIndex(-1)
+    , m_overflowing(false)
     , m_hamburgerMenu(false)
     , m_hovered(false)
     , m_showing(true)
@@ -354,6 +355,7 @@ KDecoration3::DecorationButton* AppMenuButtonGroup::buttonAt(QPoint pos) const
 
 void AppMenuButtonGroup::resetButtons()
 {
+    m_buttonIndexWaitingForPopup = -1;
     if (buttons().isEmpty()) {
         return;
     }
@@ -476,6 +478,7 @@ void AppMenuButtonGroup::performDebouncedMenuUpdate()
 
 void AppMenuButtonGroup::updateAppMenuModel()
 {
+    m_buttonIndexWaitingForPopup = -1;
     m_search->invalidateCandidates();
     m_cachedWidths.clear();
 
@@ -732,6 +735,7 @@ bool AppMenuButtonGroup::isWaitingForMenu() const
 
 void AppMenuButtonGroup::popupMenu(QMenu *menu, int buttonIndex)
 {
+    m_buttonIndexWaitingForPopup = -1;
     // Stop any caching that may be in progress from a previously opened menu.
     m_appMenuModel->stopCaching();
 
@@ -980,6 +984,7 @@ void AppMenuButtonGroup::updateShowing()
 
 void AppMenuButtonGroup::onMenuAboutToHide()
 {
+    m_buttonIndexWaitingForPopup = -1;
     QMenu *menu = qobject_cast<QMenu *>(sender());
     if (!menu) {
         return;
@@ -1066,7 +1071,7 @@ void AppMenuButtonGroup::onSubMenuReady(QMenu *menu)
         }
     }
 
-    if (m_buttonIndexWaitingForPopup == -1 || !m_appMenuModel || !m_appMenuModel->menu()) {
+    if (m_buttonIndexWaitingForPopup < 0 || !m_appMenuModel || !m_appMenuModel->menu()) {
         return;
     }
 
@@ -1158,6 +1163,7 @@ void AppMenuButtonGroup::handleHoverMove(const QPointF &pos)
     KDecoration3::DecorationButton *newHoveredButton = buttonAt(pos.toPoint());
 
     if (m_hoveredButton != newHoveredButton) {
+        m_buttonIndexWaitingForPopup = -1;
         m_hoveredButton = newHoveredButton;
 
         if (m_hoveredButton) {

--- a/src/AppMenuModel.cc
+++ b/src/AppMenuModel.cc
@@ -68,6 +68,7 @@ protected:
 
 AppMenuModel::AppMenuModel(QObject *parent)
     : QObject(parent),
+      m_menuAvailable(false),
       m_serviceWatcher(new QDBusServiceWatcher(this))
 {
     m_serviceWatcher->setConnection(QDBusConnection::sessionBus());


### PR DESCRIPTION
## Summary by Sourcery

Rafforzare la gestione del pulsante del menu dell’app e dello stato del modello in relazione al ciclo di vita dei popup e al tracciamento della disponibilità del menu.

Bug Fixes:
- Garantire che il tracciamento degli indici dei pulsanti per i popup in sospeso venga reimpostato in modo coerente, per evitare indici obsoleti o non validi durante le interazioni con il menu.
- Trattare gli indici di pulsante negativi come non validi quando si gestisce la disponibilità dei sottomenu, per prevenire operazioni errate sul menu.

Enhancements:
- Aggiungere flag espliciti per l’overflow e la disponibilità del menu, per rappresentare e gestire meglio internamente lo stato del menu dell’app.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden app menu button and model state handling around popup lifecycle and menu availability tracking.

Bug Fixes:
- Ensure button index tracking for pending popups is consistently reset to avoid stale or invalid indices during menu interactions.
- Treat negative button indices as invalid when handling submenu readiness to prevent erroneous menu operations.

Enhancements:
- Add explicit flags for overflow and menu availability to better represent and manage app menu state internally.

</details>