### PR TITLE
Add initializations for dbusmenutypes

### DIFF
--- a/src/libdbusmenuqt/dbusmenutypes_p.h
+++ b/src/libdbusmenuqt/dbusmenutypes_p.h
@@ -18,7 +18,7 @@ class QDBusArgument;
  * Internal struct used to communicate on DBus
  */
 struct DBusMenuItem {
-    int id;
+    int id = 0;
     QVariantMap properties;
 };
 
@@ -32,7 +32,7 @@ typedef QList<DBusMenuItem> DBusMenuItemList;
  * Represents a list of keys for a menu item
  */
 struct DBusMenuItemKeys {
-    int id;
+    int id = 0;
     QStringList properties;
 };
 
@@ -48,7 +48,7 @@ typedef QList<DBusMenuItemKeys> DBusMenuItemKeysList;
  */
 struct DBusMenuLayoutItem;
 struct DBusMenuLayoutItem {
-    int id;
+    int id = 0;
     QVariantMap properties;
     QList<DBusMenuLayoutItem> children;
 };


### PR DESCRIPTION
## Summary by Sourcery

Miglioramenti:
- Imposta i valori ID predefiniti per le struct `DBusMenuItem`, `DBusMenuItemKeys` e `DBusMenuLayoutItem` per migliorare la sicurezza e la coerenza nella gestione dei dati dei menu DBus.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Set default ID values for DBusMenuItem, DBusMenuItemKeys, and DBusMenuLayoutItem structs to improve safety and consistency of DBus menu data handling.

</details>