### PR TITLE
Window-Specific exceptions: add thin-outline configuration

### DIFF
--- a/src/ExceptionList.cc
+++ b/src/ExceptionList.cc
@@ -69,6 +69,7 @@ void copyInternalSettings(const InternalSettingsPtr &src, const InternalSettings
     dst->setHamburgerMenu(src->hamburgerMenu());
     dst->setSquareCorners(src->squareCorners());
     dst->setHideShadow(src->hideShadow());
+    dst->setOutlineActive(src->outlineActive());
 }
 
 InternalSettingsPtr cloneInternalSettings(const InternalSettingsPtr &src)
@@ -124,6 +125,7 @@ void ExceptionList::readConfig(const KSharedConfig::Ptr &config)
         exception->setHamburgerMenu(group.readEntry("HamburgerMenu", exception->hamburgerMenu()));
         exception->setHideShadow(group.readEntry("HideShadow", exception->hideShadow()));
         exception->setSquareCorners(group.readEntry("SquareCorners", exception->squareCorners()));
+        exception->setOutlineActive(group.readEntry("OutlineActive", exception->outlineActive()));
 
         m_exceptions.append(exception);
     }
@@ -159,6 +161,7 @@ void ExceptionList::writeConfig(KSharedConfig::Ptr config)
         group.writeEntry("HamburgerMenu", exception->hamburgerMenu());
         group.writeEntry("HideShadow", exception->hideShadow());
         group.writeEntry("SquareCorners", exception->squareCorners());
+        group.writeEntry("OutlineActive", exception->outlineActive());
     }
 
     config->sync();

--- a/src/ExceptionList.cc
+++ b/src/ExceptionList.cc
@@ -69,7 +69,6 @@ void copyInternalSettings(const InternalSettingsPtr &src, const InternalSettings
     dst->setHamburgerMenu(src->hamburgerMenu());
     dst->setSquareCorners(src->squareCorners());
     dst->setHideShadow(src->hideShadow());
-    dst->setOutlineActive(src->outlineActive());
 }
 
 InternalSettingsPtr cloneInternalSettings(const InternalSettingsPtr &src)

--- a/src/ExceptionList.h
+++ b/src/ExceptionList.h
@@ -46,6 +46,7 @@ enum ExceptionMask {
     HamburgerMenu = 1 << 2,
     HideShadow = 1 << 3,
     SquareCorners = 1 << 4,
+    OutlineActive = 1 << 5,
 };
 
 void copyInternalSettings(const InternalSettingsPtr &src, const InternalSettingsPtr &dst);

--- a/src/SettingsProvider.cc
+++ b/src/SettingsProvider.cc
@@ -124,6 +124,10 @@ InternalSettingsPtr SettingsProvider::createMergedSettings(const InternalSetting
         }
     }
 
+    if (mask & ExceptionMask::OutlineActive) {
+        merged->setOutlineActive(exceptionSettings->outlineActive());
+    }
+
     return merged;
 }
 

--- a/src/kcm/ExceptionDialog.cc
+++ b/src/kcm/ExceptionDialog.cc
@@ -75,12 +75,14 @@ ExceptionDialog::ExceptionDialog(QWidget *parent)
     m_hamburgerMenuCheckBox = new QCheckBox(i18n("Show menu as hamburger"), this);
     m_hideShadowCheckBox = new QCheckBox(i18n("Don't draw window shadow"), this);
     m_squareCornersCheckBox = new QCheckBox(i18n("Don't round window corners"), this);
+    m_outlineActiveCheckBox = new QCheckBox(i18n("Paint a thin line around the window"), this);
 
     optionsLayout->addWidget(m_hideTitleBarCheckBox);
     optionsLayout->addWidget(m_hideApplicationMenuCheckBox);
     optionsLayout->addWidget(m_hamburgerMenuCheckBox);
     optionsLayout->addWidget(m_hideShadowCheckBox);
     optionsLayout->addWidget(m_squareCornersCheckBox);
+    optionsLayout->addWidget(m_outlineActiveCheckBox);
 
     mainLayout->addWidget(optionsGroup);
 
@@ -151,6 +153,7 @@ void ExceptionDialog::setException(const InternalSettingsPtr &exception)
     m_hamburgerMenuCheckBox->setChecked(exception->hamburgerMenu());
     m_hideShadowCheckBox->setChecked(exception->hideShadow());
     m_squareCornersCheckBox->setChecked(exception->squareCorners());
+    m_outlineActiveCheckBox->setChecked(exception->outlineActive());
 
     onHideTitleBarToggled(exception->hideTitleBar());
 }
@@ -169,13 +172,15 @@ void ExceptionDialog::applyToException(InternalSettingsPtr &exception)
                ExceptionMask::HideApplicationMenu |
                ExceptionMask::HamburgerMenu |
                ExceptionMask::HideShadow |
-               ExceptionMask::SquareCorners;
+               ExceptionMask::SquareCorners |
+               ExceptionMask::OutlineActive;
 
     exception->setHideTitleBar(m_hideTitleBarCheckBox->isChecked());
     exception->setHideApplicationMenu(m_hideApplicationMenuCheckBox->isChecked());
     exception->setHamburgerMenu(m_hamburgerMenuCheckBox->isChecked());
     exception->setHideShadow(m_hideShadowCheckBox->isChecked());
     exception->setSquareCorners(m_squareCornersCheckBox->isChecked());
+    exception->setOutlineActive(m_outlineActiveCheckBox->isChecked());
 
     exception->setMask(mask);
 }

--- a/src/kcm/ExceptionDialog.h
+++ b/src/kcm/ExceptionDialog.h
@@ -57,6 +57,7 @@ private:
     QCheckBox *m_hamburgerMenuCheckBox = nullptr;
     QCheckBox *m_hideShadowCheckBox = nullptr;
     QCheckBox *m_squareCornersCheckBox = nullptr;
+    QCheckBox *m_outlineActiveCheckBox = nullptr;
 };
 
 } // namespace Material

--- a/src/kcm/ExceptionListWidget.cc
+++ b/src/kcm/ExceptionListWidget.cc
@@ -271,7 +271,8 @@ bool ExceptionListWidget::isChanged() const
             a->hideApplicationMenu() != b->hideApplicationMenu() ||
             a->hamburgerMenu() != b->hamburgerMenu() ||
             a->hideShadow() != b->hideShadow() ||
-            a->squareCorners() != b->squareCorners()) {
+            a->squareCorners() != b->squareCorners() ||
+            a->outlineActive() != b->outlineActive()) {
             return true;
         }
     }


### PR DESCRIPTION
## Riepilogo di Sourcery

Supporto alla configurazione indipendente di un contorno sottile per le finestre corrispondenti alle eccezioni.

Nuove funzionalità:
- Aggiunto il controllo specifico per finestra del disegno di un contorno sottile intorno alle finestre.

Miglioramenti:
- Persistenza e applicazione dell’impostazione del contorno durante la corrispondenza delle eccezioni, la clonazione, la configurazione e il rilevamento delle modifiche.

<details>
<summary>Original summary in English</summary>

## Riepilogo di Sourcery

Aggiunta di contorni sottili configurabili per le finestre associate alle eccezioni.

Nuove funzionalità:
- Aggiunta di un'impostazione per eccezione e finestra per disegnare un contorno sottile intorno alle finestre corrispondenti.

Miglioramenti:
- Applicazione dell'impostazione del contorno durante l'associazione delle impostazioni delle eccezioni e rilevamento delle modifiche nella UI di configurazione.

<details>
<summary>Original summary in English</summary>

## Riepilogo di Sourcery

Aggiunta di contorni sottili configurabili per le finestre corrispondenti alle eccezioni.

Nuove funzionalità:
- Aggiunta di un'opzione per ogni eccezione per disegnare un contorno sottile intorno alle finestre corrispondenti.

Miglioramenti:
- Applicazione dell'impostazione del contorno durante la corrispondenza delle impostazioni delle eccezioni e il rilevamento delle modifiche alla configurazione.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable thin outlines for windows matched by exceptions.

New Features:
- Add a per-exception option to draw a thin outline around matching windows.

Enhancements:
- Apply the outline setting when matching exception settings and detecting configuration changes.

</details>

</details>

</details>