### PR TITLE
Optimize AppMenuSearch matching

### DIFF
--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -232,10 +232,14 @@ void AppMenuSearch::rebuildSearchCandidatesIfNeeded()
 
 void AppMenuSearch::collectSearchCandidates(QMenu *menu, QSet<QMenu *> &visited, QList<QPointer<QAction>> &ancestors, bool hasNamedAncestor)
 {
-    if (!menu || visited.contains(menu) || m_searchCandidates.size() >= MAX_SEARCH_CANDIDATES || ancestors.size() >= MAX_MENU_DEPTH) {
+    if (!menu || m_searchCandidates.size() >= MAX_SEARCH_CANDIDATES || ancestors.size() >= MAX_MENU_DEPTH) {
         return;
     }
+    const int oldSize = visited.size();
     visited.insert(menu);
+    if (visited.size() == oldSize) {
+        return;
+    }
 
     QAction *menuAction = menu->menuAction();
     bool addedAncestor = false;
@@ -380,12 +384,16 @@ static int calculateFuzzyScore(const QString &pattern, const QString &text)
     int consecutive = 0;
     int prevMatchIdx = -1;
 
+    QChar pChar = pattern.at(patternIdx).toLower();
+
     for (int textIdx = 0; textIdx < textLen && patternIdx < patternLen; ++textIdx) {
-        const QChar pChar = pattern.at(patternIdx).toLower();
         const QChar tChar = text.at(textIdx).toLower();
 
         if (pChar == tChar) {
             patternIdx++;
+            if (patternIdx < patternLen) {
+                pChar = pattern.at(patternIdx).toLower();
+            }
             int charScore = 10;
 
             const bool isStart = (textIdx == 0);
@@ -418,6 +426,59 @@ static int calculateFuzzyScore(const QString &pattern, const QString &text)
     }
 
     return std::max(1, score);
+}
+
+QString AppMenuSearch::buildFullPath(const SearchCandidate &candidate, const QString &itemText) const
+{
+    QString path;
+    path.reserve(128);
+    bool first = true;
+    for (QAction *ancestor : std::as_const(candidate.ancestors)) {
+        if (ancestor) {
+            const QString text = getActionText(ancestor);
+            if (!text.isEmpty()) {
+                if (!first) {
+                    path.append(QStringLiteral(" » "));
+                }
+                path.append(text);
+                first = false;
+            }
+        }
+    }
+    if (!first) {
+        path.append(QStringLiteral(" » "));
+    }
+    path.append(itemText);
+    return path;
+}
+
+QString AppMenuSearch::buildEvalPath(const SearchCandidate &candidate, const QString &itemText, bool ignoreTopLevel) const
+{
+    QString path;
+    path.reserve(128);
+    bool first = true;
+    bool skippedTopLevel = false;
+    for (QAction *ancestor : std::as_const(candidate.ancestors)) {
+        if (ancestor) {
+            const QString text = getActionText(ancestor);
+            if (!text.isEmpty()) {
+                if (ignoreTopLevel && !skippedTopLevel) {
+                    skippedTopLevel = true;
+                } else {
+                    if (!first) {
+                        path.append(QStringLiteral(" » "));
+                    }
+                    path.append(text);
+                    first = false;
+                }
+            }
+        }
+    }
+    if (!first) {
+        path.append(QStringLiteral(" » "));
+    }
+    path.append(itemText);
+    return path;
 }
 
 QList<AppMenuSearch::SearchResult> AppMenuSearch::matchSearchCandidates(const QStringMatcher &matcher, const FilterOptions &options, const QString &query) const
@@ -472,31 +533,6 @@ QList<AppMenuSearch::SearchResult> AppMenuSearch::matchSearchCandidates(const QS
         bool match = false;
         int candidateScore = 0;
 
-        QStringList currentPath;
-        QStringList evalPathList;
-        currentPath.reserve(candidate.ancestors.size() + 1);
-        evalPathList.reserve(candidate.ancestors.size() + 1);
-
-        bool skippedTopLevel = false;
-        for (QAction *ancestor : std::as_const(candidate.ancestors)) {
-            if (ancestor) {
-                const QString text = getActionText(ancestor);
-                if (!text.isEmpty()) {
-                    currentPath.append(text);
-                    if (ignoreTopLevel && !skippedTopLevel) {
-                        skippedTopLevel = true;
-                    } else {
-                        evalPathList.append(text);
-                    }
-                }
-            }
-        }
-        currentPath.append(itemText);
-        evalPathList.append(itemText);
-
-        const QString fullPath = currentPath.join(QStringLiteral(" » "));
-        const QString evalPath = evalPathList.join(QStringLiteral(" » "));
-
         if (fuzzyMatching) {
             if (ignoreTopLevel && !candidate.hasNamedAncestor) {
                 match = false;
@@ -509,6 +545,7 @@ QList<AppMenuSearch::SearchResult> AppMenuSearch::matchSearchCandidates(const QS
                     candidateScore = itemScore + 500;
                     match = true;
                 } else {
+                    const QString evalPath = buildEvalPath(candidate, itemText, ignoreTopLevel);
                     const int pathScore = calculateFuzzyScore(query, evalPath);
                     if (pathScore > 0) {
                         candidateScore = pathScore;
@@ -537,7 +574,7 @@ QList<AppMenuSearch::SearchResult> AppMenuSearch::matchSearchCandidates(const QS
         info.isEffectivelyEnabled = isEffectivelyEnabled;
         info.isChecked = action->isChecked();
         info.isCheckable = action->isCheckable();
-        info.path = fullPath;
+        info.path = buildFullPath(candidate, itemText);
 
         results.append({action, info, action->icon().cacheKey(), candidateScore});
     }

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -359,6 +359,19 @@ bool AppMenuSearch::matchesAncestorsOrText(const SearchCandidate &candidate, con
     return false;
 }
 
+/**
+ * @brief Calculates a fuzzy matching score between a search pattern and text.
+ *
+ * Uses a two-phase scoring algorithm:
+ * 1. First checks for exact contiguous substring match (case-insensitive), awarding high scores
+ *    with bonuses for earlier positions and word boundary matches.
+ * 2. Falls back to sequential character matching with bonuses for consecutive matches,
+ *    word boundaries, camelCase transitions, and penalties for character gaps.
+ *
+ * @param pattern The search pattern to match
+ * @param text The text to search within
+ * @return Score value (higher is better), or 0 if pattern doesn't match sequentially
+ */
 static int calculateFuzzyScore(const QString &pattern, const QString &text)
 {
     if (pattern.isEmpty() || text.isEmpty()) {

--- a/src/AppMenuSearch.h
+++ b/src/AppMenuSearch.h
@@ -120,6 +120,9 @@ private:
 
     bool matchesAncestorsOrText(const SearchCandidate &candidate, const QString &itemText, const QStringMatcher &matcher, bool ignoreTopLevel, MatchContext &context) const;
     
+    QString buildFullPath(const SearchCandidate &candidate, const QString &itemText) const;
+    QString buildEvalPath(const SearchCandidate &candidate, const QString &itemText, bool ignoreTopLevel) const;
+
     QList<SearchResult> matchSearchCandidates(const QStringMatcher &matcher, const FilterOptions &options, const QString &query) const;
     QString getActionText(QAction *action) const;
     void resetSearchState();

--- a/src/AppMenuSearch.h
+++ b/src/AppMenuSearch.h
@@ -38,11 +38,26 @@ class AppMenuSearch : public QObject
     Q_OBJECT
 
 public:
+    /**
+     * @brief Constructs an AppMenuSearch instance.
+     * @param model Pointer to the AppMenuModel to search within
+     * @param parent Optional parent QObject
+     */
     explicit AppMenuSearch(AppMenuModel *model, QObject *parent = nullptr);
+
+    /**
+     * @brief Destructor.
+     */
     ~AppMenuSearch() override;
 
     static constexpr int MINIMUM_SEARCH_LENGTH = 3;
     static constexpr const char PROPERTY_SEARCH_PROXY[] = "isAppMenuSearchProxy";
+
+    /**
+     * @brief Checks if a search query is too short to be processed.
+     * @param text The query text to check
+     * @return True if the simplified text length is less than MINIMUM_SEARCH_LENGTH, false otherwise
+     */
     static bool isQueryTooShort(const QString &text);
 
     struct ActionInfo {
@@ -90,22 +105,80 @@ public:
         bool operator==(const FilterOptions &other) const = default;
     };
 
+    /**
+     * @brief Sets the menu where search results will be rendered.
+     * @param searchMenu Pointer to the QMenu that will display search result proxy actions
+     */
     void setSearchMenu(QMenu *searchMenu);
+
+    /**
+     * @brief Filters menu actions based on the search query and renders matching results.
+     *
+     * This method rebuilds search candidates if needed, searches for matches using either
+     * exact substring or fuzzy matching, creates proxy actions for results, and populates
+     * the search menu. Uses a synchronous text cache that is cleared when the method exits.
+     *
+     * @param text The search query text
+     * @param options Filter options controlling search behavior (top-level filtering, submenu inclusion, disabled actions, fuzzy matching)
+     */
     void filter(const QString &text, const FilterOptions &options);
+
+    /**
+     * @brief Clears all search result proxy actions from the search menu.
+     *
+     * Removes and schedules deletion of all actions marked with PROPERTY_SEARCH_PROXY,
+     * detaches them from their action groups, and cleans up the proxy action groups.
+     */
     void clear();
 
-    // Clears both the rendered result actions and the cached search state
-    // (query, results, options). Used whenever the search UI is dismissed.
+    /**
+     * @brief Clears both the rendered result actions and the cached search state.
+     *
+     * Combines clear() with resetSearchState() to completely reset the search,
+     * including query, results, and options. Used when the search UI is dismissed.
+     */
     void reset();
-    
+
+    /**
+     * @brief Marks the search candidates cache as dirty and clears cached data.
+     *
+     * Forces a rebuild of search candidates on the next filter() call. Clears
+     * the candidates list, action text cache, last results, and filter options,
+     * but intentionally preserves m_lastSearchQuery so hasValidQuery() can still
+     * report an in-progress query.
+     */
     void invalidateCandidates();
+
+    /**
+     * @brief Checks if there is a valid search query currently active.
+     * @return True if the last search query is non-empty and meets minimum length requirements
+     */
     bool hasValidQuery() const;
 
 signals:
     void repositionRequested();
 
 private:
+    /**
+     * @brief Rebuilds the search candidates cache if marked dirty.
+     *
+     * Clears and repopulates m_searchCandidates by recursively collecting actions
+     * from the application menu if m_searchCandidatesDirty is true.
+     */
     void rebuildSearchCandidatesIfNeeded();
+
+    /**
+     * @brief Recursively collects searchable action candidates from a menu hierarchy.
+     *
+     * Traverses the menu tree depth-first, tracking ancestors and visited menus to avoid
+     * cycles. Skips separators and invisible actions. Stops if the candidate limit or
+     * maximum depth is reached.
+     *
+     * @param menu The menu to collect candidates from
+     * @param visited Set of already-visited menus to prevent infinite recursion
+     * @param ancestors List of ancestor menu actions from root to current menu
+     * @param hasNamedAncestor True if any ancestor in the chain has a non-empty label
+     */
     void collectSearchCandidates(QMenu *menu, QSet<QMenu *> &visited, QList<QPointer<QAction>> &ancestors, bool hasNamedAncestor = false);
     
     struct MatchState {
@@ -118,13 +191,77 @@ private:
         QHash<QAction *, bool> &pathMatchCache;
     };
 
+    /**
+     * @brief Checks if a candidate matches the search query in its ancestors or item text.
+     *
+     * Uses a two-tier caching strategy: first checks if the parent path match is cached (O(1)),
+     * then falls back to sequential evaluation with per-ancestor caching. Respects ignoreTopLevel
+     * by skipping the first named ancestor from evaluation.
+     *
+     * @param candidate The search candidate to evaluate
+     * @param itemText The cleaned text of the candidate action
+     * @param matcher String matcher for substring search
+     * @param ignoreTopLevel If true, skip matching the first named ancestor
+     * @param context Match context containing caches for ancestor text and path matches
+     * @return True if the candidate or any evaluated ancestor matches the query
+     */
     bool matchesAncestorsOrText(const SearchCandidate &candidate, const QString &itemText, const QStringMatcher &matcher, bool ignoreTopLevel, MatchContext &context) const;
-    
+
+    /**
+     * @brief Builds the full hierarchical path for a candidate action.
+     *
+     * Constructs a displayable path string with all named ancestors separated by » symbols.
+     *
+     * @param candidate The search candidate
+     * @param itemText The text of the candidate action
+     * @return Full path string like "File » Open » Recent"
+     */
     QString buildFullPath(const SearchCandidate &candidate, const QString &itemText) const;
+
+    /**
+     * @brief Builds the evaluation path for a candidate, optionally skipping the top-level ancestor.
+     *
+     * Similar to buildFullPath but can exclude the first named ancestor when ignoreTopLevel is true.
+     *
+     * @param candidate The search candidate
+     * @param itemText The text of the candidate action
+     * @param ignoreTopLevel If true, skip the first named ancestor in the path
+     * @return Evaluation path string for matching purposes
+     */
     QString buildEvalPath(const SearchCandidate &candidate, const QString &itemText, bool ignoreTopLevel) const;
 
+    /**
+     * @brief Searches all candidates and returns matching results.
+     *
+     * Iterates through search candidates, checks if each matches based on filter options
+     * (substring or fuzzy matching, top-level/submenu filtering, disabled action handling),
+     * and builds a list of SearchResult objects. For fuzzy matching, results are sorted by
+     * score and limited to MAX_SEARCH_RESULTS.
+     *
+     * @param matcher String matcher for substring search (used in non-fuzzy mode)
+     * @param options Filter options controlling search behavior
+     * @param query The search query string (used in fuzzy mode)
+     * @return List of matching search results, sorted by score if fuzzy matching is enabled
+     */
     QList<SearchResult> matchSearchCandidates(const QStringMatcher &matcher, const FilterOptions &options, const QString &query) const;
+
+    /**
+     * @brief Gets the cleaned display text for an action with caching.
+     *
+     * Retrieves the action text with accelerator markers removed and leading/trailing
+     * whitespace trimmed. Results are cached in m_actionTextCache for performance.
+     *
+     * @param action The action to get text from
+     * @return Cleaned action text, or empty string if action is null
+     */
     QString getActionText(QAction *action) const;
+
+    /**
+     * @brief Resets the cached search state (query, results, options, processed menu).
+     *
+     * Internal helper that clears m_lastSearchQuery, m_lastResults, m_lastProcessedMenu,
+     * and m_lastOptions without touching the rendered menu or candidates cache.
+     */
     void resetSearchState();
 
     QPointer<AppMenuModel> m_appMenuModel;


### PR DESCRIPTION
Defer fullPath and evalPath string construction in matchSearchCandidates
until a candidate is confirmed to match (or strictly required for fuzzy
matching), eliminating thousands of redundant string allocations per query.
Use direct QString buffer building in buildFullPath/buildEvalPath, hoist
pattern lowercasing in calculateFuzzyScore, and streamline QSet lookup
in collectSearchCandidates.

## Riepilogo di Sourcery

Miglioramenti:
- Riduce l'overhead delle query di ricerca rimandando la costruzione dei percorsi finché i candidati non corrispondono e ottimizzando il punteggio fuzzy e l'attraversamento dei candidati.

<details>
<summary>Original summary in English</summary>

## Riepilogo di Sourcery

Miglioramenti:
- Ottimizzata la ricerca nei menu rimandando la costruzione dei percorsi gerarchici a quando i candidati corrispondono e riducendo l'overhead del calcolo fuzzy e dell'attraversamento dei candidati.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Optimize menu search matching by deferring hierarchical path construction until candidates match and reducing fuzzy-scoring and candidate-traversal overhead.

</details>

</details>