### PR TITLE
Hoist toLower calls in calculateFuzzyScore

### DIFF
--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -383,21 +383,28 @@ static int calculateFuzzyScore(const QString &pattern, const QString &text, cons
     const QString pLower = patternLower.isEmpty() ? pattern.toLower() : patternLower;
     const QString textLower = text.toLower();
 
+    const int pLowerLen = pLower.length();
+    const int textLowerLen = textLower.length();
+
+    if (pLowerLen == 0 || textLowerLen == 0) {
+        return 0;
+    }
+
     QChar pChar = pLower.at(0);
 
-    for (int textIdx = 0; textIdx < textLen && patternIdx < patternLen; ++textIdx) {
+    for (int textIdx = 0; textIdx < textLowerLen && patternIdx < pLowerLen; ++textIdx) {
         const QChar tChar = textLower.at(textIdx);
 
         if (pChar == tChar) {
             patternIdx++;
-            if (patternIdx < patternLen) {
+            if (patternIdx < pLowerLen) {
                 pChar = pLower.at(patternIdx);
             }
             int charScore = 10;
 
             const bool isStart = (textIdx == 0);
-            const bool isBoundary = (!isStart && !text.at(textIdx - 1).isLetterOrNumber());
-            const bool isCamel = (text.at(textIdx).isUpper() && textIdx > 0 && text.at(textIdx - 1).isLower());
+            const bool isBoundary = (!isStart && textIdx - 1 < textLen && !text.at(textIdx - 1).isLetterOrNumber());
+            const bool isCamel = (textIdx < textLen && text.at(textIdx).isUpper() && textIdx > 0 && text.at(textIdx - 1).isLower());
 
             if (isStart || isBoundary) {
                 charScore += 50;
@@ -420,7 +427,7 @@ static int calculateFuzzyScore(const QString &pattern, const QString &text, cons
         }
     }
 
-    if (patternIdx < patternLen) {
+    if (patternIdx < pLowerLen) {
         return 0; // Not all pattern characters matched in sequence
     }
 
@@ -562,10 +569,11 @@ QList<AppMenuSearch::SearchResult> AppMenuSearch::matchSearchCandidates(const QS
     return results;
 }
 
-QString AppMenuSearch::getActionText(QAction *action) const
+const QString &AppMenuSearch::getActionText(QAction *action) const
 {
+    static const QString emptyString;
     if (!action) {
-        return QString();
+        return emptyString;
     }
     auto it = m_actionTextCache.find(action);
     if (it != m_actionTextCache.end()) {
@@ -573,8 +581,7 @@ QString AppMenuSearch::getActionText(QAction *action) const
     }
     const QString rawText = action->text();
     const QString cleanedText = KLocalizedString::removeAcceleratorMarker(rawText.trimmed());
-    m_actionTextCache.insert(action, cleanedText);
-    return cleanedText;
+    return *m_actionTextCache.insert(action, cleanedText);
 }
 
 } // namespace Material

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -355,7 +355,7 @@ bool AppMenuSearch::matchesAncestorsOrText(const SearchCandidate &candidate, con
     return false;
 }
 
-static int calculateFuzzyScore(const QString &pattern, const QString &text)
+static int calculateFuzzyScore(const QString &pattern, const QString &text, const QString &patternLower = QString())
 {
     if (pattern.isEmpty() || text.isEmpty()) {
         return 0;
@@ -380,12 +380,19 @@ static int calculateFuzzyScore(const QString &pattern, const QString &text)
     int consecutive = 0;
     int prevMatchIdx = -1;
 
+    const QString pLower = patternLower.isEmpty() ? pattern.toLower() : patternLower;
+    const QString textLower = text.toLower();
+
+    QChar pChar = pLower.at(0);
+
     for (int textIdx = 0; textIdx < textLen && patternIdx < patternLen; ++textIdx) {
-        const QChar pChar = pattern.at(patternIdx).toLower();
-        const QChar tChar = text.at(textIdx).toLower();
+        const QChar tChar = textLower.at(textIdx);
 
         if (pChar == tChar) {
             patternIdx++;
+            if (patternIdx < patternLen) {
+                pChar = pLower.at(patternIdx);
+            }
             int charScore = 10;
 
             const bool isStart = (textIdx == 0);
@@ -431,6 +438,7 @@ QList<AppMenuSearch::SearchResult> AppMenuSearch::matchSearchCandidates(const QS
     const bool ignoreSubMenus = options.ignoreSubMenus;
     const bool showDisabledActions = options.showDisabledActions;
     const bool fuzzyMatching = options.fuzzyMatching;
+    const QString queryLower = fuzzyMatching ? query.toLower() : QString();
 
     for (const SearchCandidate &candidate : std::as_const(m_searchCandidates)) {
         if (!fuzzyMatching && results.size() >= MAX_SEARCH_RESULTS) {
@@ -501,15 +509,15 @@ QList<AppMenuSearch::SearchResult> AppMenuSearch::matchSearchCandidates(const QS
             if (ignoreTopLevel && !candidate.hasNamedAncestor) {
                 match = false;
             } else if (ignoreSubMenus) {
-                candidateScore = calculateFuzzyScore(query, itemText);
+                candidateScore = calculateFuzzyScore(query, itemText, queryLower);
                 match = (candidateScore > 0);
             } else {
-                const int itemScore = calculateFuzzyScore(query, itemText);
+                const int itemScore = calculateFuzzyScore(query, itemText, queryLower);
                 if (itemScore > 0) {
                     candidateScore = itemScore + 500;
                     match = true;
                 } else {
-                    const int pathScore = calculateFuzzyScore(query, evalPath);
+                    const int pathScore = calculateFuzzyScore(query, evalPath, queryLower);
                     if (pathScore > 0) {
                         candidateScore = pathScore;
                         match = true;

--- a/src/AppMenuSearch.h
+++ b/src/AppMenuSearch.h
@@ -121,7 +121,7 @@ private:
     bool matchesAncestorsOrText(const SearchCandidate &candidate, const QString &itemText, const QStringMatcher &matcher, bool ignoreTopLevel, MatchContext &context) const;
     
     QList<SearchResult> matchSearchCandidates(const QStringMatcher &matcher, const FilterOptions &options, const QString &query) const;
-    QString getActionText(QAction *action) const;
+    const QString &getActionText(QAction *action) const;
     void resetSearchState();
 
     QPointer<AppMenuModel> m_appMenuModel;


### PR DESCRIPTION
## Riepilogo di Sourcery

Miglioramenti:
- Ottimizzato il punteggio della ricerca fuzzy riutilizzando il testo della query convertito in minuscolo e preelaborando il testo ricercabile una sola volta per ogni calcolo del punteggio.

<details>
<summary>Original summary in English</summary>

## Riepilogo di Sourcery

Ottimizza il punteggio della ricerca fuzzy e il recupero del testo delle azioni per ridurre l’allocazione e l’overhead di conversione.

Miglioramenti:
- Ottimizza il punteggio della ricerca fuzzy riutilizzando la query convertita in minuscolo e preelaborando il testo ricercabile una sola volta per ogni calcolo del punteggio.
- Riduce le copie di stringhe non necessarie durante il recupero del testo delle azioni memorizzato nella cache.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize fuzzy search scoring and action-text retrieval for lower allocation and conversion overhead.

Enhancements:
- Optimize fuzzy search scoring by reusing the lowercased query and preprocessing searchable text once per score calculation.
- Reduce unnecessary string copying when retrieving cached action text.

</details>

</details>