### PR TITLE
dbusmenuimporter: optimize newIds hash lookups

### DIFF
--- a/src/libdbusmenuqt/dbusmenuimporter.cpp
+++ b/src/libdbusmenuqt/dbusmenuimporter.cpp
@@ -423,7 +423,9 @@ void DBusMenuImporter::slotGetLayoutFinished(QDBusPendingCallWatcher *watcher)
         newIds.insert(rootItem.children.at(i).id);
     }
 
-    // 1. Remove actions no longer present
+    // 1. Remove actions no longer present and keep valid ones in currentActions
+    QList<QAction *> currentActions;
+    currentActions.reserve(actions.count());
     for (QAction *action : std::as_const(actions)) {
         const int id = action->property(DBUSMENU_PROPERTY_ID).toInt();
         if (!newIds.contains(id)) {
@@ -433,15 +435,7 @@ void DBusMenuImporter::slotGetLayoutFinished(QDBusPendingCallWatcher *watcher)
             }
             action->deleteLater();
             d->m_actionForId.remove(id);
-        }
-    }
-
-    // Filter currentActions to keep only those that are not obsolete
-    QList<QAction *> currentActions;
-    currentActions.reserve(actions.count());
-    for (QAction *action : std::as_const(actions)) {
-        const int id = action->property(DBUSMENU_PROPERTY_ID).toInt();
-        if (newIds.contains(id)) {
+        } else {
             currentActions.append(action);
         }
     }


### PR DESCRIPTION
## Summary by Sourcery

Miglioramenti:
- Combina la rimozione delle azioni obsolete e la raccolta delle azioni correnti in un'unica passata per ridurre le ricerche nell'hash durante gli aggiornamenti del layout del menu.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Combine obsolete-action removal and current-action collection into a single pass to reduce hash lookups during menu layout updates.

</details>