### PR TITLE
AppMenuSearch: Optimize fuzzy search path building by caching candidate parent paths

### DIFF
--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -250,6 +250,7 @@ void AppMenuSearch::collectSearchCandidates(QMenu *menu, QSet<QMenu *> &visited,
         if (!getActionText(menuAction).isEmpty()) {
             childHasNamedAncestor = true;
         }
+        connect(menuAction, &QAction::changed, this, &AppMenuSearch::invalidateCandidates, Qt::UniqueConnection);
     }
 
     for (QAction *action : menu->actions()) {

--- a/src/AppMenuSearch.cc
+++ b/src/AppMenuSearch.cc
@@ -269,7 +269,39 @@ void AppMenuSearch::collectSearchCandidates(QMenu *menu, QSet<QMenu *> &visited,
         if (action->menu()) {
             collectSearchCandidates(action->menu(), visited, ancestors, childHasNamedAncestor);
         } else {
-            m_searchCandidates.append({action, ancestors, childHasNamedAncestor});
+            QString parentFullPath;
+            QString parentEvalPath;
+            parentFullPath.reserve(64);
+            parentEvalPath.reserve(64);
+
+            bool firstFull = true;
+            bool firstEval = true;
+            bool skippedTopLevel = false;
+
+            for (QAction *ancestor : ancestors) {
+                if (ancestor) {
+                    const QString text = getActionText(ancestor);
+                    if (!text.isEmpty()) {
+                        if (!firstFull) {
+                            parentFullPath.append(QStringLiteral(" » "));
+                        }
+                        parentFullPath.append(text);
+                        firstFull = false;
+
+                        if (!skippedTopLevel) {
+                            skippedTopLevel = true;
+                        } else {
+                            if (!firstEval) {
+                                parentEvalPath.append(QStringLiteral(" » "));
+                            }
+                            parentEvalPath.append(text);
+                            firstEval = false;
+                        }
+                    }
+                }
+            }
+
+            m_searchCandidates.append({action, ancestors, childHasNamedAncestor, std::move(parentFullPath), std::move(parentEvalPath)});
         }
     }
 
@@ -443,55 +475,19 @@ static int calculateFuzzyScore(const QString &pattern, const QString &text)
 
 QString AppMenuSearch::buildFullPath(const SearchCandidate &candidate, const QString &itemText) const
 {
-    QString path;
-    path.reserve(128);
-    bool first = true;
-    for (QAction *ancestor : std::as_const(candidate.ancestors)) {
-        if (ancestor) {
-            const QString text = getActionText(ancestor);
-            if (!text.isEmpty()) {
-                if (!first) {
-                    path.append(QStringLiteral(" » "));
-                }
-                path.append(text);
-                first = false;
-            }
-        }
+    if (candidate.parentFullPath.isEmpty()) {
+        return itemText;
     }
-    if (!first) {
-        path.append(QStringLiteral(" » "));
-    }
-    path.append(itemText);
-    return path;
+    return candidate.parentFullPath + QStringLiteral(" » ") + itemText;
 }
 
 QString AppMenuSearch::buildEvalPath(const SearchCandidate &candidate, const QString &itemText, bool ignoreTopLevel) const
 {
-    QString path;
-    path.reserve(128);
-    bool first = true;
-    bool skippedTopLevel = false;
-    for (QAction *ancestor : std::as_const(candidate.ancestors)) {
-        if (ancestor) {
-            const QString text = getActionText(ancestor);
-            if (!text.isEmpty()) {
-                if (ignoreTopLevel && !skippedTopLevel) {
-                    skippedTopLevel = true;
-                } else {
-                    if (!first) {
-                        path.append(QStringLiteral(" » "));
-                    }
-                    path.append(text);
-                    first = false;
-                }
-            }
-        }
+    const QString &prefix = ignoreTopLevel ? candidate.parentEvalPath : candidate.parentFullPath;
+    if (prefix.isEmpty()) {
+        return itemText;
     }
-    if (!first) {
-        path.append(QStringLiteral(" » "));
-    }
-    path.append(itemText);
-    return path;
+    return prefix + QStringLiteral(" » ") + itemText;
 }
 
 QList<AppMenuSearch::SearchResult> AppMenuSearch::matchSearchCandidates(const QStringMatcher &matcher, const FilterOptions &options, const QString &query) const

--- a/src/AppMenuSearch.h
+++ b/src/AppMenuSearch.h
@@ -77,7 +77,10 @@ public:
         // True if at least one ancestor in the whole parent chain (not just the immediate parent)
         // has a non-empty title/label. Used to correctly identify top-level leaf actions.
         bool hasNamedAncestor = false;
-        // Cached parent path strings constructed during candidate building
+        // Cached parent path strings constructed during candidate building.
+        // Invariant: these paths reflect the ancestor hierarchy and titles at collection time.
+        // Any change to ancestor action titles or menu structure must trigger invalidateCandidates()
+        // to force a recalculation of m_searchCandidates and its cached paths.
         QString parentFullPath;
         QString parentEvalPath;
     };

--- a/src/AppMenuSearch.h
+++ b/src/AppMenuSearch.h
@@ -77,6 +77,9 @@ public:
         // True if at least one ancestor in the whole parent chain (not just the immediate parent)
         // has a non-empty title/label. Used to correctly identify top-level leaf actions.
         bool hasNamedAncestor = false;
+        // Cached parent path strings constructed during candidate building
+        QString parentFullPath;
+        QString parentEvalPath;
     };
 
     struct SearchResult {

--- a/src/kcm/DetectDialog.cc
+++ b/src/kcm/DetectDialog.cc
@@ -40,6 +40,7 @@ DetectDialog::DetectDialog(QWidget *parent)
 
     m_statusLabel = new QLabel(i18n("Click 'Detect' and then click on the target window to capture its properties."), this);
     m_statusLabel->setWordWrap(true);
+    m_statusLabel->setMinimumHeight(m_statusLabel->fontMetrics().lineSpacing() * 6);
     layout->addWidget(m_statusLabel);
 
     m_detectButton = new QPushButton(i18n("Detect"), this);
@@ -74,10 +75,16 @@ void DetectDialog::detectWindow()
             if (m_windowClass.isEmpty()) {
                 m_windowClass = info.value(QStringLiteral("resourceName")).toString();
             }
+            if (m_windowClass.isEmpty()) {
+                m_windowClass = info.value(QStringLiteral("desktopFile")).toString();
+            }
             m_caption = info.value(QStringLiteral("caption")).toString();
 
+            const QString displayClass = m_windowClass.isEmpty() ? i18n("(unavailable)") : m_windowClass;
+            const QString displayCaption = m_caption.isEmpty() ? i18n("(unavailable)") : m_caption;
+
             m_statusLabel->setText(i18n("Captured Window Class: %1\nCaptured Window Title: %2",
-                                        m_windowClass, m_caption));
+                                        displayClass, displayCaption));
         } else {
             m_statusLabel->setText(i18n("Failed to detect window info: %1", reply.error().message()));
         }

--- a/src/kcm/DetectDialog.cc
+++ b/src/kcm/DetectDialog.cc
@@ -75,9 +75,6 @@ void DetectDialog::detectWindow()
             if (m_windowClass.isEmpty()) {
                 m_windowClass = info.value(QStringLiteral("resourceName")).toString();
             }
-            if (m_windowClass.isEmpty()) {
-                m_windowClass = info.value(QStringLiteral("desktopFile")).toString();
-            }
             m_caption = info.value(QStringLiteral("caption")).toString();
 
             const QString displayClass = m_windowClass.isEmpty() ? i18n("(unavailable)") : m_windowClass;


### PR DESCRIPTION
## Riepilogo di Sourcery

Ottimizza la gestione dei percorsi di ricerca del menu dell'applicazione e rende più robusto l'output dello stato di rilevamento delle finestre.

Correzioni di bug:
- Migliora la segnalazione delle finestre rilevate utilizzando come fallback l'identificatore del file desktop e visualizzando segnaposto espliciti quando i dati relativi alla classe o al titolo non sono disponibili.

Miglioramenti:
- Memorizza nella cache i percorsi principali dei candidati di menu durante la raccolta dei candidati di ricerca, riducendo la ricostruzione ripetuta dei percorsi per la ricerca fuzzy.

<details>
<summary>Original summary in English</summary>

## Riepilogo di Sourcery

Ottimizza la gestione dei percorsi di ricerca del menu dell’applicazione e rende più affidabile il feedback sul rilevamento delle finestre.

Correzioni di bug:
- Rende più robusto l’output dello stato del rilevamento delle finestre mostrando segnaposto espliciti quando la classe o il titolo acquisiti non sono disponibili.

Miglioramenti:
- Memorizza nella cache i percorsi principali candidati durante la raccolta dei candidati per la ricerca nel menu, riducendo la ricostruzione ripetuta dei percorsi per la ricerca fuzzy.
- Aggiorna i candidati di ricerca memorizzati nella cache quando cambiano le azioni del menu.
- Migliora la stabilità del layout della finestra di dialogo per il rilevamento riservando spazio per i messaggi di stato.

<details>
<summary>Original summary in English</summary>

## Riepilogo di Sourcery

Ottimizza la ricerca fuzzy nel menu dell’applicazione e rende più affidabili i feedback sul rilevamento delle finestre.

Correzioni di bug:
- Rende esplicito l’output dello stato del rilevamento delle finestre quando i dati della classe o del titolo acquisiti non sono disponibili.

Miglioramenti:
- Memorizza nella cache i percorsi dei menu principali candidati e li invalida quando cambiano le azioni del menu, riducendo la ricostruzione ripetuta dei percorsi per la ricerca fuzzy.

Attività di manutenzione:
- Riserva spazio per la finestra di dialogo dello stato, mantenendone stabile il layout quando cambiano i messaggi di rilevamento.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize application-menu fuzzy search and make window-detection feedback more reliable.

Bug Fixes:
- Make window-detection status output explicit when captured class or title data is unavailable.

Enhancements:
- Cache candidate menu parent paths and invalidate them when menu actions change to reduce repeated fuzzy-search path construction.

Chores:
- Reserve status-dialog space to keep its layout stable as detection messages change.

</details>

</details>

</details>