### PR TITLE
fix dbusmenu layout item init

### DIFF
--- a/src/libdbusmenuqt/dbusmenutypes_p.cpp
+++ b/src/libdbusmenuqt/dbusmenutypes_p.cpp
@@ -66,12 +66,13 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, DBusMenuLayoutIte
     argument.beginStructure();
     argument >> obj.id >> obj.properties;
     argument.beginArray();
+    obj.children.clear();
     while (!argument.atEnd()) {
         QDBusVariant dbusVariant;
         argument >> dbusVariant;
         QDBusArgument childArgument = dbusVariant.variant().value<QDBusArgument>();
 
-        DBusMenuLayoutItem child;
+        DBusMenuLayoutItem child{};
         childArgument >> child;
         obj.children.append(std::move(child));
     }


### PR DESCRIPTION
## Summary by Sourcery

Correzioni di bug:
- Corregge la deserializzazione degli elementi del layout del menu DBus azzerando gli elementi figli prima di popolarli e inizializzando per valore gli elementi annidati.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix DBus menu layout item deserialization by resetting child items before populating them and value-initializing nested items.

</details>