### PR TITLE
fix potential memory leak in dbusmenuimporter.cpp

### DIFF
--- a/src/libdbusmenuqt/dbusmenuimporter.cpp
+++ b/src/libdbusmenuqt/dbusmenuimporter.cpp
@@ -138,7 +138,9 @@ public:
         updateAction(action, map);
 
         if (isKdeTitle) {
-            action = createKdeTitle(action, parent);
+            QAction *oldAction = action;
+            action = createKdeTitle(oldAction, parent);
+            oldAction->deleteLater();
         }
 
         return action;

--- a/src/libdbusmenuqt/dbusmenuimporter.cpp
+++ b/src/libdbusmenuqt/dbusmenuimporter.cpp
@@ -54,7 +54,7 @@ static constexpr auto DBUSMENU_PROPERTY_ICON_DATA_HASH = "_dbusmenu_icon_data_ha
 static constexpr int MAX_ACTIONS_PER_MENU = 1000;
 static constexpr int MAX_TOTAL_ACTIONS = 5000;
 
-static QAction *createKdeTitle(QAction *action, QWidget *parent)
+static QAction *createKdeTitle(const QAction *action, QWidget *parent)
 {
     QToolButton *titleWidget = new QToolButton(nullptr);
     QFont font = titleWidget->font();


### PR DESCRIPTION
In dbusmenuimporter.cpp, when a KDE title is created, the original QAction pointer was overridden by the return value of createKdeTitle(action, parent). The original action was leaked. Saving it as oldAction and calling oldAction->deleteLater() correctly schedules the old action for deletion, preventing a memory leak in Qt.

## Summary by Sourcery

Bug Fixes:
- Garantire che l'`QAction` originale sia programmata per l'eliminazione dopo la creazione di una KDE title action, per evitare una perdita di memoria in Qt.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure the original QAction is scheduled for deletion after creating a KDE title action to avoid a Qt memory leak.

</details>